### PR TITLE
Parse bracketed NIP-19 entities and fix token refresh race

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProvider.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProvider.kt
@@ -139,6 +139,15 @@ class BlossomReadAuthTokenProvider(
                 if (header != null) {
                     cache[host] = CachedToken(header, clock() + CACHE_TTL_MS)
                 }
+
+                // Retire the entry *before* completing it. `invokeOnCompletion` fires when the
+                // job ends, which is after `complete()` resumes the awaiting caller — so a
+                // caller that returned from `header()` could come straight back, find this
+                // finished deferred still in the map, and be handed its already-signed token
+                // instead of signing a new one. A caller whose token has just expired does
+                // exactly that, and got the expired token back for as long as the window
+                // lasted — [refreshesAfterExpiry] closes it immediately and so hit it every run.
+                inFlight.remove(host, fresh)
                 fresh.complete(header)
             }.invokeOnCompletion {
                 inFlight.remove(host, fresh)

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProviderTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProviderTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -114,14 +115,28 @@ class BlossomReadAuthTokenProviderTest {
     fun refreshesAfterExpiry() =
         runBlocking {
             var now = 0L
-            val provider = BlossomReadAuthTokenProvider({ signer }, scope, clock = { now })
+            var lookups = 0
+            val provider =
+                BlossomReadAuthTokenProvider({
+                    lookups++
+                    signer
+                }, scope, clock = { now })
 
-            val first = provider.header(host)
+            assertNotNull(provider.header(host))
+            assertEquals("the first call must sign", 1, lookups)
+
             now += 56L * 60L * 1000L
             assertNull("token must be gone from the pure read once expired", provider.cachedHeader(host))
-            val second = provider.header(host)
 
-            assertNotEquals("an expired token must be re-signed", first, second)
+            // Counts signatures rather than comparing the two headers: the injected [clock] only
+            // drives the cache TTL, while the signed BlossomAuthorizationEvent takes its
+            // `created_at` from the real wall clock (TimeUtils.now()). Both signings land in the
+            // same second on any quick machine, so the two events — and therefore their ids, sigs
+            // and headers — are byte-identical, and an assertNotEquals on them fails even though
+            // the token was correctly re-signed. The signer is only ever consulted on a real
+            // signing pass (a cache hit returns before it), so this counter says exactly that.
+            assertNotNull(provider.header(host))
+            assertEquals("an expired token must be re-signed", 2, lookups)
         }
 
     @Test

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -261,13 +261,26 @@ class RichTextParser {
 
             // split() behaves like `line.split(' ')`, but keeps math spans
             // (`$...$`, `$$...$$`) whole instead of tearing them at internal spaces.
-            val segments =
-                MathParser.split(paragraph.trimEnd()).map { token ->
-                    when (token) {
-                        is MathParser.Token.Math -> MathSegment(token.raw, token.latex, token.displayMode, token.leading, token.trailing)
-                        is MathParser.Token.Word -> wordIdentifier(token.text, images, videos, pdfs, urls, emojis, tags)
+            val tokens = MathParser.split(paragraph.trimEnd())
+            val segments = ArrayList<Segment>(tokens.size)
+
+            tokens.forEach { token ->
+                when (token) {
+                    is MathParser.Token.Math -> segments.add(MathSegment(token.raw, token.latex, token.displayMode, token.leading, token.trailing))
+                    is MathParser.Token.Word -> {
+                        // An opening bracket or quote glued to the front of a NIP-19 entity becomes
+                        // its own word, so wordIdentifier can still see the scheme. See
+                        // [nip19OpeningPunctuationLength].
+                        val prefixLength = nip19OpeningPunctuationLength(token.text)
+                        if (prefixLength > 0) {
+                            segments.add(RegularTextSegment(token.text.substring(0, prefixLength)))
+                            segments.add(wordIdentifier(token.text.substring(prefixLength), images, videos, pdfs, urls, emojis, tags))
+                        } else {
+                            segments.add(wordIdentifier(token.text, images, videos, pdfs, urls, emojis, tags))
+                        }
                     }
                 }
+            }
 
             paragraphSegments.add(ParagraphState(segments.toPersistentList(), isRTL))
         }
@@ -614,19 +627,53 @@ class RichTextParser {
             }
         }
 
-        fun startsWithNIP19Scheme(word: String): Boolean {
-            if (word.isEmpty()) return false
-            return if (word[0] == 'n' || word[0] == 'N') {
-                if (word.startsWith("nostr:n") || word.startsWith("NOSTR:N")) {
-                    acceptedNIP19schemes.any { word.startsWith(it, 6) }
+        fun startsWithNIP19Scheme(
+            word: String,
+            from: Int = 0,
+        ): Boolean {
+            if (from >= word.length) return false
+            val first = word[from]
+            return if (first == 'n' || first == 'N') {
+                if (word.startsWith("nostr:n", from) || word.startsWith("NOSTR:N", from)) {
+                    acceptedNIP19schemes.any { word.startsWith(it, from + 6) }
                 } else {
-                    acceptedNIP19schemes.any { word.startsWith(it) }
+                    acceptedNIP19schemes.any { word.startsWith(it, from) }
                 }
-            } else if (word[0] == '@') {
-                acceptedNIP19schemes.any { word.startsWith(it, 1) }
+            } else if (first == '@') {
+                acceptedNIP19schemes.any { word.startsWith(it, from + 1) }
             } else {
                 false
             }
+        }
+
+        /**
+         * Brackets and quotes that may open a NIP-19 entity. Only characters that can never be part
+         * of an entity and that a writer would plausibly wrap one in — no trailing punctuation
+         * (that is the entity's `additionalChars`) and no markdown emphasis markers.
+         */
+        private val nip19OpeningPunctuation = charArrayOf('(', '[', '{', '<', '"', '\'', '\u00AB', '\u2039', '\u201C', '\u201E', '\u2018', '\u201A')
+
+        /**
+         * How many leading bracket/quote characters of [word] hide a NIP-19 entity behind them, or
+         * 0 when the word neither starts with such punctuation nor holds an entity right after it.
+         *
+         * [wordIdentifier] can only classify a word by its first character, so `(@npub1...)` and
+         * `"npub1..."` fell through to plain text: the leading `(`/`"` hides the scheme from
+         * [startsWithNIP19Scheme]. Splitting the punctuation into its own word restores it.
+         * Trailing punctuation needs no such help — it is captured as the entity's
+         * `additionalChars` downstream.
+         *
+         * The `nostr:`-prefixed spelling already behaves this way for free: the URL detector finds
+         * the URI inside the parentheses and [fixMissingSpaces] separates it. Bare
+         * `npub1...`/`@npub1...` are not URIs, so nothing splits them; this does.
+         */
+        fun nip19OpeningPunctuationLength(word: String): Int {
+            if (word.isEmpty() || word[0] !in nip19OpeningPunctuation) return 0
+
+            var i = 1
+            while (i < word.length && word[i] in nip19OpeningPunctuation) i++
+
+            return if (startsWithNIP19Scheme(word, i)) i else 0
         }
 
         fun isUrlWithoutScheme(url: String) = noProtocolUrlValidator.matches(url)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -676,7 +676,7 @@ class RichTextParser {
          * the URI inside the parentheses and [fixMissingSpaces] separates it. Bare
          * `npub1...`/`@npub1...` are not URIs, so nothing splits them; this does.
          */
-        fun nip19OpeningPunctuationLength(word: String): Int {
+        private fun nip19OpeningPunctuationLength(word: String): Int {
             if (word.isEmpty() || !isNip19OpeningPunctuation(word[0])) return 0
 
             var i = 1

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -650,8 +650,17 @@ class RichTextParser {
          * Brackets and quotes that may open a NIP-19 entity. Only characters that can never be part
          * of an entity and that a writer would plausibly wrap one in — no trailing punctuation
          * (that is the entity's `additionalChars`) and no markdown emphasis markers.
+         *
+         * A `when` over char literals, not a `CharArray` + `in`: every word of every rendered note
+         * asks this, and almost all of them answer no, which is the case a linear `contains` scan
+         * is slowest at — it compares against all twelve before rejecting. `when` compiles to a
+         * single lookupswitch on the char.
          */
-        private val nip19OpeningPunctuation = charArrayOf('(', '[', '{', '<', '"', '\'', '\u00AB', '\u2039', '\u201C', '\u201E', '\u2018', '\u201A')
+        private fun isNip19OpeningPunctuation(c: Char): Boolean =
+            when (c) {
+                '(', '[', '{', '<', '"', '\'', '\u00AB', '\u2039', '\u201C', '\u201E', '\u2018', '\u201A' -> true
+                else -> false
+            }
 
         /**
          * How many leading bracket/quote characters of [word] hide a NIP-19 entity behind them, or
@@ -668,10 +677,10 @@ class RichTextParser {
          * `npub1...`/`@npub1...` are not URIs, so nothing splits them; this does.
          */
         fun nip19OpeningPunctuationLength(word: String): Int {
-            if (word.isEmpty() || word[0] !in nip19OpeningPunctuation) return 0
+            if (word.isEmpty() || !isNip19OpeningPunctuation(word[0])) return 0
 
             var i = 1
-            while (i < word.length && word[i] in nip19OpeningPunctuation) i++
+            while (i < word.length && isNip19OpeningPunctuation(word[i])) i++
 
             return if (startsWithNIP19Scheme(word, i)) i else 0
         }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserBracketedNip19Test.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserBracketedNip19Test.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RichTextParserBracketedNip19Test {
+    private val npub = "npub1hgvtv4zn2l8l3ef34n87r4sf5s00xq3lhgr3mvwt7kn8gjxpjprqc89jnv"
+
+    private fun words(content: String) = RichTextParser().parseText(content, EmptyTagList, null).paragraphs.flatMap { it.words }
+
+    private fun assertSingleBech(
+        content: String,
+        expectedBech: String,
+    ) {
+        val bechs = words(content).filterIsInstance<BechSegment>()
+        assertEquals(1, bechs.size, "no BechSegment found in `$content`: ${words(content).map { it::class.simpleName to it.segmentText }}")
+        assertEquals(expectedBech, bechs.first().segmentText)
+    }
+
+    @Test
+    fun parsesNpubWrappedInParenthesis() {
+        // kind 1111 event add474916fe55bf90214ab00b7aa10df053dbdcb67fa8cc17e022e88692517b7
+        assertSingleBech("(@$npub)", "@$npub)")
+    }
+
+    @Test
+    fun parsesNpubWrappedInPunctuation() {
+        assertSingleBech("($npub)", "$npub)")
+        assertSingleBech("\"$npub\"", "$npub\"")
+        assertSingleBech("[$npub]", "$npub]")
+        assertSingleBech("{@$npub}", "@$npub}")
+        assertSingleBech("Hello (@$npub), how are you?", "@$npub),")
+    }
+
+    @Test
+    fun keepsTheOpeningPunctuationAsText() {
+        val parsed = words("(@$npub)")
+        assertEquals(2, parsed.size)
+        assertTrue(parsed[0] is RegularTextSegment)
+        assertEquals("(", parsed[0].segmentText)
+    }
+
+    @Test
+    fun doesNotSplitWordsWithoutAnEntity() {
+        val parsed = words("(just a comment)")
+        assertTrue(parsed.all { it is RegularTextSegment })
+        assertEquals("(just a comment)", parsed.joinToString(" ") { it.segmentText })
+    }
+
+    @Test
+    fun stillParsesTheUnwrappedForms() {
+        assertSingleBech(npub, npub)
+        assertSingleBech("@$npub", "@$npub")
+        assertSingleBech("nostr:$npub", "nostr:$npub")
+    }
+}

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/prodbench/RichTextParserBenchmark.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/prodbench/RichTextParserBenchmark.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.prodbench
+
+import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import com.vitorpamplona.amethyst.commons.prodbench.RegexContentBenchmark.Companion.bench
+import com.vitorpamplona.amethyst.commons.prodbench.RegexContentBenchmark.Companion.note
+import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
+import kotlin.test.Test
+
+/**
+ * Measures [RichTextParser.parseText] end to end, and the per-word segmenting loop that every
+ * word of every rendered note walks through.
+ *
+ * Exists to price the opening-bracket peel added for `(@npub1...)`: it adds a check to the hot
+ * loop that runs once per word, so the interesting number is the plain-prose corpus (no
+ * brackets, no entities) where the check can only ever cost and never pay.
+ *
+ * Deterministic and offline. Prints ns/op; no assertions on wall time.
+ */
+class RichTextParserBenchmark {
+    private val parser = RichTextParser()
+
+    private fun parse(content: String) = parser.parseText(content, EmptyTagList, null).paragraphs.sumOf { it.words.size }
+
+    /** Prose with [brackets] parenthesised asides — the shape the peel has to test and reject. */
+    private fun bracketedProse(
+        targetBytes: Int,
+        brackets: Int,
+    ): String {
+        val filler = "A few months ago a nostrich was switching from iOS to Android and asked for suggestions. "
+        val sb = StringBuilder(targetBytes + 4096)
+        var placed = 0
+        val stride = if (brackets > 0) targetBytes / (brackets + 1) else Int.MAX_VALUE
+        while (sb.length < targetBytes) {
+            sb.append(filler)
+            if (placed < brackets && sb.length >= (placed + 1).toLong() * stride) {
+                sb.append("(a parenthesised aside, as one writes) ")
+                placed++
+            }
+        }
+        return sb.toString()
+    }
+
+    /** The kind-1111 comment this peel was added for, padded to [targetBytes] of prose. */
+    private fun bracketedMentions(
+        targetBytes: Int,
+        mentions: Int,
+    ): String {
+        val npub = "npub1hgvtv4zn2l8l3ef34n87r4sf5s00xq3lhgr3mvwt7kn8gjxpjprqc89jnv"
+        val filler = "A few months ago a nostrich was switching from iOS to Android and asked for suggestions. "
+        val sb = StringBuilder(targetBytes + 4096)
+        var placed = 0
+        val stride = if (mentions > 0) targetBytes / (mentions + 1) else Int.MAX_VALUE
+        while (sb.length < targetBytes) {
+            sb.append(filler)
+            if (placed < mentions && sb.length >= (placed + 1).toLong() * stride) {
+                sb.append("(@").append(npub).append(") ")
+                placed++
+            }
+        }
+        while (placed < mentions) {
+            sb.append("(@").append(npub).append(") ")
+            placed++
+        }
+        return sb.toString()
+    }
+
+    @Test
+    fun parseTextScans() {
+        // (bytes, mentions, reps) — same distribution as RegexContentBenchmark.
+        val corpus =
+            listOf(
+                Triple(120, 1, 20_000), // short note
+                Triple(529, 2, 20_000), // MEDIAN of what matchers held
+                Triple(4_000, 5, 5_000), // long note
+                Triple(68_000, 40, 200), // v1.13.0 release notes
+            )
+
+        println("\n=== parseText — plain prose, no entities (pure cost of the per-word check) ===")
+        corpus.forEach { (n, _, r) ->
+            bench("parseText prose", note(n, 0), r) { parse(it) }
+        }
+
+        println("\n=== parseText — prose with parenthesised asides (peel tests, then rejects) ===")
+        corpus.forEach { (n, m, r) ->
+            bench("parseText asides b=$m", bracketedProse(n, m), r) { parse(it) }
+        }
+
+        println("\n=== parseText — nostr: mentions (unchanged path) ===")
+        corpus.forEach { (n, m, r) ->
+            bench("parseText nostr: m=$m", note(n, m), r) { parse(it) }
+        }
+
+        println("\n=== parseText — (@npub1...) mentions (the newly-detected shape) ===")
+        corpus.forEach { (n, m, r) ->
+            bench("parseText (@npub) m=$m", bracketedMentions(n, m), r) { parse(it) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two issues:

1. **Bracketed NIP-19 entities** — `(@npub1...)` and `"npub1..."` were falling through to plain text because the leading punctuation hid the scheme from the parser. Now splits opening brackets/quotes into their own word so the entity is recognized and linked.

2. **Token refresh race in BlossomReadAuthTokenProvider** — A cache entry expired and was removed, but a concurrent caller could find the in-flight deferred still in the map and receive the stale token. Now removes the entry *before* completing the deferred, closing the window.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all tests pass
- [x] Added `RichTextParserBracketedNip19Test` covering the four opening punctuation forms and unwrapped cases
- [x] Added `RichTextParserBenchmark` to measure the per-word check cost (deterministic, offline, prints ns/op)
- [x] Fixed `BlossomReadAuthTokenProviderTest.refreshesAfterExpiry()` to count signer invocations instead of comparing headers (which are byte-identical when signed in the same second)

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01LvZ2ExdLtowAhrdoAnzrvr