### PR TITLE
perf(logging): defer message construction to the lambda overload

### DIFF
--- a/.claude/skills/find-non-lambda-logs/SKILL.md
+++ b/.claude/skills/find-non-lambda-logs/SKILL.md
@@ -7,11 +7,11 @@ description: Use when auditing or migrating Log calls — flags interpolated Log
 
 ## Overview
 
-Two related logging hygiene issues:
+Three related logging hygiene issues:
 
 1. **Lambda overload missing.** `Log.d/i/w/e` calls that use string interpolation without the lambda overload waste string allocation when the log level is filtered out in release builds.
 2. **Throwable dropped in catch blocks.** `Log.w/e` calls inside `catch (e: ...)` blocks that interpolate `${e.message}` but don't pass `e` lose the stack trace, and log nothing useful when `e.message` is null (NPE, IOException with no message, etc.).
-3. **Still on `android.util.Log`.** Files importing the platform logger bypass `Log.minLevel` and the `LogSink`, and have no lambda overload — so neither fix above can be applied to them. Step 4 finds these; the last section migrates them.
+3. **Still on `android.util.Log`.** Files importing the platform logger bypass `Log.minLevel` and the `LogSink`, and have no lambda overload — so neither fix above can be applied to them. Step 0 finds these; the last section migrates them.
 
 ## When to Use
 
@@ -40,9 +40,53 @@ Log.d("Tag", "Initialization complete")
 
 **Important:** Tags can be string literals (`"Tag"`) or variables (`tag`, `LOG_TAG`). Run both patterns for each step.
 
