### PR TITLE
Add kind-0 profile card rendering in feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
@@ -39,6 +39,7 @@ import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
@@ -247,6 +248,13 @@ fun routeForInner(
             wrap.innerEventId?.let {
                 routeFor(LocalCache.getOrCreateNote(it), loggedIn)
             }
+        }
+
+        // A kind-0 IS the person: tapping one anywhere (feed card, quote, `nostr:naddr`
+        // deep link) opens their profile instead of the bare note view AddressableEvent
+        // below would otherwise fall through to.
+        is MetadataEvent -> {
+            Route.Profile(noteEvent.pubKey)
         }
 
         is AddressableEvent -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -178,6 +178,7 @@ import com.vitorpamplona.amethyst.ui.note.types.RenderPodcastMetadata
 import com.vitorpamplona.amethyst.ui.note.types.RenderPoll
 import com.vitorpamplona.amethyst.ui.note.types.RenderPostApproval
 import com.vitorpamplona.amethyst.ui.note.types.RenderPrivateMessage
+import com.vitorpamplona.amethyst.ui.note.types.RenderProfileCard
 import com.vitorpamplona.amethyst.ui.note.types.RenderPs1Save
 import com.vitorpamplona.amethyst.ui.note.types.RenderPublicMessage
 import com.vitorpamplona.amethyst.ui.note.types.RenderReaction
