### PR TITLE
fix(zaps): deduplicate LNURL endpoint fetches; stop NWC NIP-04 downgrade on a cold cache

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCache.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.Nip47WalletConnect
 import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcInfoEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -37,16 +38,23 @@ import java.util.concurrent.ConcurrentHashMap
  * supported RPC methods, and whether it emits notifications.
  *
  * Entries expire after [ttlSeconds] (default 2 days) so a wallet that later
- * changes its advertised capabilities is eventually re-checked. Reads never block
- * on the network:
+ * changes its advertised capabilities is eventually re-checked. Four entry
+ * points, in increasing order of how much they will wait:
  *
  *  - [current] returns whatever is cached (possibly stale, possibly null) with no
- *    side effect — for the payment hot path.
+ *    side effect and never blocks — for callers that can act on "don't know".
  *  - [refreshIfStale] triggers a background fetch when the entry is missing or
  *    expired, and returns immediately — call it right before using a wallet so a
  *    stale entry self-heals without holding up the transaction.
- *  - [getFresh] is the suspending variant for callers that can await (e.g. the
- *    notification watcher deciding whether to open a subscription).
+ *  - [currentOrFetch] waits only when nothing at all is cached, and returns a
+ *    stale entry as-is — for callers where "don't know" and "no" are different
+ *    answers, such as NIP-44 negotiation.
+ *  - [getFresh] waits whenever the entry is missing *or* expired, for a caller
+ *    that must not act on a stale answer. No production caller needs that today.
+ *
+ * Every fetching path funnels through one request per wallet, so the startup
+ * warm-up, a payment waiting on a cold cache and the notification watcher join
+ * the same call rather than racing each other.
  *
  * A completed fetch — including a definitive "wallet published no info event"
  * (null) — is cached with a timestamp. A *failed* fetch (network error/timeout)
@@ -65,7 +73,11 @@ class NwcInfoCache(
     )
 
     private val cache = ConcurrentHashMap<HexKey, Entry>()
-    private val inFlight = ConcurrentHashMap.newKeySet<HexKey>()
+
+    // Fetches in progress, keyed like [cache]. Every path that fetches goes through
+    // [fetchOnce], so the startup warm-up, a payment waiting on a cold cache and the
+    // notification watcher all join one request per wallet instead of racing.
+    private val inFlight = ConcurrentHashMap<HexKey, CompletableDeferred<NwcInfoEvent?>>()
 
     private fun isFresh(entry: Entry): Boolean = now() - entry.fetchedAt < ttlSeconds
 