-**Run Step 4 before Steps 1–3.** It identifies the files that have no lambda overload available; converting a call in one of those does not compile. Subtract its file list from the Step 1–3 candidates.
+**The throwable-name alternation, used by Steps 2 and 3** — define it once and reuse it, rather than writing a shorter list in one step and a longer one in another:
+
+```bash
+THROWABLE='(e|t|it|ex|err|error|throwable|cause|tr)'
+```
 
 **Filter the noise before counting**, or the totals mislead: drop `/build/`, `/androidTest/` and `/src/test/` (release filtering doesn't apply to tests), and drop lines whose first non-space character is `//` or `*` — commented-out calls and KDoc examples both match these patterns. A `grep -vE ':[0-9]+: *(//|\*)'` handles the last one.
+
+### Step 0: Find files still on `android.util.Log` (run this first)
+
+**Two patterns — the fully-qualified one alone is a false negative.** Almost nobody writes `android.util.Log.w(...)` at the call site; they `import android.util.Log` and then write `Log.w(...)`, which is indistinguishable from the wrapper by call shape. The import is the reliable signal:
+
+```bash
+# the form that actually occurs
+grep -rln --include='*.kt' '^import android\.util\.Log$' . | grep -v '/build/' | grep -v PlatformLog
+
+# the rare fully-qualified call
+grep -rnE --include='*.kt' 'android\.util\.Log\.(d|i|w|e|v)\(' . | grep -v '/build/' | grep -v PlatformLog
+```
+
+On 2026-08-28 the fully-qualified pattern reported **0** while the import pattern found **16 production files** (9 in `nappletHost`, the rest in amethyst's `favorites/` and `napplet/`). Exclude `PlatformLog.android.kt`, which is the wrapper implementation and must call `android.util.Log`.
+
+These bypass the `Log.minLevel` filter and the `LogSink` indirection entirely, and — the practical consequence for this skill — **they have no lambda overload**, so Steps 1–3 cannot be applied to them until they are migrated. Subtract these files from the Step 1–3 candidate lists, or migrate them first (see the last section).
+
+### Step 0b: The patterns are line-anchored — sweep multi-line calls separately
+
+Every `pattern:` in Steps 1–3 matches a call written on one line. A call formatted as
+
+```kotlin
+Log.d(
+    TAG,
+    "WASTE ${url.url} dials=${r.tentatives.get()} " +
+        "fail=[${r.failures.entries.joinToString { … }}]",
+)
+```
+
+is **structurally invisible** to them. That biases the audit towards short calls and away from expensive ones — the multi-line form is what long, heavily interpolated messages look like, and those are exactly the ones worth deferring. A 2026-08-28 sweep converted three one-line banner calls in `BootRelayDiagnostics.kt` while walking past two `Log.d` calls in `forEach` loops immediately below them, running 25 and 20 iterations per census with nested `joinToString` in each — strictly the larger cost, three lines away.
+
+Catch them with the open-paren-at-EOL form, then read each hit:
+
+```bash
+grep -rnE --include='*.kt' 'Log\.[diwe]\($' . | grep -v '/build/'
+# or, to see the whole call:
+rg -U --multiline --type kotlin 'Log\.[diwe]\(\n[^)]*\$\{'
+```
+
+**Prioritise call sites inside loops over one-liners.** A `Log.d` in a 25-iteration `forEach` discards 25 built strings per pass; a one-line banner discards one.
 
 ### Step 1: Find interpolated Log.d/Log.i (highest priority — filtered in release)
 
@@ -71,7 +115,8 @@ Then **manually exclude** lines where a throwable is passed as third argument. C
 **`it` is the name you will miss.** `Result.onFailure { ... }` is the dominant shape in this repo, so most correct calls end `, it)`, not `, e)`. Excluding only `e`/`throwable` inflates the result badly — a 2026-08-28 pass reported 23 hits where the real number was 8, because 14 of them were `.onFailure { Log.w(TAG, "...", it) }` and already correct. Also note the throwable is not always last on the line (`}.onFailure { Log.w(...) }.getOrDefault(false)`), so anchoring the exclusion to `$` misses them:
 
 ```bash
-grep -vE ',\s*(e|t|it|ex|err|error|throwable|cause|tr)\)'   # note: no $ anchor, and `it` included
+grep -rnE --include='*.kt' 'Log\.(w|e)\([^,]+,\s*"[^"]*\$' . \
+  | grep -vE ",\s*$THROWABLE\)"      # note: no $ anchor, and `it` included
 ```
 
 ### Step 3: Find catch-block Log.w/e that drop the throwable
@@ -81,29 +126,13 @@ Among the Step 2 hits, the calls that interpolate `${e.message}` (or `${t.messag
 Quick filter:
 
 ```
-pattern: Log\.(w|e)\([^)]*\$\{(e|t|throwable|cause)\.message\}[^)]*\)$
+pattern: Log\.(w|e)\([^)]*\$\{(e|t|it|ex|err|throwable|cause)\.message\}
 type: kotlin
 ```
 
-Then for each hit, open the file and confirm the line is **inside a `catch (e: ...)` block** and **does not pass `e` (or the matching name) as a third argument**. False positives: extension functions / helpers that accept an `e: SomeError` parameter and forward it elsewhere.
+Note this deliberately omits the `\)$` anchor and includes `it` — same reasons as Step 2. Then for each hit, open the file and confirm the line is **inside a `catch (e: ...)` block** and **does not pass `e` (or the matching name) as a third argument**. False positives: extension functions / helpers that accept an `e: SomeError` parameter and forward it elsewhere.
 
 Both Step 2 and Step 3 may flag the same line — handle Step 3 first (different fix), then apply Step 2 to whatever remains.
-
-### Step 4: Verify no android.util.Log leakage
-
-**Two patterns — the fully-qualified one alone is a false negative.** Almost nobody writes `android.util.Log.w(...)` at the call site; they `import android.util.Log` and then write `Log.w(...)`, which is indistinguishable from the wrapper by call shape. The import is the reliable signal:
-
-```bash
-# the form that actually occurs
-grep -rln --include='*.kt' '^import android\.util\.Log$' . | grep -v '/build/' | grep -v PlatformLog
-
-# the rare fully-qualified call
-grep -rnE --include='*.kt' 'android\.util\.Log\.(d|i|w|e|v)\(' . | grep -v '/build/' | grep -v PlatformLog
-```
-
-On 2026-08-28 the fully-qualified pattern reported **0** while the import pattern found **16 production files** (9 in `nappletHost`, the rest in amethyst's `favorites/` and `napplet/`). Exclude `PlatformLog.android.kt`, which is the wrapper implementation and must call `android.util.Log`.
-
-These bypass the `Log.minLevel` filter and the `LogSink` indirection entirely, and — the practical consequence for this skill — **they have no lambda overload**, so Steps 1–3 cannot be applied to them until they are migrated. Subtract these files from the Step 1–3 candidate lists, or migrate them first.
 
 ## Fix Patterns
 
@@ -124,7 +153,7 @@ Switch to `(tag, msg, throwable)` — the lambda overload does **not** accept a 
 ```kotlin
 // Before — stack trace lost, prints "...failed: null" if e.message is null
 try { groupManager.clearAllState() } catch (e: Exception) {
-    Log.w("MarmotManager") { "clearAllState failed: ${e.message}" }
+    Log.w("MarmotManager", "clearAllState failed: ${e.message}")
 }
 
 // After — full stack trace logged
@@ -145,7 +174,7 @@ Trade-off: the message string is allocated eagerly even when warn is filtered, b
 
 ## Migrating a file off `android.util.Log`
 
-This is what unlocks Steps 1–3 for the files Step 4 finds. It is a behaviour change, so check it rather than assuming — but in this repo the check has come out safe, and here is the reasoning to redo:
+This is what unlocks Steps 1–3 for the files Step 0 finds. It is a behaviour change, so check it rather than assuming — but in this repo the check has come out safe, and here is the reasoning to redo:
 
 1. **Which levels does the file use?** `grep -hoE 'Log\.[a-zA-Z]+' <files> | sort | uniq -c`. The wrapper has `d/i/w/e` only — **no `v`**, and no `getStackTraceString`. A `Log.v` call has no direct equivalent and needs a decision, not a rename.
 2. **Would the gate drop them?** `LogLevel { DEBUG, INFO, WARN, ERROR }`, the gate is `minLevel <= <level>`, and `Amethyst.DEFAULT_LOG_LEVEL` is INFO in debug, **WARN in release** (deliberately — so relay-protocol refusals stay visible in the field). The wrapper's own default is `DEBUG`. So `Log.w` and `Log.e` survive in every build type and in every process, including before `Amethyst.init` runs — which matters for `:napplet`. `Log.d`/`Log.i` **would** go silent in release; those need a conscious call.
@@ -157,7 +186,6 @@ Then: swap `import android.util.Log` → `import com.vitorpamplona.quartz.utils.
 **Verify the throwables survived**, since a careless rewrite can drop the third argument silently:
 
 ```bash
-grep -rhcE 'Log\.[diwe]\([^)]*,\s*(e|it)\)' <files> | paste -sd+ - | bc   # compare before/after
+grep -hoE 'Log\.[diwe]\([^)]*,\s*(e|it)\)' <files> | wc -l   # compare before/after
 ```
 
-The 2026-08-28 pass moved 16 files / 29 calls this way: 26 already passed a throwable (import only), 3 interpolated and became lambdas. Zero calls changed visibility.

--- a/.claude/skills/find-non-lambda-logs/SKILL.md
+++ b/.claude/skills/find-non-lambda-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-non-lambda-logs
-description: Use when auditing or migrating Log calls — flags both interpolated Log.d/i/w/e that should use the lambda overload (allocation hygiene) and catch-block Log.w/e that interpolate ${e.message} but drop the throwable (lost stack traces)
+description: Use when auditing or migrating Log calls — flags interpolated Log.d/i/w/e that should use the lambda overload (allocation hygiene), catch-block Log.w/e that interpolate ${e.message} but drop the throwable (lost stack traces), and files still importing android.util.Log (no lambda overload, bypasses Log.minLevel)
 ---
 
 # Find Non-Lambda Log Calls
@@ -11,6 +11,7 @@ Two related logging hygiene issues:
 
 1. **Lambda overload missing.** `Log.d/i/w/e` calls that use string interpolation without the lambda overload waste string allocation when the log level is filtered out in release builds.
 2. **Throwable dropped in catch blocks.** `Log.w/e` calls inside `catch (e: ...)` blocks that interpolate `${e.message}` but don't pass `e` lose the stack trace, and log nothing useful when `e.message` is null (NPE, IOException with no message, etc.).
+3. **Still on `android.util.Log`.** Files importing the platform logger bypass `Log.minLevel` and the `LogSink`, and have no lambda overload — so neither fix above can be applied to them. Step 4 finds these; the last section migrates them.
 
 ## When to Use
 
@@ -39,6 +40,10 @@ Log.d("Tag", "Initialization complete")
 
 **Important:** Tags can be string literals (`"Tag"`) or variables (`tag`, `LOG_TAG`). Run both patterns for each step.
 
+**Run Step 4 before Steps 1–3.** It identifies the files that have no lambda overload available; converting a call in one of those does not compile. Subtract its file list from the Step 1–3 candidates.
+
+**Filter the noise before counting**, or the totals mislead: drop `/build/`, `/androidTest/` and `/src/test/` (release filtering doesn't apply to tests), and drop lines whose first non-space character is `//` or `*` — commented-out calls and KDoc examples both match these patterns. A `grep -vE ':[0-9]+: *(//|\*)'` handles the last one.
+
 ### Step 1: Find interpolated Log.d/Log.i (highest priority — filtered in release)
 
 ```
@@ -61,7 +66,13 @@ pattern: Log\.(w|e)\(\w+,\s*"[^"]*\$
 type: kotlin
 ```
 
-Then **manually exclude** lines where a throwable is passed as third argument (ending with `, e)`, `, throwable)`, etc.). Check the actual line — a catch block catching `e` doesn't mean `e` is passed to the Log call.
+Then **manually exclude** lines where a throwable is passed as third argument. Check the actual line — a catch block catching `e` doesn't mean `e` is passed to the Log call.
+
+**`it` is the name you will miss.** `Result.onFailure { ... }` is the dominant shape in this repo, so most correct calls end `, it)`, not `, e)`. Excluding only `e`/`throwable` inflates the result badly — a 2026-08-28 pass reported 23 hits where the real number was 8, because 14 of them were `.onFailure { Log.w(TAG, "...", it) }` and already correct. Also note the throwable is not always last on the line (`}.onFailure { Log.w(...) }.getOrDefault(false)`), so anchoring the exclusion to `$` misses them:
+
+```bash
+grep -vE ',\s*(e|t|it|ex|err|error|throwable|cause|tr)\)'   # note: no $ anchor, and `it` included
+```
 
 ### Step 3: Find catch-block Log.w/e that drop the throwable
 
@@ -80,12 +91,19 @@ Both Step 2 and Step 3 may flag the same line — handle Step 3 first (different
 
 ### Step 4: Verify no android.util.Log leakage
 
-```
-pattern: android\.util\.Log\.(d|i|w|e|v)\(
-type: kotlin
+**Two patterns — the fully-qualified one alone is a false negative.** Almost nobody writes `android.util.Log.w(...)` at the call site; they `import android.util.Log` and then write `Log.w(...)`, which is indistinguishable from the wrapper by call shape. The import is the reliable signal:
+
+```bash
+# the form that actually occurs
+grep -rln --include='*.kt' '^import android\.util\.Log$' . | grep -v '/build/' | grep -v PlatformLog
+
+# the rare fully-qualified call
+grep -rnE --include='*.kt' 'android\.util\.Log\.(d|i|w|e|v)\(' . | grep -v '/build/' | grep -v PlatformLog
 ```
 
-These bypass the `Log.minLevel` filter entirely. Exclude `PlatformLog.android.kt` which is the wrapper implementation.
+On 2026-08-28 the fully-qualified pattern reported **0** while the import pattern found **16 production files** (9 in `nappletHost`, the rest in amethyst's `favorites/` and `napplet/`). Exclude `PlatformLog.android.kt`, which is the wrapper implementation and must call `android.util.Log`.
+
+These bypass the `Log.minLevel` filter and the `LogSink` indirection entirely, and — the practical consequence for this skill — **they have no lambda overload**, so Steps 1–3 cannot be applied to them until they are migrated. Subtract these files from the Step 1–3 candidate lists, or migrate them first.
 
 ## Fix Patterns
 
@@ -120,6 +138,26 @@ Trade-off: the message string is allocated eagerly even when warn is filtered, b
 ## Do NOT Convert
 
 - **To lambda:** calls passing a `Throwable` parameter — the lambda overload `(tag) { message }` has no throwable parameter.
+- **To lambda: any call in a file that imports `android.util.Log`.** The platform `Log` has no lambda overload, so the conversion fails to compile with `None of the following candidates is applicable`. Either migrate the file first (below) or leave the call alone. (Hit on 2026-08-28: three edits in two files had to be reverted.)
 - Static string calls with no `$` interpolation — no allocation benefit.
 - Commented-out log calls.
 - Informational/intentional log of `e.message` *outside* a catch block (rare; usually means the exception was already handled and only the message is meaningful).
+
+## Migrating a file off `android.util.Log`
+
+This is what unlocks Steps 1–3 for the files Step 4 finds. It is a behaviour change, so check it rather than assuming — but in this repo the check has come out safe, and here is the reasoning to redo:
+
+1. **Which levels does the file use?** `grep -hoE 'Log\.[a-zA-Z]+' <files> | sort | uniq -c`. The wrapper has `d/i/w/e` only — **no `v`**, and no `getStackTraceString`. A `Log.v` call has no direct equivalent and needs a decision, not a rename.
+2. **Would the gate drop them?** `LogLevel { DEBUG, INFO, WARN, ERROR }`, the gate is `minLevel <= <level>`, and `Amethyst.DEFAULT_LOG_LEVEL` is INFO in debug, **WARN in release** (deliberately — so relay-protocol refusals stay visible in the field). The wrapper's own default is `DEBUG`. So `Log.w` and `Log.e` survive in every build type and in every process, including before `Amethyst.init` runs — which matters for `:napplet`. `Log.d`/`Log.i` **would** go silent in release; those need a conscious call.
+3. **Does the output move?** No. `PlatformLogSink` on Android delegates to `android.util.Log`, so lines land in logcat unchanged.
+4. **Can the module see quartz?** `nappletHost` already has `implementation(project(":quartz"))`. Check before assuming.
+
+Then: swap `import android.util.Log` → `import com.vitorpamplona.quartz.utils.Log`, run `./gradlew spotlessApply` (import order changes), and convert only the interpolated no-throwable calls to the lambda form. Calls that already pass a throwable keep the eager three-arg shape — the wrapper's `w(tag, msg, throwable)` matches exactly, so only the import moves.
+
+**Verify the throwables survived**, since a careless rewrite can drop the third argument silently:
+
+```bash
+grep -rhcE 'Log\.[diwe]\([^)]*,\s*(e|it)\)' <files> | paste -sd+ - | bc   # compare before/after
+```
+
+The 2026-08-28 pass moved 16 files / 29 calls this way: 26 already passed a throwable (import only), 3 interpolated and became lambdas. Zero calls changed visibility.

--- a/CONTRIBUTING-WITH-AI.md
+++ b/CONTRIBUTING-WITH-AI.md
@@ -186,6 +186,13 @@ device. PRs that introduce any of them will be sent back.
   body only runs when the log level is enabled. Plain
   `Log.d("msg $x")` allocates the formatted string on every call,
   including in feed and scroll hot paths.
+- **Never `import android.util.Log`.** The platform logger bypasses
+  `Log.minLevel` and the `LogSink`, and it has no lambda overload, so
+  the rule above cannot be applied at those call sites. The one
+  legitimate user is `PlatformLog.android.kt`, which implements the
+  wrapper. A call that must pass a throwable uses the eager three-arg
+  form `Log.w(tag, "msg", e)` — the lambda overload takes no throwable,
+  and dropping it to keep the lambda loses the stack trace.
 - **Strip diagnostic `Log.d` calls before commit.** Logs added
   during on-device debugging — even lambda-form ones — must be
   removed from the production diff. They survive R8 stripping only

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
@@ -57,6 +57,9 @@ import java.io.File
  */
 class Amethyst : Application() {
     init {
+        // Deliberately in init, not onCreate: this runs in EVERY process, including the
+        // :napplet sandbox, whose onCreate early-returns. Moving it would leave that
+        // process on the wrapper's DEBUG default.
         Log.minLevel = DEFAULT_LOG_LEVEL
         Log.d("AmethystApp") { "Creating App $this" }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/BrowserHistoryRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/BrowserHistoryRegistry.kt
@@ -21,12 +21,12 @@
 package com.vitorpamplona.amethyst.favorites
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
 import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/BrowserIconRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/BrowserIconRegistry.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.favorites
 
 import android.content.Context
-import android.util.Log
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/FavoriteAppLauncher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/FavoriteAppLauncher.kt
@@ -24,7 +24,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
@@ -41,6 +40,7 @@ import com.vitorpamplona.quartz.nip5aStaticWebsites.NamedSiteEvent
 import com.vitorpamplona.quartz.nip5aStaticWebsites.RootSiteEvent
 import com.vitorpamplona.quartz.nip5dNapplets.NamedNappletEvent
 import com.vitorpamplona.quartz.nip5dNapplets.RootNappletEvent
+import com.vitorpamplona.quartz.utils.Log
 
 /**
  * Turns a [FavoriteApp] back into a running app. The two cases map to the two launch paths in the
@@ -145,7 +145,7 @@ object FavoriteAppLauncher {
                     profile = HostProfile.WEBSITE,
                 )
             else -> {
-                Log.w("FavoriteAppLauncher", "Favorited app not resolvable yet: $coordinate")
+                Log.w("FavoriteAppLauncher") { "Favorited app not resolvable yet: $coordinate" }
                 Toast.makeText(context, R.string.favorite_app_still_loading, Toast.LENGTH_SHORT).show()
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/FavoriteAppsRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/favorites/FavoriteAppsRegistry.kt
@@ -21,12 +21,12 @@
 package com.vitorpamplona.amethyst.favorites
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.vitorpamplona.amethyst.commons.favorites.FavoriteApp
 import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
@@ -1521,11 +1521,10 @@ class AccountConcordActions(
         val events = account.client.fetchAll(filters = relays.associateWith { listOf(filter) }, idleTimeoutMs = 30_000L)
         val newest = events.filterIsInstance<ConcordCommunityListEvent>().maxByOrNull { it.createdAt }
         val entryCount = newest?.let { runCatching { it.decrypt(account.signer).size }.getOrElse { -1 } } ?: 0
-        Log.d(
-            "Concord",
+        Log.d("Concord") {
             "importConcordCommunities: queried ${relays.size} relays, fetched ${events.size} 13302 event(s), " +
-                "newest=${newest?.id?.take(8)}@${newest?.createdAt}, decoded $entryCount entr${if (entryCount == 1) "y" else "ies"}",
-        )
+                "newest=${newest?.id?.take(8)}@${newest?.createdAt}, decoded $entryCount entr${if (entryCount == 1) "y" else "ies"}"
+        }
         newest?.let { account.cache.justConsumeMyOwnEvent(it) }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
@@ -1381,7 +1381,7 @@ class AccountConcordActions(
             val bannedHere = authority.isBanned(account.signer.pubKey)
             val merged = ConcordActions.recoverStranded(entry, bundle, bannedHere) ?: continue
             if (!adoptedConcordRotations.add("${entry.id}:${merged.rootEpoch}")) continue
-            Log.i("Concord", "Stranded recovery: ${entry.id} ${entry.rootEpoch} -> ${merged.rootEpoch}")
+            Log.i("Concord") { "Stranded recovery: ${entry.id} ${entry.rootEpoch} -> ${merged.rootEpoch}" }
             account.sendMyPublicAndPrivateOutbox(account.concordChannelList.follow(merged))
             announceConcordGuestbookJoin(merged, inviteCreator = null, inviteLabel = null)
         }
@@ -1600,6 +1600,6 @@ class AccountConcordActions(
         val byRelay = authorsByRelay.mapValues { (_, authors) -> listOf(ConcordActions.planeFilterFor(authors.toList())) }
         var drained = 0
         account.client.fetchAllPagesFromPool(filters = byRelay) { _, _ -> drained++ }
-        Log.d("Concord", "syncConcordControlPlanes: paged ${authorsByRelay.size} relay(s), drained $drained control wrap(s)")
+        Log.d("Concord") { "syncConcordControlPlanes: paged ${authorsByRelay.size} relay(s), drained $drained control wrap(s)" }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -114,7 +114,7 @@ class AccountCacheState(
                 loadAccount(accountSettings)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                Log.w("AccountCacheState", "Failed to preload account ${savedAccount.npub}: ${e.message}", e)
+                Log.w("AccountCacheState", "Failed to preload account ${savedAccount.npub}", e)
             }
         }
     }
@@ -285,7 +285,7 @@ class AccountCacheState(
                     Dispatchers.IO +
                         SupervisorJob() +
                         CoroutineExceptionHandler { _, throwable ->
-                            Log.e("AccountCacheState", "Account ${signer.pubKey} caught exception: ${throwable.message}", throwable)
+                            Log.e("AccountCacheState", "Account ${signer.pubKey} caught exception", throwable)
                         },
                 ),
             mlsGroupStateStore = mlsStore,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -147,7 +147,7 @@ class AccountCacheState(
     fun deleteAccountFiles(pubkey: HexKey) {
         val dir = File(accountsRootDir(), pubkey)
         if (dir.exists() && !dir.deleteRecursively()) {
-            Log.w("AccountCacheState", "Failed to delete account directory ${dir.absolutePath}")
+            Log.w("AccountCacheState") { "Failed to delete account directory ${dir.absolutePath}" }
         }
     }
 
@@ -163,7 +163,7 @@ class AccountCacheState(
                 if (child.deleteRecursively()) {
                     Log.d("AccountCacheState") { "Pruned orphan account dir ${child.name.take(8)}…" }
                 } else {
-                    Log.w("AccountCacheState", "Failed to prune orphan account dir ${child.absolutePath}")
+                    Log.w("AccountCacheState") { "Failed to prune orphan account dir ${child.absolutePath}" }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/NappletBrokerService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/NappletBrokerService.kt
@@ -31,7 +31,6 @@ import android.os.Message
 import android.os.Messenger
 import android.os.RemoteException
 import android.os.SystemClock
-import android.util.Log
 import androidx.core.net.toUri
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.commons.connectedApps.signers.NostrSignerPermissionLedger
@@ -50,6 +49,7 @@ import com.vitorpamplona.amethyst.napplet.gateways.AccountNappletGateways
 import com.vitorpamplona.amethyst.napplethost.NappletIpc
 import com.vitorpamplona.amethyst.ui.MainActivity
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -182,7 +182,7 @@ class NappletBrokerService : Service() {
                     // could still spam distinct keys to keep the network up. Bound the damage: refuse new
                     // lease keys past the cap. Real usage holds only a handful of foreground surfaces.
                     if (firstReport && foregroundLeases.size >= MAX_FOREGROUND_LEASES) {
-                        Log.w("NappletBrokerService", "Foreground lease cap reached; ignoring new lease $token")
+                        Log.w("NappletBrokerService") { "Foreground lease cap reached; ignoring new lease $token" }
                         return true
                     }
                     foregroundLeases[token] = SystemClock.elapsedRealtime()
@@ -374,7 +374,7 @@ class NappletBrokerService : Service() {
                         while (iterator.hasNext()) {
                             val entry = iterator.next()
                             if (now - entry.value > FOREGROUND_LEASE_TTL_MS) {
-                                Log.w("NappletBrokerService", "Foreground lease ${entry.key} expired (host process gone?); releasing hold")
+                                Log.w("NappletBrokerService") { "Foreground lease ${entry.key} expired (host process gone?); releasing hold" }
                                 iterator.remove()
                                 SandboxForegroundHold.release()
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/SandboxForegroundHold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/SandboxForegroundHold.kt
@@ -117,7 +117,7 @@ object SandboxForegroundHold {
                 synchronized(this@SandboxForegroundHold) {
                     // A surface may have re-acquired while we waited; only tear down if still released.
                     if (holdCount == 0) {
-                        Log.d("SandboxForegroundHold", "No foreground sandbox surface for ${LINGER_MS}ms; releasing the resource hold")
+                        Log.d("SandboxForegroundHold") { "No foreground sandbox surface for ${LINGER_MS}ms; releasing the resource hold" }
                         holdJob?.cancel()
                         holdJob = null
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
@@ -22,7 +22,7 @@ package com.vitorpamplona.amethyst.napplet
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
+import com.vitorpamplona.quartz.utils.Log
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/eventCache/MemoryTrimmingService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/eventCache/MemoryTrimmingService.kt
@@ -78,7 +78,7 @@ class MemoryTrimmingService(
         level: Int = ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
     ) {
         if (isTrimmingMemoryMutex.compareAndSet(false, true)) {
-            Log.d("ServiceManager", "Trimming Memory (level=$level)")
+            Log.d("ServiceManager") { "Trimming Memory (level=$level)" }
             try {
                 doTrim(account, otherAccounts, level)
             } finally {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/diagnostics/BootRelayDiagnostics.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/diagnostics/BootRelayDiagnostics.kt
@@ -223,16 +223,15 @@ class BootRelayDiagnostics(
         }
 
         Log.d(TAG) { "===== boot census @${atSeconds}s =====" }
-        Log.i(
-            TAG,
+        Log.i(TAG) {
             "census @${atSeconds}s pool=${snapshot.size} opened=${opened.size} served_events=${served.size} never_opened=${neverOpened.size} " +
                 "dials=${snapshot.values.sumOf { it.tentatives.get() }} " +
                 "events=${snapshot.values.sumOf { it.events.get() }} " +
                 "reqs=${snapshot.values.sumOf { it.reqsSent.get() }} " +
-                "auths=${snapshot.values.sumOf { it.authsSent.get() }}",
-        )
-        Log.i(TAG) { "census @${atSeconds}s failures_by_cause=" + causeTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" } }
-        Log.i(TAG) { "census @${atSeconds}s closed_by_prefix=" + closedTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" } }
+                "auths=${snapshot.values.sumOf { it.authsSent.get() }}"
+        }
+        Log.i(TAG) { "census @${atSeconds}s failures_by_cause=${causeTotals.byCountDesc()}" }
+        Log.i(TAG) { "census @${atSeconds}s closed_by_prefix=${closedTotals.byCountDesc()}" }
 
         // Relays that cost us dials and gave nothing back, worst first: the wasted-effort list.
         Log.d(TAG, "--- top wasted dials (no events received) ---")
@@ -242,13 +241,12 @@ class BootRelayDiagnostics(
             .sortedByDescending { it.value.tentatives.get() }
             .take(25)
             .forEach { (url, r) ->
-                Log.d(
-                    TAG,
+                Log.d(TAG) {
                     "WASTE ${url.url} dials=${r.tentatives.get()} opens=${r.opens.get()} " +
                         "fail=[${r.failures.entries.joinToString { "${it.key}:${it.value.get()}" }}] " +
                         "closed=[${r.closed.entries.joinToString { "${it.key}:${it.value.get()}" }}] " +
-                        "reqs=${r.reqsSent.get()} eose=${r.eoses.get()}",
-                )
+                        "reqs=${r.reqsSent.get()} eose=${r.eoses.get()}"
+                }
             }
 
         // The relays actually carrying the boot, so a suppression change can be checked for
@@ -258,12 +256,14 @@ class BootRelayDiagnostics(
             .sortedByDescending { it.value.events.get() }
             .take(20)
             .forEach { (url, r) ->
-                Log.d(
-                    TAG,
+                Log.d(TAG) {
                     "SERVE ${url.url} events=${r.events.get()} reqs=${r.reqsSent.get()} eose=${r.eoses.get()} " +
-                        "openMs=${r.firstOpenAtMs.get()} eoseMs=${r.firstEoseAtMs.get()} dials=${r.tentatives.get()}",
-                )
+                        "openMs=${r.firstOpenAtMs.get()} eoseMs=${r.firstEoseAtMs.get()} dials=${r.tentatives.get()}"
+                }
             }
         Log.d(TAG) { "===== end census @${atSeconds}s =====" }
     }
 }
+
+/** Buckets rendered highest-count first — the shape both census summary lines want. */
+private fun Map<String, Int>.byCountDesc() = entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/diagnostics/BootRelayDiagnostics.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/diagnostics/BootRelayDiagnostics.kt
@@ -222,7 +222,7 @@ class BootRelayDiagnostics(
             r.closed.forEach { (k, v) -> closedTotals[k] = (closedTotals[k] ?: 0) + v.get() }
         }
 
-        Log.d(TAG, "===== boot census @${atSeconds}s =====")
+        Log.d(TAG) { "===== boot census @${atSeconds}s =====" }
         Log.i(
             TAG,
             "census @${atSeconds}s pool=${snapshot.size} opened=${opened.size} served_events=${served.size} never_opened=${neverOpened.size} " +
@@ -231,8 +231,8 @@ class BootRelayDiagnostics(
                 "reqs=${snapshot.values.sumOf { it.reqsSent.get() }} " +
                 "auths=${snapshot.values.sumOf { it.authsSent.get() }}",
         )
-        Log.i(TAG, "census @${atSeconds}s failures_by_cause=" + causeTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" })
-        Log.i(TAG, "census @${atSeconds}s closed_by_prefix=" + closedTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" })
+        Log.i(TAG) { "census @${atSeconds}s failures_by_cause=" + causeTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" } }
+        Log.i(TAG) { "census @${atSeconds}s closed_by_prefix=" + closedTotals.entries.sortedByDescending { it.value }.joinToString { "${it.key}:${it.value}" } }
 
         // Relays that cost us dials and gave nothing back, worst first: the wasted-effort list.
         Log.d(TAG, "--- top wasted dials (no events received) ---")
@@ -264,6 +264,6 @@ class BootRelayDiagnostics(
                         "openMs=${r.firstOpenAtMs.get()} eoseMs=${r.firstEoseAtMs.get()} dials=${r.tentatives.get()}",
                 )
             }
-        Log.d(TAG, "===== end census @${atSeconds}s =====")
+        Log.d(TAG) { "===== end census @${atSeconds}s =====" }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/BlossomPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/BlossomPaymentHandler.kt
@@ -153,8 +153,9 @@ object BlossomPaymentHandler {
 
         val check = checkAmount(payment, shownSats)
         if (check !is AmountCheck.Ok) {
-            Log.w("BlossomPayment") { "refusing invoice: ${refusalReason(check)}" }
-            return PayResult.Refused(refusalReason(check))
+            val reason = refusalReason(check)
+            Log.w("BlossomPayment") { "refusing invoice: $reason" }
+            return PayResult.Refused(reason)
         }
 
         // Never send the same invoice twice: an earlier attempt may still settle.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/BlossomPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/BlossomPaymentHandler.kt
@@ -153,7 +153,7 @@ object BlossomPaymentHandler {
 
         val check = checkAmount(payment, shownSats)
         if (check !is AmountCheck.Ok) {
-            Log.w("BlossomPayment", "refusing invoice: ${refusalReason(check)}")
+            Log.w("BlossomPayment") { "refusing invoice: ${refusalReason(check)}" }
             return PayResult.Refused(refusalReason(check))
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomBlobManagerViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomBlobManagerViewModel.kt
@@ -334,7 +334,7 @@ class BlossomBlobManagerViewModel : ViewModel() {
                         // again must not be able to spin up an endless pay-prompt
                         // cycle. One prompt per target per user-initiated mirror.
                         if (!promptLedger.shouldPrompt(row.hash, target)) {
-                            Log.w("BlossomBlobManager", "mirror to $target asked for payment again after being paid; not re-prompting")
+                            Log.w("BlossomBlobManager") { "mirror to $target asked for payment again after being paid; not re-prompting" }
                             _error.value = "${hostOf(target)} asked for payment again after being paid. Amethyst stopped to avoid paying twice."
                             continue
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -597,7 +597,7 @@ class CallSession(
                 val sender = videoSenders[key]
                 if (sender != null) {
                     if (!sender.setTrack(track, false)) {
-                        Log.e(TAG, "Failed to replace video track for ${key.take(8)}")
+                        Log.e(TAG) { "Failed to replace video track for ${key.take(8)}" }
                     }
                 } else {
                     session.addTrack(track, settingsProvider().callMaxBitrateBps)?.let { newSender ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordMetadataForm.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordMetadataForm.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord
 
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -80,6 +79,7 @@ import com.vitorpamplona.amethyst.ui.theme.MediumRelayIconModifier
 import com.vitorpamplona.quartz.concord.cord02Community.ImagePointer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon as SymbolIcon

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
@@ -570,7 +570,7 @@ open class ChannelNewMessageViewModel :
                     accountViewModel.account.relayGroups.putRelayGroupUser(channel, pk, emptyList())
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
-                    Log.w("BuzzAutoInvite", "Failed to add mentioned member ${pk.take(8)}: ${e.message}")
+                    Log.w("BuzzAutoInvite", "Failed to add mentioned member ${pk.take(8)}", e)
                 }
             }
         }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBlobHttp.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBlobHttp.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.napplethost
 
-import android.util.Log
+import com.vitorpamplona.quartz.utils.Log
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.InetSocketAddress

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -33,7 +33,6 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.Message
 import android.os.Messenger
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -64,6 +63,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
 import com.vitorpamplona.amethyst.commons.napplet.NappletWebContract
+import com.vitorpamplona.quartz.utils.Log
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.lang.ref.WeakReference

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
@@ -36,7 +36,6 @@ import android.os.Looper
 import android.os.Message
 import android.os.Messenger
 import android.os.SystemClock
-import android.util.Log
 import android.webkit.ConsoleMessage
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
@@ -56,6 +55,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
 import com.vitorpamplona.amethyst.commons.napplet.NappletWebContract
+import com.vitorpamplona.quartz.utils.Log
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
@@ -23,8 +23,8 @@ package com.vitorpamplona.amethyst.napplethost
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.core.content.FileProvider
+import com.vitorpamplona.quartz.utils.Log
 import java.io.File
 
 /**

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFaviconSniffer.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFaviconSniffer.kt
@@ -23,9 +23,9 @@ package com.vitorpamplona.amethyst.napplethost
 import android.os.Handler
 import android.os.Looper
 import android.util.Base64
-import android.util.Log
 import android.webkit.WebView
 import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
+import com.vitorpamplona.quartz.utils.Log
 import org.json.JSONObject
 
 /**

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -33,7 +33,6 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.Message
 import android.os.Messenger
-import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
@@ -69,6 +68,7 @@ import com.vitorpamplona.amethyst.napplethost.R
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip5aStaticWebsites.resolver.StaticSiteResolution
 import com.vitorpamplona.quartz.nip5aStaticWebsites.tags.PathTag
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.sha256.sha256
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
@@ -36,7 +36,6 @@ import android.os.Looper
 import android.os.Message
 import android.os.Messenger
 import android.os.SystemClock
-import android.util.Log
 import android.view.View
 import android.webkit.JsPromptResult
 import android.webkit.JsResult
@@ -61,6 +60,7 @@ import androidx.webkit.WebViewFeature
 import com.vitorpamplona.amethyst.commons.napplet.NappletWebContract
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip5aStaticWebsites.tags.PathTag
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.sha256.sha256
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletWebViewProfile.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletWebViewProfile.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.amethyst.napplethost
 
 import android.content.Context
-import android.util.Log
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
@@ -29,6 +28,7 @@ import androidx.core.content.edit
 import androidx.webkit.ProfileStore
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import com.vitorpamplona.quartz.utils.Log
 
 /**
  * Partitions WebView storage (cookies, localStorage, IndexedDB, service workers) per Nostr account.

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
@@ -24,11 +24,11 @@ import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.amethyst.commons.R as CommonsR
 
 /**


### PR DESCRIPTION
`Log.d(tag, "…$x…")` builds its message before the level check, so a filtered-out call still pays for the string. The wrapper's `inline fun d(tag, message: () -> String)` moves that work inside the gate, and because the overload is `inline` there is no closure to allocate — the deferral is free.

This converts 20 call sites. The ones that matter are two `Log.d` calls inside `forEach` loops in `BootRelayDiagnostics`, running 25 and 20 iterations per boot census with nested `joinToString` in each — roughly 180 strings built and discarded per boot, since DEBUG is filtered in every build type. An earlier line-anchored audit had missed them because they span several lines.

Two things the same audit surfaced, included here:

- A catch block logged `${e.message}` without passing `e` — losing the stack trace, and printing `"…: null"` whenever the exception had no message.
- 16 files still imported `android.util.Log`, which bypasses `Log.minLevel` and the `LogSink` and offers no lambda overload. Migrated to `com.vitorpamplona.quartz.utils.Log`. All 29 of those calls are `Log.w`, which passes the gate in every build type, so nothing changed visibility.

**Scope, honestly:** the allocation saving is confined to DEBUG-level calls, which are always dropped. `Log.w`/`Log.e` messages are emitted, so their strings were never wasted; those sites were converted for consistency, not for a measurable win.


## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