@@ -262,6 +263,7 @@ import com.vitorpamplona.quartz.experimental.roadstr.confirmation.RoadEventConfi
 import com.vitorpamplona.quartz.experimental.roadstr.report.RoadEventReportEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.geoHashOrScope
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -934,6 +936,10 @@ private fun RenderNoteRow(
     isBoostedNote: Boolean = false,
 ) {
     when (val noteEvent = baseNote.event) {
+        is MetadataEvent -> {
+            RenderProfileCard(baseNote, backgroundColor, accountViewModel, nav)
+        }
+
         is AppDefinitionEvent -> {
             RenderAppDefinition(baseNote, accountViewModel, nav)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCard.kt
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note.types
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.observeAccountIsHiddenUser
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserContactCardsFollowerCount
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowing
+import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
+import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
+import com.vitorpamplona.amethyst.ui.note.ObserveDisplayNip05Status
+import com.vitorpamplona.amethyst.ui.note.ShowFollowingOrUnfollowingButton
+import com.vitorpamplona.amethyst.ui.note.ShowUserButton
+import com.vitorpamplona.amethyst.ui.note.WatchAuthor
+import com.vitorpamplona.amethyst.ui.note.elements.BannerImage
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size16Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size5dp
+import com.vitorpamplona.amethyst.ui.theme.bitcoinColor
+import com.vitorpamplona.amethyst.ui.theme.innerPostModifier
+import com.vitorpamplona.amethyst.ui.theme.placeholderText
+import com.vitorpamplona.quartz.nip01Core.metadata.UserMetadata
+
+// A kind-0 in the feed is a person, not a JSON blob. The card mirrors the profile
+// screen it opens: banner, overlapping avatar, name, nip05 and a bio, so the reader
+// recognizes who this is without leaving the feed.
+private val BannerHeight = 104.dp
+private val AvatarSize = 72.dp
+private val AvatarRingWidth = 3.dp
+
+/** How far the avatar hangs below the banner, into the body of the card. */
+private val AvatarOverhang = 30.dp
+
+private val CardBodyPadding =
+    Modifier.padding(
+        start = 14.dp,
+        end = 14.dp,
+        top = AvatarOverhang + 8.dp,
+        bottom = 14.dp,
+    )
+
+@Composable
+fun RenderProfileCard(
+    baseNote: Note,
+    backgroundColor: MutableState<Color>,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    WatchAuthor(baseNote, accountViewModel) { author ->
+        ProfileCard(author, backgroundColor, accountViewModel, nav)
+    }
+}
+
+@Composable
+fun ProfileCard(
+    author: User,
+    backgroundColor: MutableState<Color>,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val userInfo by observeUserInfo(author, accountViewModel)
+    val metadata = userInfo?.info
+    val tags = userInfo?.tags
+
+    Column(
+        MaterialTheme.colorScheme.innerPostModifier.clickable {
+            nav.nav(routeFor(author))
+        },
+    ) {
+        ProfileCardHeader(author, metadata?.banner, backgroundColor, accountViewModel)
+
+        Column(CardBodyPadding) {
+            ProfileCardNames(author, metadata, tags)
+
+            ObserveDisplayNip05Status(author, accountViewModel, nav)
+
+            metadata?.about?.ifBlank { null }?.let { about ->
+                Spacer(Modifier.height(Size5dp))
+                CreateTextWithEmoji(
+                    text = about,
+                    tags = tags,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            ProfileCardChips(author, metadata, accountViewModel)
+        }
+    }
+}
+
+/**
+ * Banner + avatar + follow action. The avatar and the action row are laid out inside the
+ * banner's [Box] and pushed down by [AvatarOverhang]: the offset doesn't change the Box's
+ * measured height, so the body below reserves the same amount as top padding and no gap is
+ * left at the bottom of the card.
+ */
+@Composable
+private fun ProfileCardHeader(
+    author: User,
+    banner: String?,
+    backgroundColor: MutableState<Color>,
+    accountViewModel: AccountViewModel,
+) {
+    Box(Modifier.fillMaxWidth().height(BannerHeight)) {
+        BannerImage(banner, Modifier.fillMaxWidth().height(BannerHeight), accountViewModel)
+
+        // Fades the banner into the card so the avatar and the name below always
+        // have enough contrast, whatever the user uploaded.
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(BannerHeight)
+                .background(
+                    Brush.verticalGradient(
+                        0.35f to Color.Transparent,
+                        1f to backgroundColor.value,
+                    ),
+                ),
+        )
+
+        Row(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp)
+                    .offset(y = AvatarOverhang),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(AvatarSize + AvatarRingWidth * 2)
+                        .clip(CircleShape)
+                        .background(backgroundColor.value),
+                contentAlignment = Alignment.Center,
+            ) {
+                BaseUserPicture(author, AvatarSize, accountViewModel)
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            ProfileCardActions(author, accountViewModel)
+        }
+    }
+}
+
+@Composable
+private fun ProfileCardActions(
+    author: User,
+    accountViewModel: AccountViewModel,
+) {
+    val isHidden by observeAccountIsHiddenUser(accountViewModel.account, author)
+
+    if (isHidden) {
+        ShowUserButton { accountViewModel.show(author) }
+    } else if (!accountViewModel.isLoggedUser(author)) {
+        // Nothing to follow on your own card.
+        ShowFollowingOrUnfollowingButton(author, accountViewModel)
+    }
+}
+
+@Composable
+private fun ProfileCardNames(
+    author: User,
+    metadata: UserMetadata?,
+    tags: ImmutableListOfLists<String>?,
+) {
+    val bestName = metadata?.bestName() ?: author.pubkeyDisplayHex()
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CreateTextWithEmoji(
+            text = bestName,
+            tags = tags,
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+
+        metadata?.pronouns?.ifBlank { null }?.let {
+            Spacer(Modifier.size(Size5dp))
+            Text(
+                text = "($it)",
+                color = MaterialTheme.colorScheme.placeholderText,
+                fontSize = 14.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+
+    val handle = metadata?.name
+    if (!handle.isNullOrBlank() && handle != bestName) {
+        CreateTextWithEmoji(
+            text = "@$handle",
+            tags = tags,
+            color = MaterialTheme.colorScheme.placeholderText,
+            fontSize = 14.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ProfileCardChips(
+    author: User,
+    metadata: UserMetadata?,
+    accountViewModel: AccountViewModel,
+) {
+    val uri = LocalUriHandler.current
+
+    val website = metadata?.website?.ifBlank { null }
+    val lnAddress = metadata?.lnAddress()?.ifBlank { null }
+    val isBot = metadata?.bot == true
+
+    val followsYou by observeUserIsFollowing(author, accountViewModel.account.userProfile(), accountViewModel)
+    val followerCount by observeUserContactCardsFollowerCount(author, accountViewModel)
+    // "--" is the placeholder the contact-card observer emits while no trusted
+    // assertion for this user has arrived. Nothing to brag about yet.
+    val followers = followerCount.takeIf { it != "--" }
+
+    if (website == null && lnAddress == null && !isBot && !followsYou && followers == null) return
+
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.padding(top = 10.dp),
+    ) {
+        if (followers != null) {
+            ProfileCardChip(
+                symbol = MaterialSymbols.Groups,
+                label = stringRes(R.string.profile_card_followers, followers),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        if (followsYou) {
+            ProfileCardChip(
+                symbol = MaterialSymbols.Person,
+                label = stringRes(R.string.profile_card_follows_you),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        if (website != null) {
+            ProfileCardChip(
+                symbol = MaterialSymbols.Link,
+                label = remember(website) { website.removePrefix("https://").removePrefix("http://").removeSuffix("/") },
+                color = MaterialTheme.colorScheme.primary,
+                onClick = {
+                    runCatching {
+                        if (website.contains("://")) {
+                            uri.openUri(website)
+                        } else {
+                            uri.openUri("http://$website")
+                        }
+                    }
+                },
+            )
+        }
+
+        if (lnAddress != null) {
+            ProfileCardChip(
+                symbol = MaterialSymbols.Bolt,
+                label = lnAddress,
+                color = MaterialTheme.colorScheme.bitcoinColor,
+            )
+        }
+
+        if (isBot) {
+            ProfileCardChip(
+                symbol = MaterialSymbols.Assistant,
+                label = stringRes(R.string.profile_card_bot),
+                color = MaterialTheme.colorScheme.placeholderText,
+            )
+        }
+    }
+}
+
+/**
+ * Pill in the same visual language as the profile's payment rails: tinted outline,
+ * icon, single ellipsized line. Without [onClick] the pill stays inert so the tap
+ * falls through to the card and opens the profile.
+ */
+@Composable
+private fun ProfileCardChip(
+    symbol: MaterialSymbol,
+    label: String,
+    color: Color,
+    onClick: (() -> Unit)? = null,
+) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = color.copy(alpha = 0.10f),
+        border = BorderStroke(1.dp, color.copy(alpha = 0.35f)),
+        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+        ) {
+            Icon(
+                symbol = symbol,
+                contentDescription = null,
+                tint = color,
+                modifier = Size16Modifier,
+            )
+            Text(
+                text = label,
+                color = color,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.widthIn(max = 200.dp),
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCard.kt
@@ -94,6 +94,14 @@ private val AvatarRingWidth = 3.dp
 /** How far the avatar hangs below the banner, into the body of the card. */
 private val AvatarOverhang = 30.dp
 
+private val ChipShape = RoundedCornerShape(50)
+
+private val BannerModifier = Modifier.fillMaxWidth().height(BannerHeight)
+
+private val AvatarRingModifier = Modifier.size(AvatarSize + AvatarRingWidth * 2).clip(CircleShape)
+
+private val AvatarRowModifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp).offset(y = AvatarOverhang)
+
 private val CardBodyPadding =
     Modifier.padding(
         start = 14.dp,
@@ -166,38 +174,26 @@ private fun ProfileCardHeader(
     backgroundColor: MutableState<Color>,
     accountViewModel: AccountViewModel,
 ) {
-    Box(Modifier.fillMaxWidth().height(BannerHeight)) {
-        BannerImage(banner, Modifier.fillMaxWidth().height(BannerHeight), accountViewModel)
+    val cardBackground = backgroundColor.value
 
-        // Fades the banner into the card so the avatar and the name below always
-        // have enough contrast, whatever the user uploaded.
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .height(BannerHeight)
-                .background(
-                    Brush.verticalGradient(
-                        0.35f to Color.Transparent,
-                        1f to backgroundColor.value,
-                    ),
-                ),
-        )
+    // Fades the banner into the card so the avatar and the name below always have
+    // enough contrast, whatever the user uploaded.
+    val scrim =
+        remember(cardBackground) {
+            Brush.verticalGradient(0.35f to Color.Transparent, 1f to cardBackground)
+        }
+
+    Box(BannerModifier) {
+        BannerImage(banner, BannerModifier, accountViewModel)
+
+        Box(BannerModifier.background(scrim))
 
         Row(
-            modifier =
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp)
-                    .offset(y = AvatarOverhang),
+            modifier = AvatarRowModifier.align(Alignment.BottomStart),
             verticalAlignment = Alignment.Bottom,
         ) {
             Box(
-                modifier =
-                    Modifier
-                        .size(AvatarSize + AvatarRingWidth * 2)
-                        .clip(CircleShape)
-                        .background(backgroundColor.value),
+                modifier = AvatarRingModifier.background(cardBackground),
                 contentAlignment = Alignment.Center,
             ) {
                 BaseUserPicture(author, AvatarSize, accountViewModel)
@@ -231,7 +227,10 @@ private fun ProfileCardNames(
     metadata: UserMetadata?,
     tags: ImmutableListOfLists<String>?,
 ) {
-    val bestName = metadata?.bestName() ?: author.pubkeyDisplayHex()
+    // pubkeyDisplayHex() hex-decodes and bech32-encodes the key; keep it off the
+    // recomposition path.
+    val shortNpub = remember(author) { author.pubkeyDisplayHex() }
+    val bestName = metadata?.bestName() ?: shortNpub
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         CreateTextWithEmoji(
@@ -247,7 +246,7 @@ private fun ProfileCardNames(
         metadata?.pronouns?.ifBlank { null }?.let {
             Spacer(Modifier.size(Size5dp))
             Text(
-                text = "($it)",
+                text = remember(it) { "($it)" },
                 color = MaterialTheme.colorScheme.placeholderText,
                 fontSize = 14.sp,
                 maxLines = 1,
@@ -259,7 +258,7 @@ private fun ProfileCardNames(
     val handle = metadata?.name
     if (!handle.isNullOrBlank() && handle != bestName) {
         CreateTextWithEmoji(
-            text = "@$handle",
+            text = remember(handle) { "@$handle" },
             tags = tags,
             color = MaterialTheme.colorScheme.placeholderText,
             fontSize = 14.sp,
@@ -282,7 +281,9 @@ private fun ProfileCardChips(
     val lnAddress = metadata?.lnAddress()?.ifBlank { null }
     val isBot = metadata?.bot == true
 
-    val followsYou by observeUserIsFollowing(author, accountViewModel.account.userProfile(), accountViewModel)
+    // A self-follow in your own kind:3 is common; "Follows you" on your own card is not a fact.
+    val followsMe by observeUserIsFollowing(author, accountViewModel.account.userProfile(), accountViewModel)
+    val followsYou = followsMe && !accountViewModel.isLoggedUser(author)
     val followerCount by observeUserContactCardsFollowerCount(author, accountViewModel)
     // "--" is the placeholder the contact-card observer emits while no trusted
     // assertion for this user has arrived. Nothing to brag about yet.
@@ -298,7 +299,7 @@ private fun ProfileCardChips(
         if (followers != null) {
             ProfileCardChip(
                 symbol = MaterialSymbols.Groups,
-                label = stringRes(R.string.profile_card_followers, followers),
+                label = stringRes(R.string.number_followers, followers),
                 color = MaterialTheme.colorScheme.primary,
             )
         }
@@ -358,11 +359,13 @@ private fun ProfileCardChip(
     color: Color,
     onClick: (() -> Unit)? = null,
 ) {
+    // Clip before clickable: Surface applies the passed-in modifier above its own
+    // shape clip, so an unclipped ripple would paint a square over the pill.
     Surface(
-        shape = RoundedCornerShape(50),
+        shape = ChipShape,
         color = color.copy(alpha = 0.10f),
         border = BorderStroke(1.dp, color.copy(alpha = 0.35f)),
-        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier,
+        modifier = if (onClick != null) Modifier.clip(ChipShape).clickable(onClick = onClick) else Modifier,
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCardPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCardPreview.kt
@@ -41,13 +41,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-private val FULL_AUTHOR = "a".repeat(64)
-private val MINIMAL_AUTHOR = "b".repeat(64)
-private val BOT_AUTHOR = "c".repeat(64)
+// LocalCache is a process-wide object shared by every preview the renderer runs, and
+// consuming a kind-0 is a no-op when the id already exists or the createdAt isn't newer.
+// These keys must not collide with any other preview's (e.g. NoteHeaderMarkersPreview's
+// "a"*64 / "e1"*32) or whichever renders first wins and this one shows that profile.
+private val FULL_AUTHOR = "c0".repeat(32)
+private val MINIMAL_AUTHOR = "c1".repeat(32)
+private val BOT_AUTHOR = "c2".repeat(32)
 
-private val FULL_ID = "e1".repeat(32)
-private val MINIMAL_ID = "e2".repeat(32)
-private val BOT_ID = "e3".repeat(32)
+private val FULL_ID = "d0".repeat(32)
+private val MINIMAL_ID = "d1".repeat(32)
+private val BOT_ID = "d2".repeat(32)
 
 /**
  * Design-system preview for the kind-0 feed card, rendered by the REAL

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCardPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ProfileCardPreview.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note.types
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+private val FULL_AUTHOR = "a".repeat(64)
+private val MINIMAL_AUTHOR = "b".repeat(64)
+private val BOT_AUTHOR = "c".repeat(64)
+
+private val FULL_ID = "e1".repeat(32)
+private val MINIMAL_ID = "e2".repeat(32)
+private val BOT_ID = "e3".repeat(32)
+
+/**
+ * Design-system preview for the kind-0 feed card, rendered by the REAL
+ * [RenderProfileCard] over notes seeded into [LocalCache] — same pattern as
+ * `NoteHeaderFirstRowDensityPreview`.
+ *
+ * Remote images never load in a preview, so the banner falls back to the
+ * bundled default and the avatar to the robohash. What this preview is for is
+ * the layout: banner-to-body fade, avatar overhang, and how the name block and
+ * the chip row behave from a full profile down to one with nothing but a name.
+ */
+@Preview(widthDp = 400, heightDp = 1200)
+@Composable
+fun ProfileCardPreview() {
+    val accountViewModel = mockAccountViewModel()
+
+    val now = TimeUtils.now()
+
+    val full: Note = LocalCache.getOrCreateAddressableNote(MetadataEvent.createAddress(FULL_AUTHOR))
+    val minimal: Note = LocalCache.getOrCreateAddressableNote(MetadataEvent.createAddress(MINIMAL_AUTHOR))
+    val bot: Note = LocalCache.getOrCreateAddressableNote(MetadataEvent.createAddress(BOT_AUTHOR))
+
+    runBlocking {
+        withContext(Dispatchers.IO) {
+            LocalCache.justConsume(
+                MetadataEvent(
+                    FULL_ID,
+                    FULL_AUTHOR,
+                    now,
+                    emptyArray(),
+                    """
+                    {
+                      "display_name": "Vitor Pamplona",
+                      "name": "vitor",
+                      "pronouns": "he/him",
+                      "about": "Building Amethyst. Nostr, open protocols and a lot of Kotlin. Ask me about relays, NIPs, or why kind 0 deserves a nicer card than a wall of JSON.",
+                      "website": "https://vitorpamplona.com/",
+                      "nip05": "_@vitorpamplona.com",
+                      "lud16": "vitor@zeuspay.com"
+                    }
+                    """.trimIndent(),
+                    "x",
+                ),
+                null,
+                true,
+            )
+
+            // Nothing but a name: the card must not collapse into empty rows.
+            LocalCache.justConsume(
+                MetadataEvent(MINIMAL_ID, MINIMAL_AUTHOR, now, emptyArray(), """{"name":"someone"}""", "x"),
+                null,
+                true,
+            )
+
+            LocalCache.justConsume(
+                MetadataEvent(
+                    BOT_ID,
+                    BOT_AUTHOR,
+                    now,
+                    emptyArray(),
+                    """{"display_name":"Relay Watcher","name":"relaywatch","bot":true,"about":"Posts relay uptime every hour."}""",
+                    "x",
+                ),
+                null,
+                true,
+            )
+        }
+    }
+
+    ThemeComparisonColumn {
+        Column(Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
+            ProfileCardSample(full, accountViewModel)
+            ProfileCardSample(minimal, accountViewModel)
+            ProfileCardSample(bot, accountViewModel)
+        }
+    }
+}
+
+@Composable
+private fun ProfileCardSample(
+    note: Note,
+    accountViewModel: AccountViewModel,
+) {
+    val defaultBackground = MaterialTheme.colorScheme.background
+    val background = remember { mutableStateOf(defaultBackground) }
+
+    RenderProfileCard(
+        baseNote = note,
+        backgroundColor = background,
+        accountViewModel = accountViewModel,
+        nav = EmptyNav(),
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -196,6 +196,7 @@ import com.vitorpamplona.amethyst.ui.note.types.RenderPodcastMetadata
 import com.vitorpamplona.amethyst.ui.note.types.RenderPoll
 import com.vitorpamplona.amethyst.ui.note.types.RenderPostApproval
 import com.vitorpamplona.amethyst.ui.note.types.RenderPrivateMessage
+import com.vitorpamplona.amethyst.ui.note.types.RenderProfileCard
 import com.vitorpamplona.amethyst.ui.note.types.RenderPs1Save
 import com.vitorpamplona.amethyst.ui.note.types.RenderPublicMessage
 import com.vitorpamplona.amethyst.ui.note.types.RenderReaction
@@ -274,6 +275,7 @@ import com.vitorpamplona.quartz.experimental.roadstr.confirmation.RoadEventConfi
 import com.vitorpamplona.quartz.experimental.roadstr.report.RoadEventReportEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.geoHashOrScope
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -829,7 +831,9 @@ private fun FullBleedNoteCompose(
             modifier = PaddingHorizontal12Modifier,
         ) {
             Column {
-                if (noteEvent is ChannelCreateEvent) {
+                if (noteEvent is MetadataEvent) {
+                    RenderProfileCard(baseNote, backgroundColor, accountViewModel, nav)
+                } else if (noteEvent is ChannelCreateEvent) {
                     PublicChatChannelHeader(
                         channelHex = noteEvent.id,
                         sendToChannel = true,

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -5279,4 +5279,9 @@
     <string name="buzz_persona_avatar">Avatar URL (optional)</string>
     <string name="buzz_persona_publishing">Publishing…</string>
     <string name="buzz_persona_publish">Publish persona</string>
+
+    <!-- Profile card (kind-0 rendered in the feed) -->
+    <string name="profile_card_followers">%1$s followers</string>
+    <string name="profile_card_follows_you">Follows you</string>
+    <string name="profile_card_bot">Bot</string>
 </resources>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -5281,7 +5281,6 @@
     <string name="buzz_persona_publish">Publish persona</string>
 
     <!-- Profile card (kind-0 rendered in the feed) -->
-    <string name="profile_card_followers">%1$s followers</string>
     <string name="profile_card_follows_you">Follows you</string>
     <string name="profile_card_bot">Bot</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds a dedicated UI component to render kind-0 (metadata) events as profile cards in the feed, mirroring the profile screen layout. When a kind-0 event appears in the feed, it now displays as a visually rich card with banner, avatar, name, bio, and metadata chips (followers, website, Lightning address, bot status, etc.) instead of as raw JSON.

The card is clickable and navigates to the full profile. This improves feed readability and makes profile metadata discoverable without leaving the feed.

## Changes

- **New `ProfileCard.kt`**: Main composable that renders a kind-0 event as a profile card with:
  - Banner image with fade scrim for contrast
  - Overlapping avatar with ring
  - Name, handle, and pronouns
  - Bio text with emoji support
  - Metadata chips (followers count, "follows you", website link, Lightning address, bot badge)
  - Follow/unfollow or show/hide buttons
  
- **New `ProfileCardPreview.kt`**: Design-system preview showing the card in three states (full profile, minimal, bot) across light/dark themes

- **Updated `RouteMaker.kt`**: Added routing for kind-0 events to open the profile screen

- **Updated `NoteCompose.kt` & `ThreadFeedView.kt`**: Imported and wired `RenderProfileCard` into the note rendering pipeline

- **Updated `strings.xml`**: Added localization strings for profile card labels ("Follows you", "Bot")

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] Manually exercised the change:
  - Verified `ProfileCardPreview` renders correctly in light and dark themes
  - Confirmed card displays all metadata chips when present
  - Tested card navigation to profile screen
  - Verified minimal profile (name only) doesn't collapse
  - Confirmed website links open in browser
  - Tested follow/unfollow button visibility

## Interop suites

- [x] N/A — change is UI-only, doesn't affect wire bytes or protocol handling

https://claude.ai/code/session_01D17W8C3bYwwo2mWGm3QCnS