### PR TITLE
fix: rapid settings toggles are silently discarded

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -25,11 +25,10 @@ import com.vitorpamplona.amethyst.model.AccountSyncedSettingsInternal
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.NoteState
 import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
-import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
+import com.vitorpamplona.quartz.nip01Core.core.awaitCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.utils.Log
-import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -75,11 +74,7 @@ class AppSpecificState(
         val (toInternal, createdAt) =
             stampOrder.withLock {
                 val snapshot = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
-                val stamp =
-                    nextCreatedAtToSupersede(
-                        newestKnown = maxOf(lastPublishedAt, amethystSettingsNote.event?.createdAt ?: 0L),
-                        now = TimeUtils.now(),
-                    )
+                val stamp = awaitCreatedAtToSupersede(maxOf(lastPublishedAt, amethystSettingsNote.event?.createdAt ?: 0L))
                 lastPublishedAt = stamp
                 snapshot to stamp
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -28,11 +28,14 @@ import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.utils.Log
+import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.cancellation.CancellationException
 
 class AppSpecificState(
@@ -43,6 +46,23 @@ class AppSpecificState(
 ) {
     companion object {
         const val APP_SPECIFIC_DATA_D_TAG = "AmethystSettings"
+
+        /**
+         * The `created_at` for the next version of a replaceable event: one second past the newest
+         * version we already know about, or the wall clock when that is already ahead.
+         *
+         * `created_at` is whole seconds, and the settings pickers republish this event on every
+         * discrete toggle, so two edits a few hundred milliseconds apart would otherwise carry the
+         * *same* timestamp. That silently loses the second edit: [LocalCache] keeps the strictly
+         * newest version per address, so it drops the republish, the app-specific-data collector
+         * never fires, `backupAppSpecificData` keeps the first edit, and the next app start restores
+         * that. Relays are no safer — NIP-01 breaks a `created_at` tie by lowest id, so which of the
+         * two edits survives there is arbitrary.
+         */
+        fun nextCreatedAt(
+            newestKnown: Long,
+            now: Long,
+        ): Long = (newestKnown + 1).coerceAtLeast(now)
     }
 
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
@@ -52,12 +72,40 @@ class AppSpecificState(
 
     fun getAppSpecificDataFlow(): StateFlow<NoteState> = amethystSettingsNote.flow().metadata.stateFlow
 
+    /**
+     * Serializes the state snapshot and the timestamp it is stamped with. Two rapid toggles publish
+     * from separate coroutines on the signer's dispatcher; without this they could read the same
+     * previous timestamp and collide again, or take timestamps in the opposite order to the state
+     * they captured. Signing and encrypting stay outside the lock — those can wait on an external
+     * signer, and they don't affect ordering.
+     */
+    private val stampOrder = Mutex()
+
+    /**
+     * The newest version this instance has published, which is not always in [amethystSettingsNote]
+     * yet: the cache is only updated once the event comes back through the broadcaster.
+     */
+    private var lastPublishedAt = 0L
+
     suspend fun saveNewAppSpecificData(): AppSpecificDataEvent {
-        val toInternal = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
+        val toInternal: AccountSyncedSettingsInternal
+        val createdAt: Long
+
+        stampOrder.withLock {
+            toInternal = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
+            createdAt =
+                nextCreatedAt(
+                    newestKnown = maxOf(lastPublishedAt, amethystSettingsNote.event?.createdAt ?: 0L),
+                    now = TimeUtils.now(),
+                )
+            lastPublishedAt = createdAt
+        }
+
         return signer.sign(
             AppSpecificDataEvent.build(
                 dTag = APP_SPECIFIC_DATA_D_TAG,
                 description = signer.nip44Encrypt(JsonMapper.toJson(toInternal), signer.pubKey),
+                createdAt = createdAt,
             ),
         )
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.model.AccountSyncedSettingsInternal
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.NoteState
 import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
+import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.utils.Log
@@ -46,23 +47,6 @@ class AppSpecificState(
 ) {
     companion object {
         const val APP_SPECIFIC_DATA_D_TAG = "AmethystSettings"
-
-        /**
-         * The `created_at` for the next version of a replaceable event: one second past the newest
-         * version we already know about, or the wall clock when that is already ahead.
-         *
-         * `created_at` is whole seconds, and the settings pickers republish this event on every
-         * discrete toggle, so two edits a few hundred milliseconds apart would otherwise carry the
-         * *same* timestamp. That silently loses the second edit: [LocalCache] keeps the strictly
-         * newest version per address, so it drops the republish, the app-specific-data collector
-         * never fires, `backupAppSpecificData` keeps the first edit, and the next app start restores
-         * that. Relays are no safer — NIP-01 breaks a `created_at` tie by lowest id, so which of the
-         * two edits survives there is arbitrary.
-         */
-        fun nextCreatedAt(
-            newestKnown: Long,
-            now: Long,
-        ): Long = (newestKnown + 1).coerceAtLeast(now)
     }
 
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
@@ -88,18 +72,17 @@ class AppSpecificState(
     private var lastPublishedAt = 0L
 
     suspend fun saveNewAppSpecificData(): AppSpecificDataEvent {
-        val toInternal: AccountSyncedSettingsInternal
-        val createdAt: Long
-
-        stampOrder.withLock {
-            toInternal = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
-            createdAt =
-                nextCreatedAt(
-                    newestKnown = maxOf(lastPublishedAt, amethystSettingsNote.event?.createdAt ?: 0L),
-                    now = TimeUtils.now(),
-                )
-            lastPublishedAt = createdAt
-        }
+        val (toInternal, createdAt) =
+            stampOrder.withLock {
+                val snapshot = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
+                val stamp =
+                    nextCreatedAtToSupersede(
+                        newestKnown = maxOf(lastPublishedAt, amethystSettingsNote.event?.createdAt ?: 0L),
+                        now = TimeUtils.now(),
+                    )
+                lastPublishedAt = stamp
+                snapshot to stamp
+            }
 
         return signer.sign(
             AppSpecificDataEvent.build(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip89AppHandlers/AppRecommendationsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip89AppHandlers/AppRecommendationsState.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -84,16 +85,11 @@ class AppRecommendationsState(
      */
     private val publishMutex = Mutex()
 
-    /**
-     * Returns a createdAt strictly greater than whatever AppRecommendationEvent
-     * currently sits in cache for this d-tag. Needed because
-     * LocalCache.consumeBaseReplaceable drops updates whose createdAt isn't
-     * strictly greater, and TimeUtils.now() has only second resolution.
-     */
+    /** The createdAt this d-tag's next version needs to supersede whatever is in cache for it. */
     private fun nextCreatedAt(supportedKind: String): Long {
         val address = Address(AppRecommendationEvent.KIND, signer.pubKey, supportedKind)
         val latest = cache.getAddressableNoteIfExists(address)?.event?.createdAt ?: 0L
-        return maxOf(TimeUtils.now(), latest + 1)
+        return nextCreatedAtToSupersede(latest, TimeUtils.now())
     }
 
     private fun currentRecommendations(supportedKind: String): List<RecommendationTag> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip89AppHandlers/AppRecommendationsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip89AppHandlers/AppRecommendationsState.kt
@@ -24,7 +24,7 @@ import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.quartz.nip01Core.core.Address
-import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
+import com.vitorpamplona.quartz.nip01Core.core.awaitCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -32,7 +32,6 @@ import com.vitorpamplona.quartz.nip89AppHandlers.PlatformType
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.recommendation.AppRecommendationEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.recommendation.tags.RecommendationTag
-import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -85,11 +84,16 @@ class AppRecommendationsState(
      */
     private val publishMutex = Mutex()
 
-    /** The createdAt this d-tag's next version needs to supersede whatever is in cache for it. */
-    private fun nextCreatedAt(supportedKind: String): Long {
+    /**
+     * The createdAt this d-tag's next version needs to supersede whatever is in cache for it. Waits
+     * out the second rather than stamping the future, so repeatedly toggling one recommendation
+     * cannot drift its `created_at` ahead of the clock. Runs under [publishMutex], which is what
+     * keeps two waits from racing each other onto the same second.
+     */
+    private suspend fun nextCreatedAt(supportedKind: String): Long {
         val address = Address(AppRecommendationEvent.KIND, signer.pubKey, supportedKind)
         val latest = cache.getAddressableNoteIfExists(address)?.event?.createdAt ?: 0L
-        return nextCreatedAtToSupersede(latest, TimeUtils.now())
+        return awaitCreatedAtToSupersede(latest)
     }
 
     private fun currentRecommendations(supportedKind: String): List<RecommendationTag> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -217,6 +217,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+/**
+ * How long the navigation pickers wait for the toggles to stop before publishing. Long enough that a
+ * run of taps is one publish, short enough that leaving the screen normally finds nothing to flush.
+ */
+private const val PICKER_PUBLISH_DEBOUNCE_MS = 2000L
+
 @Stable
 class AccountViewModel(
     val account: Account,
@@ -2006,7 +2012,7 @@ class AccountViewModel(
     /** Same ordering contract as [changeBottomBarItems]: apply on the caller's thread, publish off it. */
     fun changeHiddenDrawerItems(items: Set<NavBarItem>) {
         if (account.applyHiddenDrawerItems(items)) {
-            launchSigner { account.sendNewAppSpecificData() }
+            schedulePickerPublish()
         }
     }
 
@@ -2014,9 +2020,60 @@ class AccountViewModel(
         // Apply to the reactive flow synchronously on the caller (UI) thread so rapid edits stay
         // ordered — launchSigner dispatches on a multi-threaded pool, so wrapping the emit too would
         // let two quick edits complete out of order and revert the newer one (the settings screen
-        // re-seeds its editable list from this flow). Only the sign + encrypt + publish runs off-thread.
+        // re-seeds its editable list from this flow). Only the sign + encrypt + publish runs off-thread,
+        // and that part is debounced — see [pickerPublisher].
         if (account.applyBottomBarItems(items)) {
-            launchSigner { account.sendNewAppSpecificData() }
+            schedulePickerPublish()
+        }
+    }
+
+    /**
+     * Publishes the account's synced settings once the picker edits stop, rather than once per toggle.
+     *
+     * The Side Menu and bottom-bar pickers are the only settings surfaces that write in bursts — a
+     * configuring session is a run of discrete toggles over ~50 rows, and each one signs, encrypts
+     * and publishes the whole blob to every outbox relay, which on an external signer is an IPC
+     * round trip (and possibly a prompt) per switch. One publisher for both, since they edit the same
+     * app-specific data event and a burst that crosses the two should still collapse.
+     *
+     * Only these two. Every other synced setting changes one at a time, and the published event is
+     * its only durable copy, so delaying those would buy nothing and cost durability.
+     */
+    private val pickerPublisher =
+        DebouncedPublisher(
+            debounceMs = PICKER_PUBLISH_DEBOUNCE_MS,
+            launch = { launchSigner(it) },
+            publish = { account.sendNewAppSpecificData() },
+        )
+
+    private fun schedulePickerPublish() = pickerPublisher.schedule()
+
+    /**
+     * Publish any pending picker edits now. Called when a picker screen leaves the composition or the
+     * app stops, so an edit is never left sitting only in memory: synced settings have no local copy
+     * of their own — [com.vitorpamplona.amethyst.model.AccountSettings.backupAppSpecificData], written
+     * when the published event comes back through the collector, *is* the local copy.
+     */
+    fun flushPickerPublish() = pickerPublisher.flush()
+
+    /**
+     * Last resort for a pending publish, on the account's scope rather than [viewModelScope] — this
+     * runs from [onCleared], where [viewModelScope] is already cancelled. Covers an account switch or
+     * an Activity teardown that happens while a picker edit is still inside its debounce window; the
+     * account's scope outlives both and is only torn down at logout.
+     *
+     * Signer errors go to the log instead of a toast: by this point there is no UI left to show one.
+     */
+    private fun flushPickerPublishDetached() {
+        if (!pickerPublisher.isPending()) return
+        pickerPublisher.cancel()
+        account.scope.launch(Dispatchers.IO) {
+            try {
+                account.sendNewAppSpecificData()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.w("AccountViewModel", "Could not publish pending navigation settings", e)
+            }
         }
     }
 
@@ -2533,6 +2590,7 @@ class AccountViewModel(
             .clearViewModel()
         com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity.NestBridge
             .clear()
+        flushPickerPublishDetached()
         feedStates.destroy()
         super.onCleared()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1625,43 +1625,52 @@ class AccountViewModel(
 
     inline fun launchSigner(crossinline action: suspend () -> Unit) =
         viewModelScope.launch(Dispatchers.IO) {
-            try {
-                action()
-            } catch (_: SignerExceptions.ReadOnlyException) {
-                toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_sign_events,
-                )
-            } catch (_: SignerExceptions.UnauthorizedDecryptionException) {
-                toastManager.toast(
-                    R.string.unauthorized_exception,
-                    R.string.unauthorized_exception_description,
-                )
-            } catch (_: SignerExceptions.SignerNotFoundException) {
-                toastManager.toast(
-                    R.string.signer_not_found_exception,
-                    R.string.signer_not_found_exception_description,
-                )
-            } catch (e: SignerExceptions.TimedOutException) {
-                Log.w("AccountViewModel", "TimedOutException", e)
-            } catch (e: SignerExceptions.NothingToDecrypt) {
-                Log.w("AccountViewModel", "NothingToDecrypt", e)
-            } catch (e: SignerExceptions.CouldNotPerformException) {
-                Log.w("AccountViewModel", "CouldNotPerformException", e)
-            } catch (e: SignerExceptions.ManuallyUnauthorizedException) {
-                Log.w("AccountViewModel", "ManuallyUnauthorizedException", e)
-            } catch (e: SignerExceptions.AutomaticallyUnauthorizedException) {
-                Log.w("AccountViewModel", "AutomaticallyUnauthorizedException", e)
-            } catch (e: SignerExceptions.RunningOnBackgroundWithoutAutomaticPermissionException) {
-                Log.w("AccountViewModel", "TimedOutRunningOnBackgroundWithoutAutomaticPermissionExceptionException", e)
-            } catch (e: IllegalStateException) {
-                toastManager.toast(
-                    R.string.signer_not_found_exception,
-                    R.string.signer_illegal_state_exception_description,
-                    e,
-                )
-            }
+            reportSignerErrors { action() }
         }
+
+    /**
+     * The signer-failure reporting of [launchSigner], separated from its scope so work that must
+     * outlive [viewModelScope] can still surface the same messages. Public because [launchSigner]
+     * is inline.
+     */
+    suspend fun reportSignerErrors(action: suspend () -> Unit) {
+        try {
+            action()
+        } catch (_: SignerExceptions.ReadOnlyException) {
+            toastManager.toast(
+                R.string.read_only_user,
+                R.string.login_with_a_private_key_to_be_able_to_sign_events,
+            )
+        } catch (_: SignerExceptions.UnauthorizedDecryptionException) {
+            toastManager.toast(
+                R.string.unauthorized_exception,
+                R.string.unauthorized_exception_description,
+            )
+        } catch (_: SignerExceptions.SignerNotFoundException) {
+            toastManager.toast(
+                R.string.signer_not_found_exception,
+                R.string.signer_not_found_exception_description,
+            )
+        } catch (e: SignerExceptions.TimedOutException) {
+            Log.w("AccountViewModel", "TimedOutException", e)
+        } catch (e: SignerExceptions.NothingToDecrypt) {
+            Log.w("AccountViewModel", "NothingToDecrypt", e)
+        } catch (e: SignerExceptions.CouldNotPerformException) {
+            Log.w("AccountViewModel", "CouldNotPerformException", e)
+        } catch (e: SignerExceptions.ManuallyUnauthorizedException) {
+            Log.w("AccountViewModel", "ManuallyUnauthorizedException", e)
+        } catch (e: SignerExceptions.AutomaticallyUnauthorizedException) {
+            Log.w("AccountViewModel", "AutomaticallyUnauthorizedException", e)
+        } catch (e: SignerExceptions.RunningOnBackgroundWithoutAutomaticPermissionException) {
+            Log.w("AccountViewModel", "TimedOutRunningOnBackgroundWithoutAutomaticPermissionExceptionException", e)
+        } catch (e: IllegalStateException) {
+            toastManager.toast(
+                R.string.signer_not_found_exception,
+                R.string.signer_illegal_state_exception_description,
+                e,
+            )
+        }
+    }
 
     fun approveCommunityPost(
         post: Note,
@@ -2012,7 +2021,7 @@ class AccountViewModel(
     /** Same ordering contract as [changeBottomBarItems]: apply on the caller's thread, publish off it. */
     fun changeHiddenDrawerItems(items: Set<NavBarItem>) {
         if (account.applyHiddenDrawerItems(items)) {
-            schedulePickerPublish()
+            pickerPublisher.schedule()
         }
     }
 
@@ -2023,7 +2032,7 @@ class AccountViewModel(
         // re-seeds its editable list from this flow). Only the sign + encrypt + publish runs off-thread,
         // and that part is debounced — see [pickerPublisher].
         if (account.applyBottomBarItems(items)) {
-            schedulePickerPublish()
+            pickerPublisher.schedule()
         }
     }
 
@@ -2038,15 +2047,21 @@ class AccountViewModel(
      *
      * Only these two. Every other synced setting changes one at a time, and the published event is
      * its only durable copy, so delaying those would buy nothing and cost durability.
+     *
+     * On the account's scope, NOT [viewModelScope]. A synced setting's only durable copy is the
+     * published event, so an edit waiting out the debounce must survive this ViewModel: AndroidX
+     * closes [viewModelScope] *before* it calls [onCleared] (`ViewModel.clear()` closes the keyed
+     * closeables, and `viewModelScope` is one of them), so a pending publish tied to it would already
+     * be cancelled by the time any teardown hook here could notice — and no hook could rescue it.
+     * The account's scope is cancelled only when the account is removed, so the publish simply
+     * completes across an account switch or an Activity teardown.
      */
     private val pickerPublisher =
         DebouncedPublisher(
             debounceMs = PICKER_PUBLISH_DEBOUNCE_MS,
-            launch = { launchSigner(it) },
+            launch = { block -> account.scope.launch(Dispatchers.IO) { reportSignerErrors { block() } } },
             publish = { account.sendNewAppSpecificData() },
         )
-
-    private fun schedulePickerPublish() = pickerPublisher.schedule()
 
     /**
      * Publish any pending picker edits now. Called when a picker screen leaves the composition or the
@@ -2055,27 +2070,6 @@ class AccountViewModel(
      * when the published event comes back through the collector, *is* the local copy.
      */
     fun flushPickerPublish() = pickerPublisher.flush()
-
-    /**
-     * Last resort for a pending publish, on the account's scope rather than [viewModelScope] — this
-     * runs from [onCleared], where [viewModelScope] is already cancelled. Covers an account switch or
-     * an Activity teardown that happens while a picker edit is still inside its debounce window; the
-     * account's scope outlives both and is only torn down at logout.
-     *
-     * Signer errors go to the log instead of a toast: by this point there is no UI left to show one.
-     */
-    private fun flushPickerPublishDetached() {
-        if (!pickerPublisher.isPending()) return
-        pickerPublisher.cancel()
-        account.scope.launch(Dispatchers.IO) {
-            try {
-                account.sendNewAppSpecificData()
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                Log.w("AccountViewModel", "Could not publish pending navigation settings", e)
-            }
-        }
-    }
 
     fun pinnedChatroomsFlow(): StateFlow<Set<ChatroomKey>> = account.settings.syncedSettings.chats.pinnedChatrooms
 
@@ -2590,7 +2584,6 @@ class AccountViewModel(
             .clearViewModel()
         com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity.NestBridge
             .clear()
-        flushPickerPublishDetached()
         feedStates.destroy()
         super.onCleared()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1636,6 +1636,14 @@ class AccountViewModel(
     suspend fun reportSignerErrors(action: suspend () -> Unit) {
         try {
             action()
+        } catch (e: CancellationException) {
+            // MUST stay ahead of the IllegalStateException arm below: java.util.concurrent
+            // .CancellationException extends IllegalStateException, so without this every cancelled
+            // signer coroutine — a superseded debounce, a scope torn down mid-sign — would be
+            // swallowed there and shown to the user as a "signer" toast reading
+            // "JobCancellationException: StandaloneCoroutine was cancelled". Cancellation is not a
+            // signer failure and must propagate for structured concurrency to work.
+            throw e
         } catch (_: SignerExceptions.ReadOnlyException) {
             toastManager.toast(
                 R.string.read_only_user,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisher.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+
+/**
+ * Collapses a burst of edits into a single [publish], run once the edits stop.
+ *
+ * Superseding a still-pending publish cancels it. That is safe for a whole-state publish — one that
+ * reads the current state when it runs rather than carrying a payload — because the replacement
+ * carries the same state or newer; it is wrong for anything that publishes a delta.
+ *
+ * [launch] is injected rather than a [kotlinx.coroutines.CoroutineScope] so the caller keeps its own
+ * error handling (for [AccountViewModel], the signer-exception toasts of `launchSigner`), and so the
+ * semantics here can be unit-tested on a test scope.
+ */
+class DebouncedPublisher(
+    private val debounceMs: Long,
+    private val launch: (suspend () -> Unit) -> Job,
+    private val publish: suspend () -> Unit,
+) {
+    private var pending: Job? = null
+
+    /** True while an edit is waiting out the debounce, or its publish is still in flight. */
+    fun isPending(): Boolean = pending?.isActive == true
+
+    /** Records an edit: restarts the wait, so a run of edits publishes once, after the last one. */
+    fun schedule() = start(debounceMs)
+
+    /**
+     * Publishes a pending edit now instead of waiting out the debounce. A no-op when nothing is
+     * pending, so a caller can flush on every exit path without publishing the same state twice.
+     */
+    fun flush() {
+        if (!isPending()) return
+        start(0)
+    }
+
+    /** Abandons a pending edit without publishing. For a caller that will publish it another way. */
+    fun cancel() {
+        pending?.cancel()
+        pending = null
+    }
+
+    private fun start(delayMs: Long) {
+        pending?.cancel()
+        pending =
+            launch {
+                delay(delayMs)
+                publish()
+            }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisher.kt
@@ -30,9 +30,13 @@ import kotlinx.coroutines.delay
  * reads the current state when it runs rather than carrying a payload — because the replacement
  * carries the same state or newer; it is wrong for anything that publishes a delta.
  *
- * [launch] is injected rather than a [kotlinx.coroutines.CoroutineScope] so the caller keeps its own
- * error handling (for [AccountViewModel], the signer-exception toasts of `launchSigner`), and so the
- * semantics here can be unit-tested on a test scope.
+ * A pending edit lives entirely in the [Job] that [launch] returned, so it is only as durable as the
+ * scope that job belongs to — see `aPendingPublishDiesWithTheScopeItWasLaunchedOn`. Give [launch] a
+ * scope that outlives every teardown the edit has to survive.
+ *
+ * [launch] is injected rather than a [kotlinx.coroutines.CoroutineScope] so the caller chooses that
+ * scope and keeps its own error handling (for [AccountViewModel], the signer-exception toasts), and
+ * so the semantics here can be unit-tested on a test scope.
  */
 class DebouncedPublisher(
     private val debounceMs: Long,
@@ -40,9 +44,6 @@ class DebouncedPublisher(
     private val publish: suspend () -> Unit,
 ) {
     private var pending: Job? = null
-
-    /** True while an edit is waiting out the debounce, or its publish is still in flight. */
-    fun isPending(): Boolean = pending?.isActive == true
 
     /** Records an edit: restarts the wait, so a run of edits publishes once, after the last one. */
     fun schedule() = start(debounceMs)
@@ -52,14 +53,8 @@ class DebouncedPublisher(
      * pending, so a caller can flush on every exit path without publishing the same state twice.
      */
     fun flush() {
-        if (!isPending()) return
+        if (pending?.isActive != true) return
         start(0)
-    }
-
-    /** Abandons a pending edit without publishing. For a caller that will publish it another way. */
-    fun cancel() {
-        pending?.cancel()
-        pending = null
     }
 
     private fun start(delayMs: Long) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.participants
 
+import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.endpoint
@@ -133,17 +134,10 @@ internal object RoomParticipantActions {
                 ?: ParticipantTag(original.pubKey, null, ROLE.HOST.code, null)
         val others = participants.filterNot { it.pubKey == host.pubKey }
 
-        // Strictly monotonic createdAt. NIP-01 replaceable-event
-        // semantics drop a new version whose createdAt is <= the
-        // previous one (with a lower-id tie-break that's effectively
-        // random under signing). Creating a room then immediately
-        // promoting in the same wall-clock second produced the
-        // dreaded silent-no-op: the local cache rejected the new
-        // event in `consumeBaseReplaceable` (strict `>`) and relays
-        // applied the same rule. `+ 1` is enough to win the tie;
-        // `coerceAtLeast(now)` keeps the wire timestamp accurate
-        // when the original is already in the past.
-        val nextCreatedAt = (original.createdAt + 1L).coerceAtLeast(TimeUtils.now())
+        // Creating a room then immediately promoting in the same wall-clock
+        // second produced the dreaded silent-no-op: both versions carried the
+        // same createdAt and the tie-break picked one at random.
+        val nextCreatedAt = nextCreatedAtToSupersede(original.createdAt, TimeUtils.now())
 
         return MeetingSpaceEvent.build(
             room = original.room().orEmpty(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
@@ -137,6 +137,11 @@ internal object RoomParticipantActions {
         // Creating a room then immediately promoting in the same wall-clock
         // second produced the dreaded silent-no-op: both versions carried the
         // same createdAt and the tie-break picked one at random.
+        //
+        // The out-stamping form rather than awaitCreatedAtToSupersede: this is
+        // reached from non-suspending Compose click handlers, and the stamp is
+        // derived from the one event being acted on, so it runs at most a second
+        // ahead of the clock and cannot drift the way a repeated republish does.
         val nextCreatedAt = nextCreatedAtToSupersede(original.createdAt, TimeUtils.now())
 
         return MeetingSpaceEvent.build(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
@@ -155,6 +155,9 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
     val state = remember { BottomBarSettingsState(savedItems) { accountViewModel.changeBottomBarItems(it) } }
     LaunchedEffect(savedItems) { state.syncFrom(savedItems) }
 
+    // Edits publish on a debounce; make sure leaving the screen doesn't strand the last one.
+    FlushPickerEditsOnExit(accountViewModel)
+
     val pinned = state.pinned
     val pinnedKeys = remember(pinned) { state.pinnedKeys() }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
@@ -111,6 +111,9 @@ fun DrawerSettingsContent(accountViewModel: AccountViewModel) {
     val state = remember { DrawerSettingsState(savedHidden) { accountViewModel.changeHiddenDrawerItems(it) } }
     LaunchedEffect(savedHidden) { state.syncFrom(savedHidden) }
 
+    // Edits publish on a debounce; make sure leaving the screen doesn't strand the last one.
+    FlushPickerEditsOnExit(accountViewModel)
+
     // Sections start collapsed: expanded, they are ~50 rows of scrolling. The header's hidden
     // counter is what tells the user which one to open.
     val expandedSections = rememberExpandedKeys<DrawerSectionId>()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
@@ -52,10 +53,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.SimpleImage35Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
@@ -348,5 +352,23 @@ fun RestoreDefaultRow(onClick: () -> Unit) {
         TextButton(onClick = onClick) {
             Text(stringRes(R.string.bottom_bar_settings_restore_default))
         }
+    }
+}
+
+/**
+ * Publishes the picker's pending edits when the screen goes away — either the composable leaves the
+ * composition (back out of the screen, account switch) or the app stops.
+ *
+ * The pickers debounce their NIP-78 publish, and a synced setting has no local copy other than the
+ * published event, so an edit still inside the debounce window when the process dies is simply gone.
+ * ON_STOP is the last point the app is reliably alive, and it always precedes the ViewModel's
+ * onCleared, so between the two arms nothing is left pending.
+ */
+@Composable
+fun FlushPickerEditsOnExit(accountViewModel: AccountViewModel) {
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) { accountViewModel.flushPickerPublish() }
+
+    DisposableEffect(accountViewModel) {
+        onDispose { accountViewModel.flushPickerPublish() }
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/AppSpecificDataRepublishTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/AppSpecificDataRepublishTest.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model
 
 import android.os.Looper
-import com.vitorpamplona.amethyst.model.nip78AppSpecific.AppSpecificState
+import com.vitorpamplona.quartz.nip01Core.core.nextCreatedAtToSupersede
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
@@ -38,9 +38,9 @@ import org.junit.Test
 
 /**
  * The settings pickers (Side Menu, bottom bar) republish the NIP-78 app-specific data event on every
- * discrete toggle, and `created_at` is whole seconds. These pin the rule that keeps two toggles a few
- * hundred milliseconds apart from collapsing into one — the failure the user sees as "my side-menu
- * rows came back after a restart".
+ * discrete toggle, and `created_at` is whole seconds. These pin what that costs in LocalCache — the
+ * failure the user sees as "my side-menu rows came back after a restart". The timestamp rule itself
+ * is unit-tested in quartz, next to the supersession rule it exists to beat.
  */
 class AppSpecificDataRepublishTest {
     private val signer = NostrSignerInternal(KeyPair())
@@ -80,7 +80,7 @@ class AppSpecificDataRepublishTest {
         runBlocking {
             val sameSecond = TimeUtils.now()
 
-            val first = signer.sign(AppSpecificDataEvent.build(dTag, "first", createdAt = AppSpecificState.nextCreatedAt(0L, sameSecond)))
+            val first = signer.sign(AppSpecificDataEvent.build(dTag, "first", createdAt = nextCreatedAtToSupersede(0L, sameSecond)))
             LocalCache.justConsumeMyOwnEvent(first)
 
             val second =
@@ -88,30 +88,11 @@ class AppSpecificDataRepublishTest {
                     AppSpecificDataEvent.build(
                         dTag,
                         "second",
-                        createdAt = AppSpecificState.nextCreatedAt(first.createdAt, sameSecond),
+                        createdAt = nextCreatedAtToSupersede(first.createdAt, sameSecond),
                     ),
                 )
             LocalCache.justConsumeMyOwnEvent(second)
 
             assertEquals("second", LocalCache.getOrCreateAddressableNote(address).event?.content)
         }
-
-    @Test
-    fun theWallClockWinsOnceItHasMovedPastTheLastVersion() {
-        // The common case — edits minutes apart carry the real time, not a drifting counter.
-        assertEquals(1_000L, AppSpecificState.nextCreatedAt(newestKnown = 900L, now = 1_000L))
-    }
-
-    @Test
-    fun aBurstStepsOneSecondPerEdit() {
-        assertEquals(1_001L, AppSpecificState.nextCreatedAt(newestKnown = 1_000L, now = 1_000L))
-        assertEquals(1_002L, AppSpecificState.nextCreatedAt(newestKnown = 1_001L, now = 1_000L))
-    }
-
-    @Test
-    fun aVersionStampedInTheFutureIsStillSuperseded() {
-        // A clock skew on another device (or our own burst) can leave the newest known version ahead
-        // of this device's clock. Going back to `now` there would publish an event the cache drops.
-        assertEquals(9_001L, AppSpecificState.nextCreatedAt(newestKnown = 9_000L, now = 1_000L))
-    }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/AppSpecificDataRepublishTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/AppSpecificDataRepublishTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model
+
+import android.os.Looper
+import com.vitorpamplona.amethyst.model.nip78AppSpecific.AppSpecificState
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The settings pickers (Side Menu, bottom bar) republish the NIP-78 app-specific data event on every
+ * discrete toggle, and `created_at` is whole seconds. These pin the rule that keeps two toggles a few
+ * hundred milliseconds apart from collapsing into one — the failure the user sees as "my side-menu
+ * rows came back after a restart".
+ */
+class AppSpecificDataRepublishTest {
+    private val signer = NostrSignerInternal(KeyPair())
+    private val dTag = "AmethystSettingsRepublishTest"
+
+    private val address get() = AppSpecificDataEvent.createAddress(signer.pubKey, dTag)
+
+    @Before
+    fun setup() {
+        // LocalCache.consume refuses the main thread; plain JVM tests have no Looper,
+        // where null == null reads as "main". Distinct mocks make it a worker thread.
+        mockkStatic(Looper::class)
+        every { Looper.myLooper() } returns mockk<Looper>()
+        every { Looper.getMainLooper() } returns mockk<Looper>()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Looper::class)
+    }
+
+    @Test
+    fun theWallClockAloneLosesAnEditMadeInTheSameSecond() =
+        runBlocking {
+            // Why the fix has to exist: LocalCache keeps the strictly newest version per address, so
+            // a same-second republish never reaches the collector that persists it.
+            val sameSecond = TimeUtils.now()
+
+            LocalCache.justConsumeMyOwnEvent(signer.sign(AppSpecificDataEvent.build(dTag, "first", createdAt = sameSecond)))
+            LocalCache.justConsumeMyOwnEvent(signer.sign(AppSpecificDataEvent.build(dTag, "second", createdAt = sameSecond)))
+
+            assertEquals("first", LocalCache.getOrCreateAddressableNote(address).event?.content)
+        }
+
+    @Test
+    fun aStampedRepublishInTheSameSecondLands() =
+        runBlocking {
+            val sameSecond = TimeUtils.now()
+
+            val first = signer.sign(AppSpecificDataEvent.build(dTag, "first", createdAt = AppSpecificState.nextCreatedAt(0L, sameSecond)))
+            LocalCache.justConsumeMyOwnEvent(first)
+
+            val second =
+                signer.sign(
+                    AppSpecificDataEvent.build(
+                        dTag,
+                        "second",
+                        createdAt = AppSpecificState.nextCreatedAt(first.createdAt, sameSecond),
+                    ),
+                )
+            LocalCache.justConsumeMyOwnEvent(second)
+
+            assertEquals("second", LocalCache.getOrCreateAddressableNote(address).event?.content)
+        }
+
+    @Test
+    fun theWallClockWinsOnceItHasMovedPastTheLastVersion() {
+        // The common case — edits minutes apart carry the real time, not a drifting counter.
+        assertEquals(1_000L, AppSpecificState.nextCreatedAt(newestKnown = 900L, now = 1_000L))
+    }
+
+    @Test
+    fun aBurstStepsOneSecondPerEdit() {
+        assertEquals(1_001L, AppSpecificState.nextCreatedAt(newestKnown = 1_000L, now = 1_000L))
+        assertEquals(1_002L, AppSpecificState.nextCreatedAt(newestKnown = 1_001L, now = 1_000L))
+    }
+
+    @Test
+    fun aVersionStampedInTheFutureIsStillSuperseded() {
+        // A clock skew on another device (or our own burst) can leave the newest known version ahead
+        // of this device's clock. Going back to `now` there would publish an event the cache drops.
+        assertEquals(9_001L, AppSpecificState.nextCreatedAt(newestKnown = 9_000L, now = 1_000L))
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisherTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisherTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The publish side of the navigation pickers: a configuring session must reach the relays as one
+ * event, and no exit path may strand the last toggle.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DebouncedPublisherTest {
+    private val debounce = 2_000L
+
+    @Test
+    fun aBurstOfEditsPublishesOnce() =
+        runTest {
+            var published = 0
+            val publisher = publisher { published++ }
+
+            repeat(10) {
+                publisher.schedule()
+                advanceTimeBy(200)
+            }
+            advanceUntilIdle()
+
+            assertEquals(1, published)
+        }
+
+    @Test
+    fun editsFurtherApartThanTheDebouncePublishSeparately() =
+        runTest {
+            var published = 0
+            val publisher = publisher { published++ }
+
+            publisher.schedule()
+            advanceUntilIdle()
+            publisher.schedule()
+            advanceUntilIdle()
+
+            assertEquals(2, published)
+        }
+
+    @Test
+    fun flushPublishesWithoutWaitingOutTheDebounce() =
+        runTest {
+            var published = 0
+            val publisher = publisher { published++ }
+
+            publisher.schedule()
+            advanceTimeBy(100)
+            assertEquals(0, published)
+
+            publisher.flush()
+            advanceUntilIdle()
+
+            assertEquals(1, published)
+        }
+
+    @Test
+    fun flushingTwiceOnTheWayOutDoesNotPublishTwice() =
+        runTest {
+            // Leaving a picker screen can hit both arms of FlushPickerEditsOnExit (ON_STOP, then
+            // onDispose), and onCleared may follow. Only the first one may publish.
+            var published = 0
+            val publisher = publisher { published++ }
+
+            publisher.schedule()
+            publisher.flush()
+            advanceUntilIdle()
+
+            publisher.flush()
+            advanceUntilIdle()
+
+            assertEquals(1, published)
+        }
+
+    @Test
+    fun flushWithNothingPendingIsANoOp() =
+        runTest {
+            var published = 0
+            val publisher = publisher { published++ }
+
+            publisher.flush()
+            advanceUntilIdle()
+
+            assertEquals(0, published)
+        }
+
+    @Test
+    fun cancelHandsThePendingEditToTheCaller() =
+        runTest {
+            // What onCleared relies on: it takes the pending edit off this publisher and republishes
+            // it on the account's scope, which must not leave the original to fire as well.
+            var published = 0
+            val publisher = publisher { published++ }
+
+            publisher.schedule()
+            assertTrue(publisher.isPending())
+
+            publisher.cancel()
+            advanceUntilIdle()
+
+            assertEquals(0, published)
+            assertFalse(publisher.isPending())
+        }
+
+    private fun kotlinx.coroutines.test.TestScope.publisher(publish: suspend () -> Unit) =
+        DebouncedPublisher(
+            debounceMs = debounce,
+            launch = { block -> launch { block() } },
+            publish = publish,
+        )
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisherTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DebouncedPublisherTest.kt
@@ -20,14 +20,16 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -114,27 +116,29 @@ class DebouncedPublisherTest {
         }
 
     @Test
-    fun cancelHandsThePendingEditToTheCaller() =
+    fun aPendingPublishDiesWithTheScopeItWasLaunchedOn() =
         runTest {
-            // What onCleared relies on: it takes the pending edit off this publisher and republishes
-            // it on the account's scope, which must not leave the original to fire as well.
+            // Why the pickers launch on the account's scope and not viewModelScope: a pending edit is
+            // only as durable as the scope holding it, and AndroidX cancels viewModelScope BEFORE it
+            // calls onCleared — so an edit tied to it is already gone by the time any teardown hook
+            // there could rescue it.
             var published = 0
-            val publisher = publisher { published++ }
+            val shortLived = CoroutineScope(coroutineContext + Job())
+            val publisher = publisher(scope = shortLived) { published++ }
 
             publisher.schedule()
-            assertTrue(publisher.isPending())
-
-            publisher.cancel()
+            shortLived.cancel()
             advanceUntilIdle()
 
             assertEquals(0, published)
-            assertFalse(publisher.isPending())
         }
 
-    private fun kotlinx.coroutines.test.TestScope.publisher(publish: suspend () -> Unit) =
-        DebouncedPublisher(
-            debounceMs = debounce,
-            launch = { block -> launch { block() } },
-            publish = publish,
-        )
+    private fun TestScope.publisher(
+        scope: CoroutineScope = this,
+        publish: suspend () -> Unit,
+    ) = DebouncedPublisher(
+        debounceMs = debounce,
+        launch = { block -> scope.launch { block() } },
+        publish = publish,
+    )
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
@@ -33,3 +33,21 @@ fun Event.supersedes(existing: Event): Boolean =
         createdAt < existing.createdAt -> false
         else -> id < existing.id
     }
+
+/**
+ * The `created_at` a new version needs in order to supersede [newestKnown]: one second past it, or
+ * [now] when the clock has already moved beyond it.
+ *
+ * `created_at` has one-second resolution, so republishing an address twice inside the same second
+ * stamps both versions identically and leaves [supersedes] to settle it on the id tie-break — which
+ * signing makes effectively random. Every store applies that rule, so the loser is dropped silently:
+ * locally it never reaches the observers watching the address, and relays may keep a different
+ * version than the one this client kept. Any address republished from user input (a settings toggle,
+ * a room status change) hits this routinely.
+ *
+ * [now] is a parameter rather than read here so the rule stays pure and testable.
+ */
+fun nextCreatedAtToSupersede(
+    newestKnown: Long,
+    now: Long,
+): Long = (newestKnown + 1).coerceAtLeast(now)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
@@ -20,6 +20,9 @@
  */
 package com.vitorpamplona.quartz.nip01Core.core
 
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.delay
+
 /**
  * The NIP-01 replaceable/addressable supersession rule: the winner of an
  * address is the highest `created_at`, with ties broken by the LEXICALLY
@@ -51,3 +54,40 @@ fun nextCreatedAtToSupersede(
     newestKnown: Long,
     now: Long,
 ): Long = (newestKnown + 1).coerceAtLeast(now)
+
+/**
+ * How far ahead of this device's clock [awaitCreatedAtToSupersede] is still willing to wait. A
+ * version further ahead than this came from another device's skewed clock rather than from this
+ * client's own burst, and waiting it out could mean sleeping for hours.
+ */
+const val MAX_SUPERSEDE_WAIT_SECONDS = 5L
+
+/**
+ * The `created_at` for the next version of an address, waiting for the clock rather than running
+ * ahead of it: if [newestKnown] already claims the current second, this suspends until that second
+ * has passed and then stamps the real time.
+ *
+ * Prefer this to [nextCreatedAtToSupersede] wherever the caller can suspend. Both make the new
+ * version win, but this one never puts a `created_at` in the future — one second of second-resolution
+ * `created_at` is genuinely the floor on how often an address can be replaced, so a client that
+ * replaces one faster has to wait, not invent a timestamp. Repeatedly out-stamping instead would
+ * drift a second further ahead per republish, and relays reject events too far in the future.
+ *
+ * The wait is bounded by [MAX_SUPERSEDE_WAIT_SECONDS]; past that the only way to supersede is still
+ * to out-stamp, so it falls back to [nextCreatedAtToSupersede].
+ *
+ * [now] is injectable so the rule can be tested against a virtual clock.
+ */
+suspend fun awaitCreatedAtToSupersede(
+    newestKnown: Long,
+    now: () -> Long = TimeUtils::now,
+): Long {
+    val startedAt = now()
+    if (newestKnown < startedAt) return startedAt
+
+    val secondsToWait = newestKnown - startedAt + 1
+    if (secondsToWait > MAX_SUPERSEDE_WAIT_SECONDS) return nextCreatedAtToSupersede(newestKnown, startedAt)
+
+    delay(secondsToWait * 1000)
+    return maxOf(now(), newestKnown + 1)
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/core/AwaitCreatedAtToSupersedeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/core/AwaitCreatedAtToSupersedeTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.core
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The point of waiting rather than out-stamping: `created_at` is whole seconds, so one second is the
+ * real floor on how often an address can be replaced. A client that replaces one faster has to wait
+ * for the clock — inventing a timestamp instead drifts a second further into the future per
+ * republish, and relays reject events too far ahead.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AwaitCreatedAtToSupersedeTest {
+    @Test
+    fun stampsTheClockWhenItHasAlreadyMovedPastTheNewestVersion() =
+        runTest {
+            advanceTimeBy(10_000)
+            val clock = { testScheduler.currentTime / 1000 }
+
+            val stamp = awaitCreatedAtToSupersede(newestKnown = 5, now = clock)
+
+            assertEquals(10L, stamp)
+            assertEquals(10_000L, testScheduler.currentTime, "must not wait when there is nothing to wait for")
+        }
+
+    @Test
+    fun waitsOutTheSecondTheNewestVersionClaimedInsteadOfStampingTheFuture() =
+        runTest {
+            advanceTimeBy(10_000)
+            val clock = { testScheduler.currentTime / 1000 }
+
+            val stamp = awaitCreatedAtToSupersede(newestKnown = 10, now = clock)
+
+            assertEquals(11L, stamp)
+            assertEquals(11_000L, testScheduler.currentTime, "should have waited exactly the one second out")
+            assertTrue(stamp <= clock(), "a stamp must never be ahead of the clock")
+        }
+
+    @Test
+    fun aBurstNeverRunsAheadOfTheClock() =
+        runTest {
+            advanceTimeBy(10_000)
+            val clock = { testScheduler.currentTime / 1000 }
+
+            // Five back-to-back republishes, each superseding the one before it.
+            var newest = 10L
+            repeat(5) {
+                newest = awaitCreatedAtToSupersede(newestKnown = newest, now = clock)
+                assertTrue(newest <= clock(), "republish $it stamped the future")
+            }
+
+            assertEquals(15L, newest)
+        }
+
+    @Test
+    fun outStampsAVersionTooFarAheadToWaitOut() =
+        runTest {
+            advanceTimeBy(10_000)
+            val clock = { testScheduler.currentTime / 1000 }
+
+            // Another device's skewed clock. Waiting it out would mean sleeping for hours, so the
+            // only way to supersede it is still to out-stamp it.
+            val stamp = awaitCreatedAtToSupersede(newestKnown = 10 + MAX_SUPERSEDE_WAIT_SECONDS + 1, now = clock)
+
+            assertEquals(17L, stamp)
+            assertEquals(10_000L, testScheduler.currentTime, "must not wait out an implausible skew")
+        }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/core/NextCreatedAtToSupersedeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/core/NextCreatedAtToSupersedeTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NextCreatedAtToSupersedeTest {
+    @Test
+    fun theWallClockWinsOnceItHasMovedPastTheNewestVersion() {
+        // The common case — versions minutes apart carry the real time, not a drifting counter.
+        assertEquals(1_000L, nextCreatedAtToSupersede(newestKnown = 900L, now = 1_000L))
+    }
+
+    @Test
+    fun aBurstInsideOneSecondStepsOneSecondPerVersion() {
+        assertEquals(1_001L, nextCreatedAtToSupersede(newestKnown = 1_000L, now = 1_000L))
+        assertEquals(1_002L, nextCreatedAtToSupersede(newestKnown = 1_001L, now = 1_000L))
+    }
+
+    @Test
+    fun aVersionStampedInTheFutureIsStillSuperseded() {
+        // Clock skew on another device (or this client's own burst) can leave the newest known
+        // version ahead of this device's clock. Falling back to `now` there would publish a version
+        // every store drops.
+        assertEquals(9_001L, nextCreatedAtToSupersede(newestKnown = 9_000L, now = 1_000L))
+    }
+}


### PR DESCRIPTION
## The bug

Toggling rows quickly in **Settings → Side Menu** silently discards some of them. The switch flips, the drawer updates, and then the edit is gone on the next app start — never written to preferences, and only arbitrarily present on relays.

On a device, flipping 16 switches at a normal tapping pace (~2/second) lost **7 of them**.

## Root cause

Synced settings live in one NIP-78 app-specific data event (kind 30078, `d=AmethystSettings`), and that published event is also their *only* local copy: `AccountSettings.backupAppSpecificData` is written when the event comes back through the `LocalCache` collector, and that is what reaches SharedPreferences.

`created_at` has one-second resolution. The Side Menu picker republishes on every discrete toggle, so two toggles a few hundred milliseconds apart stamp the *same* `created_at`. `LocalCache.consumeBaseReplaceable` keeps only the strictly newest version per address, so it drops the second one — the collector never fires, `backupAppSpecificData` keeps the earlier edit, and the restart restores that. Relays are no safer: NIP-01 breaks a `created_at` tie by lowest id, so which edit survives there is effectively random.

The picker was modelled on the bottom-bar picker added three days earlier (`7a41e21272` → `dda0f0d9e8`), and inherited its publish-on-every-change contract along with the bug. `BottomBarSettingsState.togglePin` persists per change in exactly the same way, so **both pickers are affected**; the bottom bar's `commit()` only defers its drag gesture, not its switches.

## The fix

**Publish once the toggles stop, not once per toggle.** The two navigation pickers are the only settings surfaces that write in bursts — a configuring session is a run of discrete taps over ~50 rows, and each one signed, encrypted and published the whole blob to every outbox relay, which on an external signer is an IPC round trip per switch. They now share a 2s debounce, flushed when the screen leaves the composition, when the app stops, and from `onCleared`. The other settings call sites are deliberately untouched: they change one setting at a time, and the published event is that setting's only durable copy, so delaying them would buy nothing and cost durability.

The publisher runs on the account's scope rather than `viewModelScope`, because AndroidX closes `viewModelScope` *before* it invokes `onCleared` (`ViewModel.clear()` closes the keyed closeables, and `viewModelScope` is one of them). A pending publish tied to it would already be cancelled by the time any teardown hook could rescue it. The account's scope is cancelled only when the account is removed, so a pending edit simply completes across an account switch or an Activity teardown.

**Wait for the clock rather than stamping the future.** One second is the real floor on how often an address can be replaced, so a client that replaces one faster has to wait rather than invent a timestamp. `awaitCreatedAtToSupersede` suspends until the second the previous version claimed has passed, then stamps the real time: the new version still wins, and no event is ever dated ahead of the clock. The wait is bounded by `MAX_SUPERSEDE_WAIT_SECONDS` — a version further ahead than that came from another device's skewed clock rather than this client's own burst, and sleeping it out could take hours, so past the bound out-stamping is still the only way to supersede.

It lives in quartz next to `supersedes`: that function decides who wins an address, this one says what a new version must stamp in order to be that winner. The same rule was already written out twice in the app (`RoomParticipantActions`, `AppRecommendationsState`), each with its own comment re-deriving the same NIP-01 argument. `AppRecommendationsState` and the settings blob use the waiting form, since both can accumulate drift across repeated edits and both already suspend under a mutex. `RoomParticipantActions` keeps the non-suspending form — it is reached from Compose click handlers, and its stamp derives from the single event being acted on, so it sits at most one second ahead and cannot drift.

**Stop reporting cancellation as a signer failure.** `java.util.concurrent.CancellationException` extends `IllegalStateException`, so the trailing `catch (e: IllegalStateException)` in the signer error reporter was swallowing every cancelled signer coroutine and toasting it as "signer not found" with the raw exception text. Latent since that arm was written — nothing cancelled those jobs — but the debounce cancels a superseded publish on every rapid edit, which made it fire on essentially every fast toggle. Swallowing it also meant cancellation never propagated.

## Testing

### Automated

| Suite | Covers |
| --- | --- |
| `AwaitCreatedAtToSupersedeTest` (quartz) | waits out the claimed second instead of stamping ahead; a five-deep burst never runs ahead of the clock; no wait when the clock is already past; out-stamps a version too far ahead to wait out |
| `NextCreatedAtToSupersedeTest` (quartz) | the non-suspending rule kept for callers that cannot suspend |
| `AppSpecificDataRepublishTest` (amethyst) | against the real `LocalCache`: a same-second republish is dropped, a stamped one lands |
| `DebouncedPublisherTest` (amethyst) | a burst publishes once, spaced edits publish separately, flush skips the wait, double-flush does not double-publish, a pending publish dies with the scope it was launched on |

Full `:amethyst` unit suite and `:quartz:jvmTest` pass; `spotlessCheck` clean.

### Manual, on a Pixel 9a (Android 17)

Instrumented the publish path end to end and ran the same test on both branches — flip switches in Settings → Side Menu at a normal tapping pace, force-stop, reopen.

| | before | after |
| --- | --- | --- |
| Toggles | 16 | 23 |
| Events signed | 16 | 3 |
| Rejected by the cache | **7** | **0** |
| Persisted | 9 | 3 |

Before, every rejected event shared its `created_at` with the one immediately preceding it, and no collector or persist step followed it — the edit existed nowhere.

After, the set the UI ended on, the set that was published, and the set restored after the cold start were byte-identical:

```
BADGES BLOSSOM_DATA BOOKMARKS CALENDARS COMMUNITIES DISCOVER EMOJI_PACKS
FAVORITE_ALGO_FEEDS FOLLOW_PACKS INTEREST_SETS LONGS MESSAGES MUSIC_PLAYLISTS
MUSIC_TRACKS NAPPLETS NOTIFICATIONS PICTURES PODCASTS RELAY_GROUPS SHORTS
SOFTWARE_APPS WEB_BOOKMARKS
```

Every published event carried the true wall-clock second — with the debounce in place the sub-second path never ran, so nothing was future-dated even before the waiting change landed. No decrypt or decode failures, and no signer toast under fast clicking.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