@@ -80,15 +92,9 @@ class NwcInfoCache(
     fun refreshIfStale(uri: Nip47WalletConnect.Nip47URINorm) {
         val entry = cache[uri.pubKeyHex]
         if (entry != null && isFresh(entry)) return
-        if (!inFlight.add(uri.pubKeyHex)) return
+        if (inFlight.containsKey(uri.pubKeyHex)) return
 
-        scope.launch(Dispatchers.IO) {
-            try {
-                fetchAndStore(uri)
-            } finally {
-                inFlight.remove(uri.pubKeyHex)
-            }
-        }
+        scope.launch(Dispatchers.IO) { fetchOnce(uri) }
     }
 
     /**
@@ -99,7 +105,56 @@ class NwcInfoCache(
     suspend fun getFresh(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
         val entry = cache[uri.pubKeyHex]
         if (entry != null && isFresh(entry)) return entry.info
-        return fetchAndStore(uri)
+        return fetchOnce(uri)
+    }
+
+    /**
+     * Returns whatever is cached, waiting for a fetch only when there is nothing
+     * cached at all.
+     *
+     * This is the encryption-negotiation entry point. [current] answers "what does
+     * this wallet advertise" from memory, but on a cold cache it answers null, and
+     * a null there is indistinguishable from "no NIP-44" — so the caller silently
+     * downgrades to NIP-04 on the first transaction after every app start. Waiting
+     * once, only when nothing is known, removes that.
+     *
+     * A stale entry is returned as-is without waiting: it still says which
+     * encryption the wallet advertises, and [refreshIfStale] self-heals it in the
+     * background for next time.
+     */
+    suspend fun currentOrFetch(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
+        val entry = cache[uri.pubKeyHex]
+        if (entry != null) {
+            refreshIfStale(uri)
+            return entry.info
+        }
+        return fetchOnce(uri)
+    }
+
+    /**
+     * Runs [fetchAndStore] for [uri] exactly once, however many callers ask at
+     * once; the rest await that one result.
+     *
+     * Cancellation reaches only the caller that owns the fetch — awaiters are
+     * separate coroutines that are still alive, and get the last cached value (or
+     * null) rather than being cancelled along with it.
+     */
+    private suspend fun fetchOnce(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
+        val key = uri.pubKeyHex
+        val ours = CompletableDeferred<NwcInfoEvent?>()
+        // putIfAbsent returns the previous entry, so a non-null result means
+        // someone else already owns this wallet's fetch.
+        inFlight.putIfAbsent(key, ours)?.let { return it.await() }
+
+        var info: NwcInfoEvent? = null
+        try {
+            info = fetchAndStore(uri)
+        } finally {
+            // Non-suspending, so awaiters are released even if we are cancelled.
+            inFlight.remove(key, ours)
+            ours.complete(info)
+        }
+        return info
     }
 
     private suspend fun fetchAndStore(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCache.kt
@@ -74,9 +74,7 @@ class NwcInfoCache(
 
     private val cache = ConcurrentHashMap<HexKey, Entry>()
 
-    // Fetches in progress, keyed like [cache]. Every path that fetches goes through
-    // [fetchOnce], so the startup warm-up, a payment waiting on a cold cache and the
-    // notification watcher all join one request per wallet instead of racing.
+    // Fetches in progress, keyed like [cache]. Every fetching path goes through [fetchOnce].
     private val inFlight = ConcurrentHashMap<HexKey, CompletableDeferred<NwcInfoEvent?>>()
 
     private fun isFresh(entry: Entry): Boolean = now() - entry.fetchedAt < ttlSeconds
@@ -92,7 +90,6 @@ class NwcInfoCache(
     fun refreshIfStale(uri: Nip47WalletConnect.Nip47URINorm) {
         val entry = cache[uri.pubKeyHex]
         if (entry != null && isFresh(entry)) return
-        if (inFlight.containsKey(uri.pubKeyHex)) return
 
         scope.launch(Dispatchers.IO) { fetchOnce(uri) }
     }
@@ -101,6 +98,9 @@ class NwcInfoCache(
      * Suspends until a fresh-enough info event is available, fetching when the
      * entry is missing or expired. Returns the last cached (possibly stale) value
      * if the fetch fails.
+     *
+     * For a caller that must not act on a stale answer. No production caller needs
+     * that today; prefer [currentOrFetch], which only waits on a cold cache.
      */
     suspend fun getFresh(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
         val entry = cache[uri.pubKeyHex]
@@ -123,38 +123,52 @@ class NwcInfoCache(
      * background for next time.
      */
     suspend fun currentOrFetch(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
-        val entry = cache[uri.pubKeyHex]
-        if (entry != null) {
-            refreshIfStale(uri)
-            return entry.info
-        }
-        return fetchOnce(uri)
+        val entry = cache[uri.pubKeyHex] ?: return fetchOnce(uri)
+        refreshIfStale(uri)
+        return entry.info
     }
 
     /**
      * Runs [fetchAndStore] for [uri] exactly once, however many callers ask at
-     * once; the rest await that one result.
+     * once; every caller awaits that one result.
      *
-     * Cancellation reaches only the caller that owns the fetch — awaiters are
-     * separate coroutines that are still alive, and get the last cached value (or
-     * null) rather than being cancelled along with it.
+     * The fetch runs in this cache's own [scope], never in the caller's. A caller
+     * on the payment path is a `viewModelScope` coroutine that dies when the user
+     * backs out of the screen — owning the fetch there would abandon it, leave the
+     * cache cold and make the next attempt pay the whole cost again. Here a caller
+     * giving up cancels only its own `await`, and the fetch it started still lands.
      */
     private suspend fun fetchOnce(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
         val key = uri.pubKeyHex
         val ours = CompletableDeferred<NwcInfoEvent?>()
         // putIfAbsent returns the previous entry, so a non-null result means
-        // someone else already owns this wallet's fetch.
+        // someone else already started this wallet's fetch.
         inFlight.putIfAbsent(key, ours)?.let { return it.await() }
 
-        var info: NwcInfoEvent? = null
-        try {
-            info = fetchAndStore(uri)
-        } finally {
-            // Non-suspending, so awaiters are released even if we are cancelled.
-            inFlight.remove(key, ours)
-            ours.complete(info)
+        val job =
+            scope.launch(Dispatchers.IO) {
+                var info: NwcInfoEvent? = null
+                try {
+                    info = fetchAndStore(uri)
+                } finally {
+                    // Non-suspending, so awaiters are released even if the fetch is cancelled.
+                    inFlight.remove(key, ours)
+                    ours.complete(info)
+                }
+            }
+
+        // A scope that was already cancelled — this account was logged off while a
+        // payment was in flight — never runs the body, so the finally above never
+        // releases anyone. Without this, the caller awaits forever and the abandoned
+        // slot makes every later call for this wallet do the same. Fires immediately
+        // when the job is already complete, and is a no-op on the normal path.
+        job.invokeOnCompletion {
+            if (!ours.isCompleted) {
+                inFlight.remove(key, ours)
+                ours.complete(null)
+            }
         }
-        return info
+        return ours.await()
     }
 
     private suspend fun fetchAndStore(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Manages NIP-47 (Nostr Wallet Connect) related signing operations and decryption cache for a given account.
@@ -147,10 +148,20 @@ class NwcSignerState(
      * back to NIP-04 even against a wallet advertising `nip44_v2`. Only a cold
      * cache waits: a stale entry still says what the wallet advertises and is used
      * as-is while it refreshes in the background.
+     *
+     * The wait is capped, because this sits in front of a payment the user has
+     * already tapped. Its own fetch is bounded only by the relay accessory's 30s
+     * idle window, and the no-response timer below does not start until this
+     * returns. On expiry we send NIP-04 for this one request rather than hold the
+     * tap; the fetch keeps running in the cache's scope, so the next request gets
+     * the negotiated scheme. Never bound the fetch itself instead — a null from it
+     * is cached as a definitive "no info event" for the whole TTL, which would pin
+     * the wallet to NIP-04 for days.
      */
     private suspend fun prefersNip44(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
         uri ?: return false
-        return infoCache?.currentOrFetch(uri)?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } ?: false
+        val info = withTimeoutOrNull(NIP44_NEGOTIATION_WAIT_MS) { infoCache?.currentOrFetch(uri) }
+        return info?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } == true
     }
 
     fun hasWalletConnectSetup(): Boolean = settings.nwcWallets.value.isNotEmpty()
@@ -336,5 +347,12 @@ class NwcSignerState(
         const val NWC_RESPONSE_TIMEOUT_SECONDS = 60
 
         const val NWC_RESPONSE_TIMEOUT_MS = NWC_RESPONSE_TIMEOUT_SECONDS * 1000L
+
+        /**
+         * How long a request will wait for a cold info cache before falling back to
+         * NIP-04. Comfortably over a healthy single-relay round trip, far under the
+         * 30s the fetch itself would otherwise allow in front of a payment tap.
+         */
+        const val NIP44_NEGOTIATION_WAIT_MS = 3_000L
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -136,17 +136,21 @@ class NwcSignerState(
     }
 
     /**
-     * Non-blocking read of the negotiated encryption preference for a wallet.
-     * NIP-47 says a client "should always prefer nip44 if supported by the wallet
-     * service". Returns true only when the cached info event advertises `nip44_v2`;
-     * otherwise NIP-04 (the legacy default). Also nudges a background refresh so a
-     * stale/expired entry self-heals for the next transaction without blocking this
-     * one.
+     * The negotiated encryption preference for a wallet. NIP-47 says a client
+     * "should always prefer nip44 if supported by the wallet service", so a false
+     * here has to mean "the wallet does not offer NIP-44" — not "we have not asked
+     * yet".
+     *
+     * That distinction is why this waits. The info cache is per-account and held in
+     * memory only, so it starts empty on every app launch, and reading it without
+     * waiting made the first transaction to each wallet after every launch fall
+     * back to NIP-04 even against a wallet advertising `nip44_v2`. Only a cold
+     * cache waits: a stale entry still says what the wallet advertises and is used
+     * as-is while it refreshes in the background.
      */
-    private fun prefersNip44(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
+    private suspend fun prefersNip44(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
         uri ?: return false
-        infoCache?.refreshIfStale(uri)
-        return infoCache?.current(uri)?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } ?: false
+        return infoCache?.currentOrFetch(uri)?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } ?: false
     }
 
     fun hasWalletConnectSetup(): Boolean = settings.nwcWallets.value.isNotEmpty()

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
@@ -28,8 +28,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -172,7 +177,7 @@ class NwcInfoCacheTest {
     }
 
     @Test
-    fun `concurrent getFresh callers share one fetch`() =
+    fun concurrentGetFreshCallersShareOneFetch() =
         runBlocking {
             val fetcher = GatedFetch(info("pay_invoice"))
             val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
@@ -191,7 +196,7 @@ class NwcInfoCacheTest {
         }
 
     @Test
-    fun `getFresh joins a fetch already started by refreshIfStale`() =
+    fun getFreshJoinsFetchAlreadyStartedByRefreshIfStale() =
         runBlocking {
             val fetcher = GatedFetch(info("pay_invoice"))
             val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
@@ -213,7 +218,7 @@ class NwcInfoCacheTest {
     // --- currentOrFetch: wait only when there is nothing cached at all ---
 
     @Test
-    fun `currentOrFetch waits for the first fetch when nothing is cached`() =
+    fun currentOrFetchWaitsWhenNothingIsCached() =
         runBlocking {
             val fetcher = GatedFetch(info("pay_invoice"))
             val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
@@ -231,13 +236,16 @@ class NwcInfoCacheTest {
         }
 
     @Test
-    fun `currentOrFetch returns a stale entry without waiting`() =
+    fun currentOrFetchReturnsStaleEntryWithoutWaiting() =
         runBlocking {
-            var calls = 0
+            // The background refresh is made to hang, so waiting on it would hang the
+            // test. Returning at all is the assertion.
+            val hang = CompletableDeferred<Unit>()
+            val calls = AtomicInteger(0)
             val cache =
                 NwcInfoCache(
                     fetch = {
-                        calls++
+                        if (calls.incrementAndGet() > 1) hang.await()
                         info("pay_invoice")
                     },
                     scope = scope,
@@ -246,12 +254,51 @@ class NwcInfoCacheTest {
                 )
 
             assertNotNull(cache.currentOrFetch(uri("wallet1")))
-            assertEquals(1, calls)
+            assertEquals(1, calls.get())
 
-            // Past the TTL the entry is stale, but it still answers the question it
-            // is asked (which encryption the wallet advertises), so the caller must
-            // get it back without a round-trip. The background refresh self-heals.
+            // Past the TTL the entry is stale, but it still says which encryption the
+            // wallet advertises, so it comes back as-is while the refresh runs on.
             clock += 1_000
-            assertNotNull(cache.currentOrFetch(uri("wallet1")))
+            val stale = cache.currentOrFetch(uri("wallet1"))
+            hang.complete(Unit)
+            assertNotNull(stale)
+        }
+
+    @Test
+    fun cancellingTheCallerDoesNotAbortTheSharedFetch() =
+        runBlocking {
+            // A payment coroutine that asks first must not own the fetch: backing out
+            // of the payment screen would cancel it, leaving the cache cold so the
+            // next attempt pays the whole cost again.
+            val fetcher = GatedFetch(info("pay_invoice"))
+            val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
+
+            val caller = launch(Dispatchers.IO) { cache.currentOrFetch(uri("wallet1")) }
+            fetcher.started.await()
+            caller.cancelAndJoin()
+            fetcher.release.complete(Unit)
+
+            withTimeout(5_000) {
+                while (cache.current(uri("wallet1")) == null) delay(5)
+            }
+            assertEquals("the abandoned fetch still completed and warmed the cache", 1, fetcher.calls.get())
+        }
+
+    @Test
+    fun aDeadScopeReleasesCallersInsteadOfHanging() =
+        runBlocking {
+            // Account.scope is cancelled on logout (AccountCacheState.removeAccount),
+            // which runs asynchronously and can race a payment already in flight.
+            // Launching into it does not run the body, so nothing would complete the
+            // deferred a caller is awaiting.
+            val dead = CoroutineScope(Dispatchers.IO).also { it.cancel() }
+            val fetcher = GatedFetch(info("pay_invoice"))
+            val cache = NwcInfoCache(fetch = fetcher::fetch, scope = dead, ttlSeconds = 100, now = { clock })
+
+            assertNull(withTimeout(2_000) { cache.currentOrFetch(uri("wallet1")) })
+            assertEquals(0, fetcher.calls.get())
+
+            // and the abandoned slot must not poison every later call for that wallet
+            assertNull(withTimeout(2_000) { cache.currentOrFetch(uri("wallet1")) })
         }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
@@ -23,13 +23,19 @@ package com.vitorpamplona.amethyst.model.nip47WalletConnect
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip47WalletConnect.Nip47WalletConnect
 import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcInfoEvent
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 class NwcInfoCacheTest {
     private var clock = 1_000L
@@ -141,5 +147,111 @@ class NwcInfoCacheTest {
             assertNull(cache.current(uri("wallet1"))) // nothing fetched yet
             cache.getFresh(uri("wallet1"))
             assertNotNull(cache.current(uri("wallet1")))
+        }
+
+    // --- one fetch per wallet, however many callers ask at once ---
+
+    /**
+     * A fetch that reports when it has started and then blocks until released, so
+     * a test can put callers into a known interleaving without sleeping: caller
+     * one is provably inside the fetch before the others arrive.
+     */
+    private class GatedFetch(
+        private val result: NwcInfoEvent?,
+    ) {
+        val calls = AtomicInteger(0)
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        suspend fun fetch(uri: Nip47WalletConnect.Nip47URINorm): NwcInfoEvent? {
+            calls.incrementAndGet()
+            started.complete(Unit)
+            release.await()
+            return result
+        }
+    }
+
+    @Test
+    fun `concurrent getFresh callers share one fetch`() =
+        runBlocking {
+            val fetcher = GatedFetch(info("pay_invoice"))
+            val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
+
+            val results =
+                coroutineScope {
+                    val first = async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) }
+                    fetcher.started.await()
+                    val rest = (1..4).map { async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) } }
+                    fetcher.release.complete(Unit)
+                    (listOf(first) + rest).awaitAll()
+                }
+
+            assertEquals(1, fetcher.calls.get())
+            assertTrue(results.all { it != null })
+        }
+
+    @Test
+    fun `getFresh joins a fetch already started by refreshIfStale`() =
+        runBlocking {
+            val fetcher = GatedFetch(info("pay_invoice"))
+            val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
+
+            cache.refreshIfStale(uri("wallet1"))
+            fetcher.started.await()
+
+            val joined =
+                coroutineScope {
+                    val caller = async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) }
+                    fetcher.release.complete(Unit)
+                    caller.await()
+                }
+
+            assertEquals(1, fetcher.calls.get())
+            assertNotNull(joined)
+        }
+
+    // --- currentOrFetch: wait only when there is nothing cached at all ---
+
+    @Test
+    fun `currentOrFetch waits for the first fetch when nothing is cached`() =
+        runBlocking {
+            val fetcher = GatedFetch(info("pay_invoice"))
+            val cache = NwcInfoCache(fetch = fetcher::fetch, scope = scope, ttlSeconds = 100, now = { clock })
+
+            val result =
+                coroutineScope {
+                    val caller = async(Dispatchers.IO) { cache.currentOrFetch(uri("wallet1")) }
+                    fetcher.started.await()
+                    fetcher.release.complete(Unit)
+                    caller.await()
+                }
+
+            assertEquals(1, fetcher.calls.get())
+            assertNotNull("a cold cache must resolve before the caller decides on encryption", result)
+        }
+
+    @Test
+    fun `currentOrFetch returns a stale entry without waiting`() =
+        runBlocking {
+            var calls = 0
+            val cache =
+                NwcInfoCache(
+                    fetch = {
+                        calls++
+                        info("pay_invoice")
+                    },
+                    scope = scope,
+                    ttlSeconds = 100,
+                    now = { clock },
+                )
+
+            assertNotNull(cache.currentOrFetch(uri("wallet1")))
+            assertEquals(1, calls)
+
+            // Past the TTL the entry is stale, but it still answers the question it
+            // is asked (which encryption the wallet advertises), so the caller must
+            // get it back without a round-trip. The background refresh self-heals.
+            clock += 1_000
+            assertNotNull(cache.currentOrFetch(uri("wallet1")))
         }
 }

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
@@ -49,7 +49,7 @@ class OkHttpLnurlEndpointResolver(
 ) : LnurlEndpointResolver {
     private val mapper = jacksonObjectMapper()
 
-    override suspend fun resolve(lnurlpUrl: String): LnurlEndpointInfo? = LnurlEndpointCache.getOrFetch(lnurlpUrl) { fetch(it) }
+    override suspend fun resolve(lnurlpUrl: String): LnurlEndpointInfo? = LnurlEndpointCache.getOrFetch(lnurlpUrl, ::fetch)
 
     private suspend fun fetch(url: String): LnurlEndpointInfo? =
         withContext(Dispatchers.IO) {

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
@@ -24,11 +24,14 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointCache
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointInfo
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointResolver
+import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlForm
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.coroutines.executeAsync
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -40,17 +43,44 @@ import kotlin.coroutines.cancellation.CancellationException
  * `/.well-known/lnurlp/<user>` endpoint, parses `nostrPubkey` + `allowsNostr`,
  * caches the result, and returns it. Returns null on HTTP / parse failure;
  * callers should treat that as "validation unavailable" rather than "invalid".
+ *
+ * Fetches are single-flighted per URL. A feed carrying twenty receipts for one
+ * lightning address hands us twenty concurrent [resolve] calls before the first
+ * fetch can populate the cache; without this, that is twenty requests to a
+ * stranger's unthrottled `/.well-known/` endpoint for one user action.
  */
 class OkHttpLnurlEndpointResolver(
     private val okHttpClient: (String) -> OkHttpClient,
 ) : LnurlEndpointResolver {
     private val mapper = jacksonObjectMapper()
 
+    /**
+     * Fetches in progress, keyed the same way [LnurlEndpointCache] keys itself so
+     * two spellings of one address share a flight. An entry lives only for the
+     * duration of its fetch: the winner removes it in a `finally`, so a failed
+     * fetch is retried by the next caller rather than being remembered as null.
+     */
+    private val inFlight = ConcurrentHashMap<String, CompletableDeferred<LnurlEndpointInfo?>>()
+
     override suspend fun resolve(lnurlpUrl: String): LnurlEndpointInfo? {
         LnurlEndpointCache.get(lnurlpUrl)?.let { return it }
 
-        val info = fetch(lnurlpUrl) ?: return null
-        LnurlEndpointCache.put(lnurlpUrl, info)
+        val key = LnurlForm.normalizeUrl(lnurlpUrl)
+        val ours = CompletableDeferred<LnurlEndpointInfo?>()
+        // Whoever wins putIfAbsent owns the fetch; everyone else awaits its result.
+        inFlight.putIfAbsent(key, ours)?.let { return it.await() }
+
+        var info: LnurlEndpointInfo? = null
+        try {
+            info = fetch(lnurlpUrl)
+            if (info != null) LnurlEndpointCache.put(lnurlpUrl, info)
+        } finally {
+            // Cache first, then release, so a caller arriving in between reads the
+            // cache rather than starting a second flight. Non-suspending, so it
+            // still runs — and still unblocks the awaiters — if we are cancelled.
+            inFlight.remove(key, ours)
+            ours.complete(info)
+        }
         return info
     }
 

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
@@ -24,14 +24,11 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointCache
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointInfo
 import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointResolver
-import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlForm
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.coroutines.executeAsync
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -44,45 +41,15 @@ import kotlin.coroutines.cancellation.CancellationException
  * caches the result, and returns it. Returns null on HTTP / parse failure;
  * callers should treat that as "validation unavailable" rather than "invalid".
  *
- * Fetches are single-flighted per URL. A feed carrying twenty receipts for one
- * lightning address hands us twenty concurrent [resolve] calls before the first
- * fetch can populate the cache; without this, that is twenty requests to a
- * stranger's unthrottled `/.well-known/` endpoint for one user action.
+ * Caching and fetch deduplication both belong to [LnurlEndpointCache]; this
+ * class is only the HTTP half.
  */
 class OkHttpLnurlEndpointResolver(
     private val okHttpClient: (String) -> OkHttpClient,
 ) : LnurlEndpointResolver {
     private val mapper = jacksonObjectMapper()
 
-    /**
-     * Fetches in progress, keyed the same way [LnurlEndpointCache] keys itself so
-     * two spellings of one address share a flight. An entry lives only for the
-     * duration of its fetch: the winner removes it in a `finally`, so a failed
-     * fetch is retried by the next caller rather than being remembered as null.
-     */
-    private val inFlight = ConcurrentHashMap<String, CompletableDeferred<LnurlEndpointInfo?>>()
-
-    override suspend fun resolve(lnurlpUrl: String): LnurlEndpointInfo? {
-        LnurlEndpointCache.get(lnurlpUrl)?.let { return it }
-
-        val key = LnurlForm.normalizeUrl(lnurlpUrl)
-        val ours = CompletableDeferred<LnurlEndpointInfo?>()
-        // Whoever wins putIfAbsent owns the fetch; everyone else awaits its result.
-        inFlight.putIfAbsent(key, ours)?.let { return it.await() }
-
-        var info: LnurlEndpointInfo? = null
-        try {
-            info = fetch(lnurlpUrl)
-            if (info != null) LnurlEndpointCache.put(lnurlpUrl, info)
-        } finally {
-            // Cache first, then release, so a caller arriving in between reads the
-            // cache rather than starting a second flight. Non-suspending, so it
-            // still runs — and still unblocks the awaiters — if we are cancelled.
-            inFlight.remove(key, ours)
-            ours.complete(info)
-        }
-        return info
-    }
+    override suspend fun resolve(lnurlpUrl: String): LnurlEndpointInfo? = LnurlEndpointCache.getOrFetch(lnurlpUrl) { fetch(it) }
 
     private suspend fun fetch(url: String): LnurlEndpointInfo? =
         withContext(Dispatchers.IO) {

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
@@ -42,73 +42,52 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * A zap-receipt burst hands the resolver N concurrent calls for the same
- * lightning address. Each one is meant to await a single fetch, not start its
- * own — the endpoint the fetch hits belongs to somebody else's server.
+ * Deduplication itself belongs to `LnurlEndpointCache` and is pinned by
+ * `LnurlEndpointCacheTest` in quartz. What is left to prove here is that this
+ * resolver actually routes through it, so a zap-receipt burst turns into one
+ * request on a real OkHttp client rather than one per receipt.
  */
 class OkHttpLnurlEndpointResolverTest {
-    private val url = "https://example.com/.well-known/lnurlp/vitor"
+    /** Counts requests and holds each open long enough for the burst to pile up behind it. */
+    private class CountingInterceptor : Interceptor {
+        val calls = AtomicInteger(0)
 
-    /** Counts fetches and holds each one open long enough for the burst to pile up behind it. */
-    private class CountingInterceptor(
-        val calls: AtomicInteger = AtomicInteger(0),
-        private val body: String = """{"nostrPubkey":"aabbcc","allowsNostr":true}""",
-        private val delayMs: Long = 200,
-        private val failFirst: Int = 0,
-    ) : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
-            val n = calls.incrementAndGet()
-            Thread.sleep(delayMs)
-            if (n <= failFirst) {
-                return Response
-                    .Builder()
-                    .request(chain.request())
-                    .protocol(Protocol.HTTP_1_1)
-                    .code(503)
-                    .message("Service Unavailable")
-                    .body("".toResponseBody("text/plain".toMediaType()))
-                    .build()
-            }
+            calls.incrementAndGet()
+            Thread.sleep(HOLD_MS)
             return Response
                 .Builder()
                 .request(chain.request())
                 .protocol(Protocol.HTTP_1_1)
                 .code(200)
                 .message("OK")
-                .body(body.toResponseBody("application/json".toMediaType()))
+                .body(BODY.toResponseBody("application/json".toMediaType()))
                 .build()
         }
     }
 
-    private fun resolverWith(interceptor: Interceptor): OkHttpLnurlEndpointResolver {
-        val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
-        return OkHttpLnurlEndpointResolver { client }
-    }
-
     /**
-     * Releases [n] callers at once and collects what they got.
-     *
-     * The gate matters: the assertion under test is "these callers were all in
-     * flight together", and without it a straggler that arrives after the
-     * winner's fetch has already returned legitimately starts a second one. That
-     * would be a slow test machine failing the test, not a regression.
+     * Releases [n] callers at once. The gate matters: the claim under test is
+     * that these callers were all in flight together, and a straggler arriving
+     * after the first response landed would legitimately issue a second request.
      */
-    private suspend fun burst(
-        n: Int,
-        call: suspend (Int) -> LnurlEndpointInfo?,
-    ): List<LnurlEndpointInfo?> =
+    private suspend fun burst(n: Int): List<LnurlEndpointInfo?> =
         coroutineScope {
+            val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
+            val resolver = OkHttpLnurlEndpointResolver { client }
             val gate = CompletableDeferred<Unit>()
             val callers =
-                (0 until n).map { i ->
+                (0 until n).map {
                     async(Dispatchers.IO) {
                         gate.await()
-                        call(i)
+                        resolver.resolve(URL)
                     }
                 }
             gate.complete(Unit)
             callers.awaitAll()
         }
+
+    private val interceptor = CountingInterceptor()
 
     @BeforeTest
     fun clearCache() {
@@ -116,57 +95,20 @@ class OkHttpLnurlEndpointResolverTest {
     }
 
     @Test
-    fun concurrentCallersForTheSameUrlShareOneFetch() =
+    fun `a burst of callers makes one http request`() =
         runBlocking {
-            val interceptor = CountingInterceptor()
-            val resolver = resolverWith(interceptor)
+            val results = burst(20)
 
-            val results = burst(20) { resolver.resolve(url) }
-
-            assertEquals(1, interceptor.calls.get(), "20 concurrent callers must share one fetch")
-            assertEquals(20, results.size)
-            assertTrue(results.all { it != null && it == results.first() }, "every caller gets the same result")
+            assertEquals(1, interceptor.calls.get(), "20 concurrent callers must share one request")
+            assertNotNull(results.first(), "the shared fetch resolved")
+            assertTrue(results.all { it == results.first() }, "every caller gets the same result")
         }
 
-    @Test
-    fun aFailedFetchIsNotRememberedAndTheNextCallerRetries() =
-        runBlocking {
-            // The server is down for the first burst. Nothing may be cached from
-            // that — otherwise one bad minute poisons the address until eviction.
-            val interceptor = CountingInterceptor(failFirst = 1)
-            val resolver = resolverWith(interceptor)
+    private companion object {
+        const val URL = "https://example.com/.well-known/lnurlp/vitor"
+        const val BODY = """{"nostrPubkey":"aabbcc","allowsNostr":true}"""
 
-            val firstBurst = burst(5) { resolver.resolve(url) }
-            assertEquals(1, interceptor.calls.get(), "the failing burst is one fetch, not five")
-            assertTrue(firstBurst.all { it == null }, "a 503 resolves to null, not a cached verdict")
-
-            val retry = resolver.resolve(url)
-            assertEquals(2, interceptor.calls.get(), "the next caller retries a failed address")
-            assertNotNull(retry, "the retry sees the recovered server")
-
-            resolver.resolve(url)
-            assertEquals(2, interceptor.calls.get(), "and the success is cached from then on")
-        }
-
-    @Test
-    fun twoSpellingsOfOneAddressShareOneFetch() =
-        runBlocking {
-            // LnurlEndpointCache keys case-insensitively on host and ignores a
-            // trailing slash. The in-flight map has to agree, or a burst that
-            // spells the host two ways is two stampedes instead of one.
-            val interceptor = CountingInterceptor(delayMs = 200)
-            val resolver = resolverWith(interceptor)
-
-            val spellings =
-                listOf(
-                    "https://example.com/.well-known/lnurlp/vitor",
-                    "https://EXAMPLE.com/.well-known/lnurlp/vitor",
-                    "https://example.com/.well-known/lnurlp/vitor/",
-                )
-
-            val results = burst(12) { i -> resolver.resolve(spellings[i % 3]) }
-
-            assertEquals(1, interceptor.calls.get(), "host case and a trailing slash are the same address")
-            assertTrue(results.all { it != null && it == results.first() })
-        }
+        /** Long enough for the whole burst to pile up behind the first request. */
+        const val HOLD_MS = 200L
+    }
 }

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.service.lnurl
+
+import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointCache
+import com.vitorpamplona.quartz.nip57Zaps.validate.LnurlEndpointInfo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * A zap-receipt burst hands the resolver N concurrent calls for the same
+ * lightning address. Each one is meant to await a single fetch, not start its
+ * own — the endpoint the fetch hits belongs to somebody else's server.
+ */
+class OkHttpLnurlEndpointResolverTest {
+    private val url = "https://example.com/.well-known/lnurlp/vitor"
+
+    /** Counts fetches and holds each one open long enough for the burst to pile up behind it. */
+    private class CountingInterceptor(
+        val calls: AtomicInteger = AtomicInteger(0),
+        private val body: String = """{"nostrPubkey":"aabbcc","allowsNostr":true}""",
+        private val delayMs: Long = 200,
+        private val failFirst: Int = 0,
+    ) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val n = calls.incrementAndGet()
+            Thread.sleep(delayMs)
+            if (n <= failFirst) {
+                return Response
+                    .Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(503)
+                    .message("Service Unavailable")
+                    .body("".toResponseBody("text/plain".toMediaType()))
+                    .build()
+            }
+            return Response
+                .Builder()
+                .request(chain.request())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(body.toResponseBody("application/json".toMediaType()))
+                .build()
+        }
+    }
+
+    private fun resolverWith(interceptor: Interceptor): OkHttpLnurlEndpointResolver {
+        val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
+        return OkHttpLnurlEndpointResolver { client }
+    }
+
+    /**
+     * Releases [n] callers at once and collects what they got.
+     *
+     * The gate matters: the assertion under test is "these callers were all in
+     * flight together", and without it a straggler that arrives after the
+     * winner's fetch has already returned legitimately starts a second one. That
+     * would be a slow test machine failing the test, not a regression.
+     */
+    private suspend fun burst(
+        n: Int,
+        call: suspend (Int) -> LnurlEndpointInfo?,
+    ): List<LnurlEndpointInfo?> =
+        coroutineScope {
+            val gate = CompletableDeferred<Unit>()
+            val callers =
+                (0 until n).map { i ->
+                    async(Dispatchers.IO) {
+                        gate.await()
+                        call(i)
+                    }
+                }
+            gate.complete(Unit)
+            callers.awaitAll()
+        }
+
+    @BeforeTest
+    fun clearCache() {
+        LnurlEndpointCache.clear()
+    }
+
+    @Test
+    fun concurrentCallersForTheSameUrlShareOneFetch() =
+        runBlocking {
+            val interceptor = CountingInterceptor()
+            val resolver = resolverWith(interceptor)
+
+            val results = burst(20) { resolver.resolve(url) }
+
+            assertEquals(1, interceptor.calls.get(), "20 concurrent callers must share one fetch")
+            assertEquals(20, results.size)
+            assertTrue(results.all { it != null && it == results.first() }, "every caller gets the same result")
+        }
+
+    @Test
+    fun aFailedFetchIsNotRememberedAndTheNextCallerRetries() =
+        runBlocking {
+            // The server is down for the first burst. Nothing may be cached from
+            // that — otherwise one bad minute poisons the address until eviction.
+            val interceptor = CountingInterceptor(failFirst = 1)
+            val resolver = resolverWith(interceptor)
+
+            val firstBurst = burst(5) { resolver.resolve(url) }
+            assertEquals(1, interceptor.calls.get(), "the failing burst is one fetch, not five")
+            assertTrue(firstBurst.all { it == null }, "a 503 resolves to null, not a cached verdict")
+
+            val retry = resolver.resolve(url)
+            assertEquals(2, interceptor.calls.get(), "the next caller retries a failed address")
+            assertNotNull(retry, "the retry sees the recovered server")
+
+            resolver.resolve(url)
+            assertEquals(2, interceptor.calls.get(), "and the success is cached from then on")
+        }
+
+    @Test
+    fun twoSpellingsOfOneAddressShareOneFetch() =
+        runBlocking {
+            // LnurlEndpointCache keys case-insensitively on host and ignores a
+            // trailing slash. The in-flight map has to agree, or a burst that
+            // spells the host two ways is two stampedes instead of one.
+            val interceptor = CountingInterceptor(delayMs = 200)
+            val resolver = resolverWith(interceptor)
+
+            val spellings =
+                listOf(
+                    "https://example.com/.well-known/lnurlp/vitor",
+                    "https://EXAMPLE.com/.well-known/lnurlp/vitor",
+                    "https://example.com/.well-known/lnurlp/vitor/",
+                )
+
+            val results = burst(12) { i -> resolver.resolve(spellings[i % 3]) }
+
+            assertEquals(1, interceptor.calls.get(), "host case and a trailing slash are the same address")
+            assertTrue(results.all { it != null && it == results.first() })
+        }
+}

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolverTest.kt
@@ -97,7 +97,24 @@ class OkHttpLnurlEndpointResolverTest {
     @Test
     fun `a burst of callers makes one http request`() =
         runBlocking {
-            val results = burst(20)
+            // The gate matters: the claim under test is that these callers were all
+            // in flight together, and a straggler arriving after the first response
+            // landed would legitimately issue a second request.
+            val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
+            val resolver = OkHttpLnurlEndpointResolver { client }
+            val gate = CompletableDeferred<Unit>()
+            val results =
+                coroutineScope {
+                    val callers =
+                        (0 until 20).map {
+                            async(Dispatchers.IO) {
+                                gate.await()
+                                resolver.resolve(URL)
+                            }
+                        }
+                    gate.complete(Unit)
+                    callers.awaitAll()
+                }
 
             assertEquals(1, interceptor.calls.get(), "20 concurrent callers must share one request")
             assertNotNull(results.first(), "the shared fetch resolved")

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCache.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCache.kt
@@ -100,10 +100,10 @@ object LnurlEndpointCache {
         try {
             info = fetch(url)?.also { cache.put(key, it) }
         } finally {
-            // Populate the cache before releasing the flight, so a caller arriving
-            // in between reads the result instead of starting a second fetch.
-            // Both calls are non-suspending, so this still runs — and still
-            // unblocks the awaiters — if we are cancelled mid-fetch.
+            // The cache is populated before the flight is released, so a caller
+            // arriving in between reads the result instead of starting a second
+            // fetch. Non-suspending, so awaiters are released even if the fetch is
+            // cancelled.
             inFlight.remove(key, ours)
             ours.complete(info)
         }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCache.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCache.kt
@@ -21,6 +21,8 @@
 package com.vitorpamplona.quartz.nip57Zaps.validate
 
 import com.vitorpamplona.quartz.utils.cache.ConcurrentLruCache
+import kotlinx.coroutines.CompletableDeferred
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Process-wide cache of LNURL-pay endpoint metadata, keyed by the canonical
@@ -44,6 +46,12 @@ object LnurlEndpointCache {
     // the previous LinkedHashMap-based behaviour where only put reordered.
     private val cache = ConcurrentLruCache<String, LnurlEndpointInfo>(MAX_ENTRIES)
 
+    // Fetches in progress, keyed exactly as [cache] is. The two must agree on
+    // what counts as "the same address", which is why they live together: a
+    // flight map that keyed URLs differently would silently stop deduplicating
+    // the moment this object's canonicalisation changed, and nothing would fail.
+    private val inFlight = ConcurrentHashMap<String, CompletableDeferred<LnurlEndpointInfo?>>()
+
     fun get(url: String): LnurlEndpointInfo? = cache.get(LnurlForm.normalizeUrl(url))
 
     fun put(
@@ -53,8 +61,58 @@ object LnurlEndpointCache {
         cache.put(LnurlForm.normalizeUrl(url), info)
     }
 
+    /**
+     * Returns the cached entry for [url], or runs [fetch] — exactly once, however
+     * many callers ask at once — and caches what it returns.
+     *
+     * A zap-receipt burst asks once per receipt: twenty receipts for one
+     * lightning address arrive together, all miss, and without this they would
+     * be twenty requests to a stranger's unthrottled `/.well-known/lnurlp/`
+     * endpoint for one user action. The first caller fetches; the rest await it.
+     *
+     * A [fetch] returning null is not cached, so a provider having a bad minute
+     * is retried by the next caller rather than remembered as unresolvable.
+     *
+     * [fetch] is expected to report failure by returning null rather than by
+     * throwing. Cancellation is the exception: if the coroutine that owns the
+     * fetch is cancelled, the CancellationException propagates to that caller
+     * alone, and everyone awaiting it gets null — "unresolved", the same as a
+     * failed fetch. That asymmetry is deliberate. Awaiters are separate
+     * coroutines that are still alive, and cancelling them because the caller
+     * that happened to win the race went away would be wrong. Any other
+     * throwable reaches awaiters the same way, as null, while propagating to
+     * the owner — so a [fetch] that throws gives the two a different answer for
+     * one failure. Return null instead.
+     */
+    suspend fun getOrFetch(
+        url: String,
+        fetch: suspend (String) -> LnurlEndpointInfo?,
+    ): LnurlEndpointInfo? {
+        val key = LnurlForm.normalizeUrl(url)
+        cache.get(key)?.let { return it }
+
+        val ours = CompletableDeferred<LnurlEndpointInfo?>()
+        // Whoever wins putIfAbsent owns the fetch; it returns the previous entry,
+        // so a non-null result means someone else is already in flight.
+        inFlight.putIfAbsent(key, ours)?.let { return it.await() }
+
+        var info: LnurlEndpointInfo? = null
+        try {
+            info = fetch(url)?.also { cache.put(key, it) }
+        } finally {
+            // Populate the cache before releasing the flight, so a caller arriving
+            // in between reads the result instead of starting a second fetch.
+            // Both calls are non-suspending, so this still runs — and still
+            // unblocks the awaiters — if we are cancelled mid-fetch.
+            inFlight.remove(key, ours)
+            ours.complete(info)
+        }
+        return info
+    }
+
     fun clear() {
         cache.clear()
+        inFlight.clear()
     }
 
     internal fun size(): Int = cache.size()

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCacheTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip57Zaps/validate/LnurlEndpointCacheTest.kt
@@ -20,8 +20,17 @@
  */
 package com.vitorpamplona.quartz.nip57Zaps.validate
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class LnurlEndpointCacheTest {
@@ -54,5 +63,108 @@ class LnurlEndpointCacheTest {
         // Cache should not exceed 1000 entries; the first inserted key should be evicted.
         assertEquals(null, LnurlEndpointCache.get("https://example.com/.well-known/lnurlp/user0"))
         assertTrue(LnurlEndpointCache.get("https://example.com/.well-known/lnurlp/user1000") != null)
+    }
+
+    // --- getOrFetch: one fetch per address, however many callers ask at once ---
+
+    private val info = LnurlEndpointInfo(nostrPubkey = "d".repeat(64), allowsNostr = true)
+
+    /**
+     * Counts fetches and holds each one open long enough for a burst to pile up
+     * behind it. [failFirst] resolves the first N calls to null, as a provider
+     * having a bad minute does.
+     */
+    private class CountingFetch(
+        private val failFirst: Int = 0,
+        private val result: LnurlEndpointInfo,
+    ) {
+        val calls = AtomicInteger(0)
+
+        suspend fun fetch(url: String): LnurlEndpointInfo? {
+            val ok = calls.incrementAndGet() > failFirst
+            delay(HOLD_MS)
+            return if (ok) result else null
+        }
+    }
+
+    /**
+     * Releases [n] callers at once and collects what they got.
+     *
+     * The gate matters: the claim under test is "these callers were all in flight
+     * together", and a straggler arriving after the winner's fetch already
+     * returned legitimately starts a second one. Without the gate that would be a
+     * slow machine failing the test rather than a regression.
+     */
+    private suspend fun burst(
+        n: Int,
+        call: suspend (Int) -> LnurlEndpointInfo?,
+    ): List<LnurlEndpointInfo?> =
+        coroutineScope {
+            val gate = CompletableDeferred<Unit>()
+            val callers =
+                (0 until n).map { i ->
+                    async(Dispatchers.IO) {
+                        gate.await()
+                        call(i)
+                    }
+                }
+            gate.complete(Unit)
+            callers.awaitAll()
+        }
+
+    @Test
+    fun `concurrent callers for one url share a single fetch`() =
+        runBlocking {
+            LnurlEndpointCache.clear()
+            val fetcher = CountingFetch(result = info)
+
+            val results = burst(20) { LnurlEndpointCache.getOrFetch(URL, fetcher::fetch) }
+
+            assertEquals(1, fetcher.calls.get(), "20 concurrent callers must share one fetch")
+            assertTrue(results.all { it == info }, "every caller gets the same result")
+        }
+
+    @Test
+    fun `a failed fetch is not cached and the next caller retries`() =
+        runBlocking {
+            LnurlEndpointCache.clear()
+            val fetcher = CountingFetch(failFirst = 1, result = info)
+
+            val firstBurst = burst(5) { LnurlEndpointCache.getOrFetch(URL, fetcher::fetch) }
+            assertEquals(1, fetcher.calls.get(), "the failing burst is one fetch, not five")
+            assertTrue(firstBurst.all { it == null }, "a failed fetch resolves to null, not a cached verdict")
+
+            assertNotNull(LnurlEndpointCache.getOrFetch(URL, fetcher::fetch), "the retry sees the recovered provider")
+            assertEquals(2, fetcher.calls.get(), "the next caller retries a failed address")
+
+            LnurlEndpointCache.getOrFetch(URL, fetcher::fetch)
+            assertEquals(2, fetcher.calls.get(), "and the success is cached from then on")
+        }
+
+    @Test
+    fun `two spellings of one address share a single fetch`() =
+        runBlocking {
+            LnurlEndpointCache.clear()
+            val fetcher = CountingFetch(result = info)
+            // The flight map has to canonicalise the way get/put do, or a burst
+            // that spells the host two ways is two stampedes instead of one.
+            val spellings =
+                listOf(
+                    "https://example.com/.well-known/lnurlp/vitor",
+                    "https://EXAMPLE.com/.well-known/lnurlp/vitor",
+                    "https://example.com/.well-known/lnurlp/vitor/",
+                )
+
+            val results = burst(spellings.size * 4) { i -> LnurlEndpointCache.getOrFetch(spellings[i % spellings.size], fetcher::fetch) }
+
+            assertEquals(1, fetcher.calls.get(), "host case and a trailing slash are the same address")
+            assertTrue(results.all { it == info })
+        }
+
+    private companion object {
+        const val URL = "https://example.com/.well-known/lnurlp/vitor"
+
+        /** Long enough for a whole burst to pile up behind the first fetch. */
+        const val HOLD_MS = 200L
     }
 }


### PR DESCRIPTION
Two independent fixes to zap-related fetching, both found by operating a NIP-57/NIP-47 wallet service against Amethyst and reading the client source to explain what the server saw.

1. **LNURL endpoint fetches were not deduplicated**, so a burst of zap receipts for one lightning address produced one HTTP request per receipt to that provider's `/.well-known/lnurlp/` endpoint. Measured at 211 requests in 3.18 seconds for a single address.
2. **NWC requests silently downgraded to NIP-04** on the first transaction to each wallet after every app launch, even against a wallet advertising `nip44_v2`.

They share no files and can be reviewed independently — commits 1–2 are the LNURL fix, commits 3–5 the NWC one.

---

## 1. LNURL endpoint fetch stampede

`LocalCache.consume(LnZapEvent)` validates each incoming zap receipt against the recipient's LNURL provider `nostrPubkey` (NIP-57 Appendix F). It launches one coroutine per receipt, and each one calls `LnurlEndpointResolver.resolve()`.

The resolver's cache is read-through, so it only helps once a fetch has landed. A burst of receipts for one address therefore missed together: N receipts became N coroutines, N cache misses and N HTTP requests to the same document, followed by N redundant writes of the same value.

This costs the LNURL provider, not Amethyst. The endpoint is unauthenticated and unthrottled by design, and a feed or profile carrying many receipts for one popular address is exactly the burst shape.

### Fix

`LnurlEndpointCache` gains `getOrFetch(url, fetch)`: one in-flight `CompletableDeferred` per URL, with concurrent callers awaiting it rather than starting their own. The eviction policy, capacity and key normalisation are unchanged.

The deduplication lives on the cache rather than in the OkHttp resolver deliberately. The flight map and the store must agree on what counts as "the same address"; keeping them apart meant the resolver had to call `LnurlForm.normalizeUrl` purely to mirror a keying detail private to a class in another module, with nothing enforcing that. Together, the key is computed once and shared, so they cannot drift.

Two properties worth noting for review:

- The cache is populated **before** the in-flight slot is released, so a caller arriving in between reads the result instead of starting a second fetch.
- The slot is released in a non-suspending `finally`, so awaiters are unblocked even if the coroutine that owns the fetch is cancelled. A failed fetch caches nothing, so a provider having a bad minute is retried by the next caller rather than remembered as unresolvable.

### Effect on provider load

For a burst of N receipts for one address, requests to the provider drop from N to 1. The cache has no TTL, so after the first fetch the address is answered from memory for the life of the process.

This is not a client-side latency change. The fetches were already asynchronous and off the render path; the receipts were displayed immediately either way.

### Deliberately not included

- **Negative caching.** A failed fetch still caches nothing, so an endpoint that is down or rate-limiting is re-fetched once per receipt. Deduplication collapses each burst, but not the drip. Choosing a TTL is a policy decision with a real downside (briefly refusing to credit legitimate zaps), so it is left out of a bugfix.
- **`LightningAddressResolver`.** The zap-*sending* path writes to `LnurlEndpointCache` but never reads it. That looks like an omission, but the sending path needs the document's `callback` field and `LnurlEndpointInfo` stores only `nostrPubkey` and `allowsNostr`. Making it read the cache would require widening what that cache is for, and would raise a staleness question it currently avoids: a stale `nostrPubkey` costs an uncredited zap, but a stale `callback` costs a failed payment on a deliberate user action.

---

## 2. NWC NIP-04 downgrade on a cold info cache

NIP-47 says a client "should always prefer nip44 if supported by the wallet service". `NwcSignerState.prefersNip44()` returning false therefore has to mean "this wallet does not offer NIP-44". It meant two different things: that, and "we have not asked yet".

`NwcInfoCache` is per-account and held in memory only, so it starts empty on every app launch. `prefersNip44` read it without waiting, so a cold read returned null, which is indistinguishable from "no NIP-44". The first transaction to each wallet after each launch went out as NIP-04 against a wallet advertising `nip44_v2` — a silent downgrade to deprecated encryption on a payment request.

The existing startup warm-up narrows the window but does not close it: it is asynchronous and races the user's first tap.

### Fix

`NwcInfoCache.currentOrFetch()` waits only when nothing at all is cached, and returns a stale entry as-is. Staleness never caused the downgrade — a stale entry already says which schemes the wallet advertises — so waiting on it would buy nothing and would add a round-trip every TTL period. `prefersNip44` becomes `suspend` and uses it; both call sites were already suspend.

Three properties matter for review, and each is pinned by a test:

- **The wait is capped at 3s.** It sits in front of a payment the user has already tapped, and the fetch itself is bounded only by the relay accessory's default 30s idle window, with the no-response timer not starting until `prefersNip44` returns. On expiry the request goes out as NIP-04 and the fetch keeps running, so the next request gets the negotiated scheme. The cap is on the wait and never on the fetch: a null from the fetch is cached as a definitive "no info event" for the whole TTL, so bounding the fetch would pin the wallet to NIP-04 for days — the opposite of the intent.
- **The fetch runs in the cache's own scope, not the caller's.** A caller on the payment path is a `viewModelScope` coroutine; owning the fetch there meant backing out of the payment screen cancelled it, leaving the cache cold so the next attempt paid the whole cost again. Every caller now only awaits, so giving up cancels one await and nothing else.
- **A dead scope releases its awaiters.** `Account.scope` is cancelled on log-off (`AccountCacheState.removeAccount`), which runs on its own coroutine and can race a payment already in flight. Launching into an already-cancelled scope never runs the body, so the `finally` that completes the deferred never runs either — the caller would await forever and the abandoned in-flight slot would make every later call for that wallet do the same. The deferred is now completed from the job's own completion when the body never got to do it.

Every fetching path in `NwcInfoCache` funnels through one request per wallet. Previously only the background refresh was guarded, and by a plain key set that could not be awaited.

### Effect on latency and load, stated precisely

This is a correctness fix, not a latency optimisation, and it is worth being exact about the direction:

- **It adds latency, bounded and once.** On a genuinely cold cache the first request to a wallet waits up to 3s for its kind 13194 info event instead of proceeding immediately with NIP-04. That is per wallet, per app launch, and only when nothing is cached. Subsequent requests and stale entries do not wait.
- **It reduces relay load slightly.** At most one kind 13194 subscription per wallet is open at a time, regardless of how many paths ask concurrently. This is deduplication of a relay REQ, not of an NWC RPC.
- **It does not change NWC request volume.** The number of `get_balance` / `get_info` / `pay_invoice` requests reaching the wallet service is unchanged. There is no direct reduction in wallet-service load.

---

## Field measurement

A wallet-service operator measured a patched build against stock from the server side, using a self-hosted NIP-47 service (LND on a Raspberry Pi 4). Same nostr account in both clients, and separate NWC pairings configured identically — same backend, same single relay `wss://nos.lol`, same limits.

Method: builds run alternately inside one ten-minute window, three cycles, so time-varying relay conditions apply equally to both. Identical script each arm — force-close, open the wallet five times ~10 s apart, request transactions once, no payments. Requests attributed by the service's per-connection id, with marker requests separating runs.

| Arm | Answered | Unanswered | Wall clock | Gaps ≥8 s | Service handling median/max |
| --- | --- | --- | --- | --- | --- |
| cycle 1 — stock | 42 | 0 | 53 s | — | 18.2 / 74 ms |
| cycle 1 — patched | 33 | 0 | 28 s | — | 47.1 / 113 ms |
| cycle 2 — stock | 31 | 0 | 41 s | 17.6 | 30.4 / 105 ms |
| cycle 2 — patched | 33 | 0 | 26 s | — | 17.0 / 87 ms |
| cycle 3 — stock | 33 | 0 | 104 s | 26.9, 17.4, 11.6, 9.0 | 18.4 / 80 ms |
| cycle 3 — patched | 33 | 0 | 26 s | — | 19.0 / 147 ms |

Totals: stock 106 answered, 0 unanswered, five gaps ≥8 s. Patched 99 answered, 0 unanswered, no gaps ≥8 s.

The service answered 100% of requests in every arm with median handling of 17–47 ms. In cycle 1 the patched build was served *more slowly* than stock (47.1 ms against 18.2 ms median) and still completed the script in half the time, which rules out service latency as the explanation.

### What this data does establish

What it does establish is the thing most relevant to reviewing section 2: **the added cold-cache wait does not degrade responsiveness in practice.** The natural objection to making a payment path wait on a relay round-trip is that it shows up as a slower first interaction. Across three alternating cycles the patched build completed an identical script in 28 s, 26 s and 26 s with no gap over 8 s, against 53 s, 41 s and 104 s for stock.

That evidence applies *a fortiori* to what is proposed here. The measured build carried the first three commits — the wait it contained was **uncapped**, bounded only by the fetch's own 30s idle window. The 3s cap and the scope-ownership fix were written after the measurement and only reduce the worst case, so the shipped behaviour cannot be slower than what was measured.

The separate LNURL measurement — 211 requests for one address in 3.18 s, from a stock client — is direct evidence for section 1, taken from the same operator's logs.

---

## Tests

New tests, each of which fails without the change it covers:

- `LnurlEndpointCacheTest` — 20 concurrent callers for one URL produce one fetch; a failed fetch is not cached and the next caller retries; two spellings of one address (host case, trailing slash) share one fetch.
- `OkHttpLnurlEndpointResolverTest` — a burst of callers produces one HTTP request through a real OkHttp client, proving the resolver routes through the cache.
- `NwcInfoCacheTest` — concurrent callers share one fetch; a caller joins a fetch already started by the background refresh; `currentOrFetch` waits when nothing is cached and returns a stale entry without waiting (the refresh is made to hang, so waiting on it would hang the test); cancelling a caller does not abort the shared fetch; a cache built on an already-cancelled scope releases its callers instead of hanging.

Concurrency tests release their callers through a shared gate rather than sleeping, so they assert "these callers were in flight together" rather than depending on timing.

Each guard was verified by mutation — removing the single-flight, keying the flight map on the raw URL, never releasing the in-flight slot, making the resolver bypass the cache, reverting `currentOrFetch` to the old non-waiting read, putting the fetch back on the caller's coroutine, and removing the dead-scope safety net each fail exactly the test that covers them.

`prefersNip44` itself is a two-line call-site swap covered by the cache tests. `NwcSignerState` has no test harness and constructing one (it needs `LocalCache`, `AccountSettings` and the filter assembler) was out of proportion to the change.

Green: `:quartz:jvmTest`, `:commons:jvmTest`, `:amethyst:testPlayDebugUnitTest`, `:quartz:verifyKmpPurity`, `spotlessCheck`, and compiles for `:amethyst` (fdroid and play), `:desktopApp` and `:commons:compileAndroidMain`.

## Follow-ups deliberately left out

- The single-flight mechanism is now implemented twice — `LnurlEndpointCache` in `quartz` and `NwcInfoCache` in `amethyst`. Extracting a shared `SingleFlight<K, V>` into `quartz/utils` is the right next change, but it adds public API to a shared module and is better reviewed on its own.
- `NwcInfoCache.getFresh` has no production caller. That predates this branch; it is documented as such rather than removed, since deleting it would rewrite pre-existing tests.
- `NwcInfoEvent?` conflates "never fetched" with "wallet published no info event", and the three production readers each encode that differently. Making the distinction explicit in the type is the deeper fix; this PR fixes the call site that was getting it wrong.


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
