### PR TITLE
fix(i18n): unbreak main's lint; publish desktop test reports on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,39 @@ jobs:
             $CMD
           fi
 
+      # This job runs five test suites (:quartz, :commons, :nestsClient, :cli,
+      # :desktopApp) but, unlike test-geode / test-quartz-ios /
+      # test-and-build-android, published nothing when one of them failed. The
+      # console line names the failing test and the exception class and stops
+      # there, so the message is lost with the runner. That is how the
+      # NostrClientNegentropySyncTest failure in run 10540 became
+      # undiagnosable: NegentropySyncException carries a `detail` naming which
+      # branch fired (connect timeout / idle silence / NEG-ERR / disconnect),
+      # and nobody could read it. Same action and pin as the Android job below.
+      - name: Desktop Test Report
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+        if: always()
+        with:
+          report_paths: '**/build/test-results/**/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: true
+          fail_on_failure: true
+
+      # The HTML reports carry the full stack traces and stdout/stderr the
+      # annotations truncate. Named per-OS because the three matrix legs upload
+      # into the same run and artifact names must be unique.
+      - name: Upload Desktop Test Reports
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: Desktop Test Reports (${{ matrix.os }})
+          path: |
+            quartz/build/reports/tests
+            commons/build/reports/tests
+            nestsClient/build/reports/tests
+            cli/build/reports/tests
+            desktopApp/build/reports/tests
+
       # jpackage pins libicu to the build host's version (libicu74 on
       # ubuntu-24.04). Rewrite the .deb so testers on other Debian/Ubuntu
       # releases can install the uploaded artifact.

--- a/amethyst/src/main/res/values-ar-rSA/strings.xml
+++ b/amethyst/src/main/res/values-ar-rSA/strings.xml
@@ -3034,7 +3034,6 @@
     <string name="relay_members_removed">تمت إزالة %1$d أعضاء من الـ relay</string>
     <string name="relay_join_request">طلب الانضمام إلى relay</string>
     <string name="relay_leave_request">طلب مغادرة relay</string>
-    <string name="ai_writing_help">مساعدة الذكاء الاصطناعي في الكتابة</string>
     <string name="ai_writing_setting_title">اقتراح تحسينات النص</string>
     <string name="ai_writing_setting_description">يستخدم نموذج ذكاء اصطناعي على الجهاز لاقتراح تصحيحات نصية وتغييرات في النبرة.</string>
     <string name="tracked_broadcasts_setting_title">البث المتتبَّع</string>
@@ -3052,8 +3051,6 @@
     <string name="ai_tone_elaborate">توسيع</string>
     <string name="ai_tone_friendly">ودّي</string>
     <string name="ai_tone_professional">احترافي</string>
-    <string name="ai_tone_more_direct">أكثر مباشرة</string>
-    <string name="ai_tone_punchy">قوي ومؤثر</string>
     <string name="ai_tone_emojify">+ إيموجي</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">حزم الإيموجي</string>

--- a/amethyst/src/main/res/values-bn-rBD/strings.xml
+++ b/amethyst/src/main/res/values-bn-rBD/strings.xml
@@ -2918,7 +2918,6 @@
     <string name="relay_members_removed">Relay থেকে %1$d জন সদস্য সরানো হয়েছে</string>
     <string name="relay_join_request">Relay যোগ দেওয়ার অনুরোধ</string>
     <string name="relay_leave_request">Relay ছেড়ে যাওয়ার অনুরোধ</string>
-    <string name="ai_writing_help">AI লেখার সহায়তা</string>
     <string name="ai_writing_setting_title">পাঠ্য উন্নতির প্রস্তাব দিন</string>
     <string name="ai_writing_setting_description">পাঠ্য সংশোধন এবং সুরের পরিবর্তন প্রস্তাব করতে ডিভাইসে AI মডেল ব্যবহার করে।</string>
     <string name="tracked_broadcasts_setting_title">ট্র্যাকড সম্প্রচার</string>
@@ -2936,8 +2935,6 @@
     <string name="ai_tone_elaborate">বিস্তারিত</string>
     <string name="ai_tone_friendly">বন্ধুত্বপূর্ণ</string>
     <string name="ai_tone_professional">পেশাদার</string>
-    <string name="ai_tone_more_direct">আরো সরাসরি</string>
-    <string name="ai_tone_punchy">প্রভাবশালী</string>
     <string name="ai_tone_emojify">+ ইমোজি</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">ইমোজি প্যাক</string>

--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -4727,7 +4727,6 @@
     <string name="relay_members_removed">%1$d členů odebráno z relé</string>
     <string name="relay_join_request">Žádost o připojení k relé</string>
     <string name="relay_leave_request">Žádost o opuštění relé</string>
-    <string name="ai_writing_help">Asistent psaní s AI</string>
     <string name="ai_writing_setting_title">Navrhovat vylepšení textu</string>
     <string name="ai_writing_setting_description">Používá AI model běžící v zařízení k navrhování oprav textu a změn tónu.</string>
     <string name="tracked_broadcasts_setting_title">Sledovaná vysílání</string>
@@ -4850,8 +4849,6 @@
     <string name="ai_tone_elaborate">Rozvést</string>
     <string name="ai_tone_friendly">Přátelský</string>
     <string name="ai_tone_professional">Profesionální</string>
-    <string name="ai_tone_more_direct">Přímější</string>
-    <string name="ai_tone_punchy">Úderný</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji balíčky</string>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -4539,7 +4539,6 @@
     <string name="relay_members_removed">%1$d Mitglieder aus Relay entfernt</string>
     <string name="relay_join_request">Relay-Beitrittsanfrage</string>
     <string name="relay_leave_request">Relay-Austrittsanfrage</string>
-    <string name="ai_writing_help">KI-Schreibhilfe</string>
     <string name="ai_writing_setting_title">Textverbesserungen vorschlagen</string>
     <string name="ai_writing_setting_description">Verwendet ein KI-Modell auf dem Gerät, um Textkorrekturen und Tonänderungen vorzuschlagen.</string>
     <string name="tracked_broadcasts_setting_title">Verfolgte Übertragungen</string>
@@ -4644,8 +4643,6 @@
     <string name="ai_tone_elaborate">Ausführen</string>
     <string name="ai_tone_friendly">Freundlich</string>
     <string name="ai_tone_professional">Professionell</string>
-    <string name="ai_tone_more_direct">Direkter</string>
-    <string name="ai_tone_punchy">Prägnant</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji-Pakete</string>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -4600,7 +4600,6 @@ anz der Bedingungen ist erforderlich</string>
     
 <string name="relay_leave_request">Relay-Austrittsanfrage</string>
     
-<string name="ai_writing_help">KI-Schreibhilfe</string>
     
 <string name="ai_writing_setting_title">Textverbesserungen vorschlagen</string>
     
@@ -4636,9 +4635,7 @@ anz der Bedingungen ist erforderlich</string>
     
 <string name="ai_tone_professional">Professionell</string>
     
-<string name="ai_tone_more_direct">Direkter</string>
     
-<string name="ai_tone_punchy">Prägnant</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-el-rGR/strings.xml
+++ b/amethyst/src/main/res/values-el-rGR/strings.xml
@@ -2862,7 +2862,6 @@
     <string name="relay_members_removed">%1$d μέλη αφαιρέθηκαν από το relay</string>
     <string name="relay_join_request">Αίτηση συμμετοχής σε relay</string>
     <string name="relay_leave_request">Αίτηση αποχώρησης από relay</string>
-    <string name="ai_writing_help">Βοήθεια Συγγραφής AI</string>
     <string name="ai_writing_setting_title">Πρόταση βελτιώσεων κειμένου</string>
     <string name="ai_writing_setting_description">Χρησιμοποιεί ένα τοπικό μοντέλο AI για να προτείνει διορθώσεις κειμένου και αλλαγές τόνου.</string>
     <string name="tracked_broadcasts_setting_title">Παρακολουθούμενες μεταδόσεις</string>
@@ -2880,8 +2879,6 @@
     <string name="ai_tone_elaborate">Επεξεργασία</string>
     <string name="ai_tone_friendly">Φιλικό</string>
     <string name="ai_tone_professional">Επαγγελματικό</string>
-    <string name="ai_tone_more_direct">Πιο Άμεσο</string>
-    <string name="ai_tone_punchy">Δυναμικό</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Πακέτα Emoji</string>
     <string name="emoji_pack_management_title">Προσθήκη στη Λίστα Emoji</string>

--- a/amethyst/src/main/res/values-eo-rUY/strings.xml
+++ b/amethyst/src/main/res/values-eo-rUY/strings.xml
@@ -2921,7 +2921,6 @@
     <string name="relay_members_removed">%1$d membroj forigitaj el relay</string>
     <string name="relay_join_request">Peto pri aliĝo al relay</string>
     <string name="relay_leave_request">Peto pri foriro el relay</string>
-    <string name="ai_writing_help">Helpo pri AI-Skribado</string>
     <string name="ai_writing_setting_title">Proponi tekstajn plibonigojn</string>
     <string name="ai_writing_setting_description">Uzas aparatan AI-modelon por proponi tekstajn korektojn kaj tondoŝanĝojn.</string>
     <string name="tracked_broadcasts_setting_title">Spurataj dissendoj</string>
@@ -2939,8 +2938,6 @@
     <string name="ai_tone_elaborate">Plidetali</string>
     <string name="ai_tone_friendly">Amika</string>
     <string name="ai_tone_professional">Profesia</string>
-    <string name="ai_tone_more_direct">Pli Rekta</string>
-    <string name="ai_tone_punchy">Trafa</string>
     <string name="ai_tone_emojify">+ Emodžio</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emodžio-Pakaj</string>

--- a/amethyst/src/main/res/values-eo/strings.xml
+++ b/amethyst/src/main/res/values-eo/strings.xml
@@ -2727,7 +2727,6 @@
 <string name="relay_members_removed">%1$d membroj forigitaj el relay</string>
 <string name="relay_join_request">Peto pri aliĝo al relay</string>
 <string name="relay_leave_request">Peto pri foriro el relay</string>
-<string name="ai_writing_help">Helpo pri AI-Skribado</string>
 <string name="ai_writing_setting_title">Proponi tekstajn plibonigojn</string>
 <string name="ai_writing_setting_description">Uzas aparatan AI-modelon por proponi tekstajn korektojn kaj tondoŝanĝojn.</string>
 <string name="tracked_broadcasts_setting_title">Spurataj dissendoj</string>
@@ -2745,8 +2744,6 @@
 <string name="ai_tone_elaborate">Plidetali</string>
 <string name="ai_tone_friendly">Amika</string>
 <string name="ai_tone_professional">Profesia</string>
-<string name="ai_tone_more_direct">Pli Rekta</string>
-<string name="ai_tone_punchy">Trafa</string>
 <string name="ai_tone_emojify">+ Emodžio</string>
 <string name="emoji_packs_title">Emodžio-Pakaj</string>
 <string name="emoji_pack_management_title">Aldoni al Emodžio-Listo</string>

--- a/amethyst/src/main/res/values-es-rES/strings.xml
+++ b/amethyst/src/main/res/values-es-rES/strings.xml
@@ -2982,7 +2982,6 @@
     <string name="relay_members_removed">%1$d miembros eliminados del relay</string>
     <string name="relay_join_request">Solicitud de unión al relay</string>
     <string name="relay_leave_request">Solicitud de salida del relay</string>
-    <string name="ai_writing_help">Ayuda de escritura IA</string>
     <string name="ai_writing_setting_title">Proponer mejoras de texto</string>
     <string name="ai_writing_setting_description">Usa un modelo de IA en el dispositivo para proponer correcciones de texto y cambios de tono.</string>
     <string name="tracked_broadcasts_setting_title">Difusiones rastreadas</string>
@@ -3000,8 +2999,6 @@
     <string name="ai_tone_elaborate">Ampliar</string>
     <string name="ai_tone_friendly">Amigable</string>
     <string name="ai_tone_professional">Profesional</string>
-    <string name="ai_tone_more_direct">Más directo</string>
-    <string name="ai_tone_punchy">Contundente</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Paquetes de emojis</string>
     <string name="emoji_pack_management_title">Añadir a la lista de emojis</string>

--- a/amethyst/src/main/res/values-es-rMX/strings.xml
+++ b/amethyst/src/main/res/values-es-rMX/strings.xml
@@ -2973,7 +2973,6 @@
     <string name="relay_members_removed">%1$d miembros eliminados del relay</string>
     <string name="relay_join_request">Solicitud de unión al relay</string>
     <string name="relay_leave_request">Solicitud de salida del relay</string>
-    <string name="ai_writing_help">Ayuda de escritura IA</string>
     <string name="ai_writing_setting_title">Proponer mejoras de texto</string>
     <string name="ai_writing_setting_description">Usa un modelo de IA en el dispositivo para proponer correcciones de texto y cambios de tono.</string>
     <string name="tracked_broadcasts_setting_title">Difusiones rastreadas</string>
@@ -2991,8 +2990,6 @@
     <string name="ai_tone_elaborate">Ampliar</string>
     <string name="ai_tone_friendly">Amigable</string>
     <string name="ai_tone_professional">Profesional</string>
-    <string name="ai_tone_more_direct">Más directo</string>
-    <string name="ai_tone_punchy">Contundente</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Paquetes de emojis</string>
     <string name="emoji_pack_management_title">Añadir a la lista de emojis</string>

--- a/amethyst/src/main/res/values-es-rUS/strings.xml
+++ b/amethyst/src/main/res/values-es-rUS/strings.xml
@@ -2973,7 +2973,6 @@
     <string name="relay_members_removed">%1$d miembros eliminados del relay</string>
     <string name="relay_join_request">Solicitud de unión al relay</string>
     <string name="relay_leave_request">Solicitud de salida del relay</string>
-    <string name="ai_writing_help">Ayuda de escritura IA</string>
     <string name="ai_writing_setting_title">Proponer mejoras de texto</string>
     <string name="ai_writing_setting_description">Usa un modelo de IA en el dispositivo para proponer correcciones de texto y cambios de tono.</string>
     <string name="tracked_broadcasts_setting_title">Difusiones rastreadas</string>
@@ -2991,8 +2990,6 @@
     <string name="ai_tone_elaborate">Ampliar</string>
     <string name="ai_tone_friendly">Amigable</string>
     <string name="ai_tone_professional">Profesional</string>
-    <string name="ai_tone_more_direct">Más directo</string>
-    <string name="ai_tone_punchy">Contundente</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Paquetes de emojis</string>
     <string name="emoji_pack_management_title">Añadir a la lista de emojis</string>

--- a/amethyst/src/main/res/values-es/strings.xml
+++ b/amethyst/src/main/res/values-es/strings.xml
@@ -3027,7 +3027,6 @@
     
 <string name="relay_leave_request">Solicitud de salida del relay</string>
     
-<string name="ai_writing_help">Ayuda de escritura IA</string>
     
 <string name="ai_writing_setting_title">Proponer mejoras de texto</string>
     
@@ -3063,9 +3062,7 @@
     
 <string name="ai_tone_professional">Profesional</string>
     
-<string name="ai_tone_more_direct">Más directo</string>
     
-<string name="ai_tone_punchy">Contundente</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-fa-rIR/strings.xml
+++ b/amethyst/src/main/res/values-fa-rIR/strings.xml
@@ -2933,7 +2933,6 @@
     <string name="relay_members_removed">%1$d عضو از relay حذف شد</string>
     <string name="relay_join_request">درخواست پیوستن به relay</string>
     <string name="relay_leave_request">درخواست خروج از relay</string>
-    <string name="ai_writing_help">کمک نوشتاری هوش مصنوعی</string>
     <string name="ai_writing_setting_title">پیشنهاد بهبود متن</string>
     <string name="ai_writing_setting_description">از یک مدل هوش مصنوعی روی دستگاه برای پیشنهاد اصلاحات متن و تغییر لحن استفاده می‌کند.</string>
     <string name="tracked_broadcasts_setting_title">پخش‌های ردیابی‌شده</string>
@@ -2951,8 +2950,6 @@
     <string name="ai_tone_elaborate">بسط دادن</string>
     <string name="ai_tone_friendly">دوستانه</string>
     <string name="ai_tone_professional">حرفه‌ای</string>
-    <string name="ai_tone_more_direct">مستقیم‌تر</string>
-    <string name="ai_tone_punchy">تأثیرگذار</string>
     <string name="ai_tone_emojify">+ ایموجی</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">بسته‌های ایموجی</string>

--- a/amethyst/src/main/res/values-fa/strings.xml
+++ b/amethyst/src/main/res/values-fa/strings.xml
@@ -3678,7 +3678,6 @@
     
     <string name="relay_leave_request">درخواست خروج از relay</string>
     
-    <string name="ai_writing_help">کمک نوشتاری هوش مصنوعی</string>
     
     <string name="ai_writing_setting_title">پیشنهاد بهبود متن</string>
     
@@ -3714,9 +3713,7 @@
     
     <string name="ai_tone_professional">حرفه‌ای</string>
     
-    <string name="ai_tone_more_direct">مستقیم‌تر</string>
     
-    <string name="ai_tone_punchy">تأثیرگذار</string>
 
     <string name="ai_tone_emojify">+ ایموجی</string>
     

--- a/amethyst/src/main/res/values-fi-rFI/strings.xml
+++ b/amethyst/src/main/res/values-fi-rFI/strings.xml
@@ -2893,7 +2893,6 @@
     <string name="relay_members_removed">%1$d jäsentä poistettu relaylta</string>
     <string name="relay_join_request">Relayn liittymispyyntö</string>
     <string name="relay_leave_request">Relayn poistumispyyntö</string>
-    <string name="ai_writing_help">Tekoälyn kirjoitusapu</string>
     <string name="ai_writing_setting_title">Ehdota tekstiparannuksia</string>
     <string name="ai_writing_setting_description">Käyttää laitteen tekoälymallia ehdottamaan tekstikorjauksia ja sävymuutoksia.</string>
     <string name="tracked_broadcasts_setting_title">Seuratut lähetykset</string>
@@ -2911,8 +2910,6 @@
     <string name="ai_tone_elaborate">Laajenna</string>
     <string name="ai_tone_friendly">Ystävällinen</string>
     <string name="ai_tone_professional">Ammattimainen</string>
-    <string name="ai_tone_more_direct">Suorempi</string>
-    <string name="ai_tone_punchy">Napakka</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji-paketit</string>
     <string name="emoji_pack_management_title">Lisää emoji-listaan</string>

--- a/amethyst/src/main/res/values-fr-rCA/strings.xml
+++ b/amethyst/src/main/res/values-fr-rCA/strings.xml
@@ -2817,7 +2817,6 @@
     <string name="relay_members_removed">%1$d membres retirés du relais</string>
     <string name="relay_join_request">Demande d\'adhésion au relais</string>
     <string name="relay_leave_request">Demande de départ du relais</string>
-    <string name="ai_writing_help">Aide à la rédaction IA</string>
     <string name="ai_writing_setting_title">Proposer des améliorations de texte</string>
     <string name="ai_writing_setting_description">Utilise un modèle IA embarqué pour proposer des corrections de texte et des changements de ton.</string>
     <string name="tracked_broadcasts_setting_title">Diffusions suivies</string>
@@ -2835,8 +2834,6 @@
     <string name="ai_tone_elaborate">Développer</string>
     <string name="ai_tone_friendly">Amical</string>
     <string name="ai_tone_professional">Professionnel</string>
-    <string name="ai_tone_more_direct">Plus direct</string>
-    <string name="ai_tone_punchy">Percutant</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Packs d\'emojis</string>
     <string name="emoji_pack_management_title">Ajouter à la liste d\'emojis</string>

--- a/amethyst/src/main/res/values-fr-rFR/strings.xml
+++ b/amethyst/src/main/res/values-fr-rFR/strings.xml
@@ -3190,7 +3190,6 @@
     <string name="relay_members_removed">%1$d membres retirés du relais</string>
     <string name="relay_join_request">Demande d\'adhésion au relais</string>
     <string name="relay_leave_request">Demande de départ du relais</string>
-    <string name="ai_writing_help">Aide à la rédaction IA</string>
     <string name="ai_writing_setting_title">Proposer des améliorations de texte</string>
     <string name="ai_writing_setting_description">Utilise un modèle IA embarqué pour proposer des corrections de texte et des changements de ton.</string>
     <string name="tracked_broadcasts_setting_title">Diffusions suivies</string>
@@ -3221,8 +3220,6 @@
     <string name="ai_tone_elaborate">Développer</string>
     <string name="ai_tone_friendly">Amical</string>
     <string name="ai_tone_professional">Professionnel</string>
-    <string name="ai_tone_more_direct">Plus direct</string>
-    <string name="ai_tone_punchy">Percutant</string>
     <string name="ai_tone_emojify">+ Émoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Packs d\'emojis</string>

--- a/amethyst/src/main/res/values-fr/strings.xml
+++ b/amethyst/src/main/res/values-fr/strings.xml
@@ -5004,7 +5004,6 @@
     
 <string name="relay_leave_request">Demande de départ du relais</string>
     
-<string name="ai_writing_help">Aide à la rédaction IA</string>
     
 <string name="ai_writing_setting_title">Proposer des améliorations de texte</string>
     
@@ -5040,9 +5039,7 @@
     
 <string name="ai_tone_professional">Professionnel</string>
     
-<string name="ai_tone_more_direct">Plus direct</string>
     
-<string name="ai_tone_punchy">Percutant</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-hi-rIN/strings.xml
+++ b/amethyst/src/main/res/values-hi-rIN/strings.xml
@@ -4540,7 +4540,6 @@
     <string name="relay_members_removed">%1$d सदस्य हटाए गए पुनःप्रसारक से</string>
     <string name="relay_join_request">पुनःप्रसारक से जुडने का अनुरोध</string>
     <string name="relay_leave_request">पुनःप्रसारक से चले जाने का अनुरोध</string>
-    <string name="ai_writing_help">एआई॰ लेखन सहायता</string>
     <string name="ai_writing_setting_title">लेख शोधन प्रस्ताव करें</string>
     <string name="ai_writing_setting_description">यन्त्र स्थित एआई॰ प्रतिरूप का प्रयोग करता है लेख सुधार तथा स्वर परिवर्तन प्रस्तावों के लिए।</string>
     <string name="tracked_broadcasts_setting_title">पदचिह्न युक्त प्रसारण</string>
@@ -4645,8 +4644,6 @@
     <string name="ai_tone_elaborate">विस्तार</string>
     <string name="ai_tone_friendly">मित्रतापूर्ण</string>
     <string name="ai_tone_professional">व्यावसायिक</string>
-    <string name="ai_tone_more_direct">अधिक सीधा</string>
-    <string name="ai_tone_punchy">आघाती</string>
     <string name="ai_tone_emojify">भावचिह्न युक्त</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">भावचिह्न पोटलियाँ</string>

--- a/amethyst/src/main/res/values-hu-rHU/strings.xml
+++ b/amethyst/src/main/res/values-hu-rHU/strings.xml
@@ -4541,7 +4541,6 @@
     <string name="relay_members_removed">%1$d tag el lett távolítva az átjátszóról</string>
     <string name="relay_join_request">Átjátszóhoz való csatlakozás kérése</string>
     <string name="relay_leave_request">Átjátszó elhagyásának kérése</string>
-    <string name="ai_writing_help">Súgó az LLM-alapú íráshoz</string>
     <string name="ai_writing_setting_title">Javaslatok a szöveg javítására</string>
     <string name="ai_writing_setting_description">Az eszközön futó LLM-modell segítségével szövegjavításokkal és hangnemváltoztatásokkal kapcsolatos javaslatokat kaphat.</string>
     <string name="tracked_broadcasts_setting_title">Nyomon követhető közvetítések</string>
@@ -4646,8 +4645,6 @@
     <string name="ai_tone_elaborate">Kidolgozott</string>
     <string name="ai_tone_friendly">Barátságos</string>
     <string name="ai_tone_professional">Szakmai</string>
-    <string name="ai_tone_more_direct">Közvetlenebb</string>
-    <string name="ai_tone_punchy">Erőteljes</string>
     <string name="ai_tone_emojify">+ Emodzsi</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emodzsicsomagok</string>

--- a/amethyst/src/main/res/values-in-rID/strings.xml
+++ b/amethyst/src/main/res/values-in-rID/strings.xml
@@ -2822,7 +2822,6 @@ Seharusnya %3$s</string>
     <string name="relay_members_removed">%1$d anggota dihapus dari relay</string>
     <string name="relay_join_request">Permintaan bergabung relay</string>
     <string name="relay_leave_request">Permintaan keluar relay</string>
-    <string name="ai_writing_help">Bantuan Penulisan AI</string>
     <string name="ai_writing_setting_title">Usulkan perbaikan teks</string>
     <string name="ai_writing_setting_description">Menggunakan model AI di perangkat untuk mengusulkan koreksi teks dan perubahan nada.</string>
     <string name="tracked_broadcasts_setting_title">Siaran terlacak</string>
@@ -2840,8 +2839,6 @@ Seharusnya %3$s</string>
     <string name="ai_tone_elaborate">Elaborasi</string>
     <string name="ai_tone_friendly">Ramah</string>
     <string name="ai_tone_professional">Profesional</string>
-    <string name="ai_tone_more_direct">Lebih Langsung</string>
-    <string name="ai_tone_punchy">Tegas</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Paket Emoji</string>
     <string name="emoji_pack_management_title">Tambah ke Daftar Emoji</string>

--- a/amethyst/src/main/res/values-in/strings.xml
+++ b/amethyst/src/main/res/values-in/strings.xml
@@ -4004,7 +4004,6 @@
     
     <string name="relay_leave_request">Permintaan keluar relay</string>
     
-    <string name="ai_writing_help">Bantuan Penulisan AI</string>
     
     <string name="ai_writing_setting_title">Usulkan perbaikan teks</string>
     
@@ -4040,9 +4039,7 @@
     
     <string name="ai_tone_professional">Profesional</string>
     
-    <string name="ai_tone_more_direct">Lebih Langsung</string>
     
-    <string name="ai_tone_punchy">Tegas</string>
     
     <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-it-rIT/strings.xml
+++ b/amethyst/src/main/res/values-it-rIT/strings.xml
@@ -2859,7 +2859,6 @@
     <string name="relay_members_removed">%1$d membri rimossi dal relay</string>
     <string name="relay_join_request">Richiesta di iscrizione al relay</string>
     <string name="relay_leave_request">Richiesta di uscita dal relay</string>
-    <string name="ai_writing_help">Assistenza Scrittura AI</string>
     <string name="ai_writing_setting_title">Proponi miglioramenti al testo</string>
     <string name="ai_writing_setting_description">Utilizza un modello AI sul dispositivo per proporre correzioni al testo e modifiche al tono.</string>
     <string name="tracked_broadcasts_setting_title">Trasmissioni tracciate</string>
@@ -2877,8 +2876,6 @@
     <string name="ai_tone_elaborate">Approfondisci</string>
     <string name="ai_tone_friendly">Amichevole</string>
     <string name="ai_tone_professional">Professionale</string>
-    <string name="ai_tone_more_direct">Più diretto</string>
-    <string name="ai_tone_punchy">Incisivo</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Pacchetti Emoji</string>
     <string name="emoji_pack_management_title">Aggiungi alla Lista Emoji</string>

--- a/amethyst/src/main/res/values-ja-rJP/strings.xml
+++ b/amethyst/src/main/res/values-ja-rJP/strings.xml
@@ -2877,7 +2877,6 @@
     <string name="relay_members_removed">%1$d 人のメンバーが relay から削除されました</string>
     <string name="relay_join_request">Relay 参加リクエスト</string>
     <string name="relay_leave_request">Relay 退出リクエスト</string>
-    <string name="ai_writing_help">AI ライティングサポート</string>
     <string name="ai_writing_setting_title">テキストの改善を提案</string>
     <string name="ai_writing_setting_description">デバイス上のAIモデルを使用して、テキストの修正やトーンの変更を提案します。</string>
     <string name="tracked_broadcasts_setting_title">追跡ブロードキャスト</string>
@@ -2895,8 +2894,6 @@
     <string name="ai_tone_elaborate">詳しく書く</string>
     <string name="ai_tone_friendly">フレンドリーに</string>
     <string name="ai_tone_professional">プロフェッショナルに</string>
-    <string name="ai_tone_more_direct">より直接的に</string>
-    <string name="ai_tone_punchy">パンチを効かせる</string>
     <string name="ai_tone_emojify">+ 絵文字</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">絵文字パック</string>

--- a/amethyst/src/main/res/values-ja/strings.xml
+++ b/amethyst/src/main/res/values-ja/strings.xml
@@ -4093,7 +4093,6 @@
     
     <string name="relay_leave_request">Relay 退出リクエスト</string>
     
-    <string name="ai_writing_help">AI ライティングサポート</string>
     
     <string name="ai_writing_setting_title">テキストの改善を提案</string>
 
@@ -4129,9 +4128,7 @@
     
     <string name="ai_tone_professional">プロフェッショナルに</string>
     
-    <string name="ai_tone_more_direct">より直接的に</string>
     
-    <string name="ai_tone_punchy">パンチを効かせる</string>
     
     <string name="ai_tone_emojify">+ 絵文字</string>
     

--- a/amethyst/src/main/res/values-ko-rKR/strings.xml
+++ b/amethyst/src/main/res/values-ko-rKR/strings.xml
@@ -2864,7 +2864,6 @@
     <string name="relay_members_removed">Relay에서 %1$d명의 멤버가 제거되었습니다</string>
     <string name="relay_join_request">Relay 가입 요청</string>
     <string name="relay_leave_request">Relay 탈퇴 요청</string>
-    <string name="ai_writing_help">AI 작성 도우미</string>
     <string name="ai_writing_setting_title">텍스트 개선 제안</string>
     <string name="ai_writing_setting_description">기기 내 AI 모델을 사용하여 텍스트 수정 및 톤 변경을 제안합니다.</string>
     <string name="tracked_broadcasts_setting_title">추적된 방송</string>
@@ -2882,8 +2881,6 @@
     <string name="ai_tone_elaborate">자세히</string>
     <string name="ai_tone_friendly">친근하게</string>
     <string name="ai_tone_professional">전문적으로</string>
-    <string name="ai_tone_more_direct">더 직접적으로</string>
-    <string name="ai_tone_punchy">임팩트 있게</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji 팩</string>
     <string name="emoji_pack_management_title">Emoji 목록에 추가</string>

--- a/amethyst/src/main/res/values-lv-rLV/strings.xml
+++ b/amethyst/src/main/res/values-lv-rLV/strings.xml
@@ -2947,7 +2947,6 @@
     <string name="relay_members_removed">%1$d dalībnieki noņemti no relay servera</string>
     <string name="relay_join_request">Relay pievienošanās pieprasījums</string>
     <string name="relay_leave_request">Relay aiziešanas pieprasījums</string>
-    <string name="ai_writing_help">MI rakstīšanas palīdzība</string>
     <string name="ai_writing_setting_title">Piedāvāt teksta uzlabojumus</string>
     <string name="ai_writing_setting_description">Izmanto ierīcē esošu MI modeli, lai piedāvātu teksta labojumus un toņa izmaiņas.</string>
     <string name="tracked_broadcasts_setting_title">Izsekotās pārraides</string>
@@ -2965,8 +2964,6 @@
     <string name="ai_tone_elaborate">Izvērst</string>
     <string name="ai_tone_friendly">Draudzīgi</string>
     <string name="ai_tone_professional">Profesionāli</string>
-    <string name="ai_tone_more_direct">Tiešāk</string>
-    <string name="ai_tone_punchy">Izteiksmīgi</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji pakotnes</string>
     <string name="emoji_pack_management_title">Pievienot emoji sarakstam</string>

--- a/amethyst/src/main/res/values-nl-rBE/strings.xml
+++ b/amethyst/src/main/res/values-nl-rBE/strings.xml
@@ -5057,7 +5057,6 @@
     
 <string name="relay_leave_request">Relay-opzegverzoek</string>
     
-<string name="ai_writing_help">AI-schrijfassistent</string>
     
 <string name="ai_writing_setting_title">Tekstverbeteringen voorstellen</string>
     
@@ -5093,9 +5092,7 @@
     
 <string name="ai_tone_professional">Professioneel</string>
     
-<string name="ai_tone_more_direct">Directer</string>
     
-<string name="ai_tone_punchy">Kort en krachtig</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-nl-rNL/strings.xml
+++ b/amethyst/src/main/res/values-nl-rNL/strings.xml
@@ -4502,7 +4502,6 @@
     <string name="relay_members_removed">%1$d leden verwijderd van relay</string>
     <string name="relay_join_request">Relay-lidmaatschapsverzoek</string>
     <string name="relay_leave_request">Relay-opzegverzoek</string>
-    <string name="ai_writing_help">AI-schrijfassistent</string>
     <string name="ai_writing_setting_title">Tekstverbeteringen voorstellen</string>
     <string name="ai_writing_setting_description">Gebruikt een on-device AI-model om tekstcorrecties en toonwijzigingen voor te stellen.</string>
     <string name="tracked_broadcasts_setting_title">Getrackte uitzendingen</string>
@@ -4607,8 +4606,6 @@
     <string name="ai_tone_elaborate">Uitbreiden</string>
     <string name="ai_tone_friendly">Vriendelijk</string>
     <string name="ai_tone_professional">Professioneel</string>
-    <string name="ai_tone_more_direct">Directer</string>
-    <string name="ai_tone_punchy">Kort en krachtig</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji-pakketten</string>

--- a/amethyst/src/main/res/values-nl/strings.xml
+++ b/amethyst/src/main/res/values-nl/strings.xml
@@ -4350,7 +4350,6 @@
     
 <string name="relay_leave_request">Relay-opzegverzoek</string>
     
-<string name="ai_writing_help">AI-schrijfassistent</string>
     
 <string name="ai_writing_setting_title">Tekstverbeteringen voorstellen</string>
     
@@ -4386,9 +4385,7 @@
     
 <string name="ai_tone_professional">Professioneel</string>
     
-<string name="ai_tone_more_direct">Directer</string>
     
-<string name="ai_tone_punchy">Kort en krachtig</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-pl-rPL/strings.xml
+++ b/amethyst/src/main/res/values-pl-rPL/strings.xml
@@ -4729,7 +4729,6 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <string name="relay_members_removed">%1$d użytkowników usuniętych z transmitera</string>
     <string name="relay_join_request">Prośba o dołączenie do transmitera</string>
     <string name="relay_leave_request">Żądanie opuszczenia transmitera</string>
-    <string name="ai_writing_help">Pomoc w pisaniu z użyciem AI</string>
     <string name="ai_writing_setting_title">Zaproponuj poprawki w tekście</string>
     <string name="ai_writing_setting_description">Używa modelu sztucznej inteligencji wbudowanego w urządzenie, proponując poprawki tekstu i zmiany tonu wypowiedzi.</string>
     <string name="tracked_broadcasts_setting_title">Monitorowane transmisje</string>
@@ -4852,8 +4851,6 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <string name="ai_tone_elaborate">Rozwiń</string>
     <string name="ai_tone_friendly">Przyjazny</string>
     <string name="ai_tone_professional">Profesjonalny</string>
-    <string name="ai_tone_more_direct">Bardziej bezpośredni</string>
-    <string name="ai_tone_punchy">Mocny</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Pakiety emotikonów</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -4537,7 +4537,6 @@
     <string name="relay_members_removed">%1$d membros removidos do relay</string>
     <string name="relay_join_request">Solicitação de entrada no relay</string>
     <string name="relay_leave_request">Solicitação de saída do relay</string>
-    <string name="ai_writing_help">Assistente de escrita com IA</string>
     <string name="ai_writing_setting_title">Sugerir melhorias de texto</string>
     <string name="ai_writing_setting_description">Usa um modelo de IA no dispositivo para sugerir correções de texto e mudanças de tom.</string>
     <string name="tracked_broadcasts_setting_title">Transmissões rastreadas</string>
@@ -4642,8 +4641,6 @@
     <string name="ai_tone_elaborate">Elaborar</string>
     <string name="ai_tone_friendly">Amigável</string>
     <string name="ai_tone_professional">Profissional</string>
-    <string name="ai_tone_more_direct">Mais direto</string>
-    <string name="ai_tone_punchy">Impactante</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Pacotes de emojis</string>

--- a/amethyst/src/main/res/values-pt-rPT/strings.xml
+++ b/amethyst/src/main/res/values-pt-rPT/strings.xml
@@ -2881,7 +2881,6 @@
     <string name="relay_members_removed">%1$d membros removidos do relay</string>
     <string name="relay_join_request">Solicitação de entrada no relay</string>
     <string name="relay_leave_request">Solicitação de saída do relay</string>
-    <string name="ai_writing_help">Assistente de escrita com IA</string>
     <string name="ai_writing_setting_title">Sugerir melhorias de texto</string>
     <string name="ai_writing_setting_description">Usa um modelo de IA no dispositivo para sugerir correções de texto e mudanças de tom.</string>
     <string name="tracked_broadcasts_setting_title">Transmissões rastreadas</string>
@@ -2899,8 +2898,6 @@
     <string name="ai_tone_elaborate">Elaborar</string>
     <string name="ai_tone_friendly">Amigável</string>
     <string name="ai_tone_professional">Profissional</string>
-    <string name="ai_tone_more_direct">Mais direto</string>
-    <string name="ai_tone_punchy">Impactante</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Pacotes de emojis</string>
     <string name="emoji_pack_management_title">Adicionar à lista de emojis</string>

--- a/amethyst/src/main/res/values-ru-rRU/strings.xml
+++ b/amethyst/src/main/res/values-ru-rRU/strings.xml
@@ -2955,7 +2955,6 @@
     <string name="relay_members_removed">%1$d участников удалено из relay</string>
     <string name="relay_join_request">Запрос на вступление в relay</string>
     <string name="relay_leave_request">Запрос на выход из relay</string>
-    <string name="ai_writing_help">Помощь ИИ в написании</string>
     <string name="ai_writing_setting_title">Предлагать улучшения текста</string>
     <string name="ai_writing_setting_description">Использует модель ИИ на устройстве для предложения исправлений текста и изменения тональности.</string>
     <string name="tracked_broadcasts_setting_title">Отслеживаемые трансляции</string>
@@ -2973,8 +2972,6 @@
     <string name="ai_tone_elaborate">Подробнее</string>
     <string name="ai_tone_friendly">Дружелюбно</string>
     <string name="ai_tone_professional">Профессионально</string>
-    <string name="ai_tone_more_direct">Прямее</string>
-    <string name="ai_tone_punchy">Энергично</string>
     <string name="ai_tone_emojify">+ Эмодзи</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Наборы эмодзи</string>

--- a/amethyst/src/main/res/values-ru-rUA/strings.xml
+++ b/amethyst/src/main/res/values-ru-rUA/strings.xml
@@ -2938,7 +2938,6 @@
     <string name="relay_members_removed">%1$d участников удалено из relay</string>
     <string name="relay_join_request">Запрос на вступление в relay</string>
     <string name="relay_leave_request">Запрос на выход из relay</string>
-    <string name="ai_writing_help">Помощь ИИ в написании</string>
     <string name="ai_writing_setting_title">Предлагать улучшения текста</string>
     <string name="ai_writing_setting_description">Использует модель ИИ на устройстве для предложения исправлений текста и изменения тональности.</string>
     <string name="tracked_broadcasts_setting_title">Отслеживаемые трансляции</string>
@@ -2956,8 +2955,6 @@
     <string name="ai_tone_elaborate">Подробнее</string>
     <string name="ai_tone_friendly">Дружелюбно</string>
     <string name="ai_tone_professional">Профессионально</string>
-    <string name="ai_tone_more_direct">Прямее</string>
-    <string name="ai_tone_punchy">Энергично</string>
     <string name="ai_tone_emojify">+ Эмодзи</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Наборы эмодзи</string>

--- a/amethyst/src/main/res/values-ru/strings.xml
+++ b/amethyst/src/main/res/values-ru/strings.xml
@@ -3846,7 +3846,6 @@
     
     <string name="relay_leave_request">Запрос на выход из relay</string>
     
-    <string name="ai_writing_help">Помощь ИИ в написании</string>
     
     <string name="ai_writing_setting_title">Предлагать улучшения текста</string>
     
@@ -3882,9 +3881,7 @@
     
     <string name="ai_tone_professional">Профессионально</string>
     
-    <string name="ai_tone_more_direct">Прямее</string>
     
-    <string name="ai_tone_punchy">Энергично</string>
     
     <string name="ai_tone_emojify">+ Эмодзи</string>
     

--- a/amethyst/src/main/res/values-sl-rSI/strings.xml
+++ b/amethyst/src/main/res/values-sl-rSI/strings.xml
@@ -4727,7 +4727,6 @@ Za podpisovanje se je potrebno prijaviti s privatnim ključem</string>
     <string name="relay_members_removed">%1$d članov odstranjenih iz releja</string>
     <string name="relay_join_request">Prošnja za dostop do releja</string>
     <string name="relay_leave_request">Prošnja za izstop z releja</string>
-    <string name="ai_writing_help">Pomoč za pisanje z umetno inteligenco</string>
     <string name="ai_writing_setting_title">Predlagaj tekstovne izboljšave</string>
     <string name="ai_writing_setting_description">Uporablja model umetne inteligence v napravi za predloge popravkov besedila in spremembe tona.</string>
     <string name="tracked_broadcasts_setting_title">Sledeni prenosi</string>
@@ -4850,8 +4849,6 @@ Za podpisovanje se je potrebno prijaviti s privatnim ključem</string>
     <string name="ai_tone_elaborate">Razloži podrobneje</string>
     <string name="ai_tone_friendly">Prijateljsko</string>
     <string name="ai_tone_professional">Profesionalno</string>
-    <string name="ai_tone_more_direct">Boj direktno</string>
-    <string name="ai_tone_punchy">Udarno</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji paketi</string>

--- a/amethyst/src/main/res/values-sr-rSP/strings.xml
+++ b/amethyst/src/main/res/values-sr-rSP/strings.xml
@@ -2918,7 +2918,6 @@
     <string name="relay_members_removed">%1$d članova uklonjeno iz relay-a</string>
     <string name="relay_join_request">Zahtev za pridruživanje relay-u</string>
     <string name="relay_leave_request">Zahtev za napuštanje relay-a</string>
-    <string name="ai_writing_help">Pomoć AI pri pisanju</string>
     <string name="ai_writing_setting_title">Predloži poboljšanja teksta</string>
     <string name="ai_writing_setting_description">Koristi AI model na uređaju za predlaganje ispravki teksta i promena tona.</string>
     <string name="tracked_broadcasts_setting_title">Praćena emitovanja</string>
@@ -2936,8 +2935,6 @@
     <string name="ai_tone_elaborate">Razradi</string>
     <string name="ai_tone_friendly">Prijateljski</string>
     <string name="ai_tone_professional">Profesionalno</string>
-    <string name="ai_tone_more_direct">Direktnije</string>
-    <string name="ai_tone_punchy">Upečatljivo</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji paketi</string>
     <string name="emoji_pack_management_title">Dodaj na emoji listu</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -4537,7 +4537,6 @@
     <string name="relay_members_removed">%1$d medlemmar borttagna från relä</string>
     <string name="relay_join_request">Begäran om att gå med i relä</string>
     <string name="relay_leave_request">Begäran om att lämna relä</string>
-    <string name="ai_writing_help">AI-skrivhjälp</string>
     <string name="ai_writing_setting_title">Föreslå textförbättringar</string>
     <string name="ai_writing_setting_description">Använder en AI-modell på enheten för att föreslå textkorrigeringar och tonändringar.</string>
     <string name="tracked_broadcasts_setting_title">Spårade sändningar</string>
@@ -4642,8 +4641,6 @@
     <string name="ai_tone_elaborate">Utveckla</string>
     <string name="ai_tone_friendly">Vänlig</string>
     <string name="ai_tone_professional">Professionell</string>
-    <string name="ai_tone_more_direct">Mer direkt</string>
-    <string name="ai_tone_punchy">Slagkraftig</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji-paket</string>

--- a/amethyst/src/main/res/values-sw/strings.xml
+++ b/amethyst/src/main/res/values-sw/strings.xml
@@ -2900,7 +2900,6 @@
     <string name="relay_members_removed">%1$d wanachama wameondolewa kutoka relay</string>
     <string name="relay_join_request">Ombi la kujiunga na relay</string>
     <string name="relay_leave_request">Ombi la kuacha relay</string>
-    <string name="ai_writing_help">Msaada wa Uandishi wa AI</string>
     <string name="ai_writing_setting_title">Pendekeza maboresho ya maandishi</string>
     <string name="ai_writing_setting_description">Hutumia mfano wa AI uliopo kwenye kifaa kupendekeza marekebisho ya maandishi na mabadiliko ya sauti.</string>
     <string name="tracked_broadcasts_setting_title">Matangazo yanayofuatiliwa</string>
@@ -2918,8 +2917,6 @@
     <string name="ai_tone_elaborate">Panua</string>
     <string name="ai_tone_friendly">Kirafiki</string>
     <string name="ai_tone_professional">Kitaalamu</string>
-    <string name="ai_tone_more_direct">Zaidi ya Moja kwa Moja</string>
-    <string name="ai_tone_punchy">Chenye Nguvu</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Pakiti za Emoji</string>
     <string name="emoji_pack_management_title">Ongeza kwenye Orodha ya Emoji</string>

--- a/amethyst/src/main/res/values-ta-rIN/strings.xml
+++ b/amethyst/src/main/res/values-ta-rIN/strings.xml
@@ -2888,7 +2888,6 @@
     <string name="relay_members_removed">%1$d உறுப்பினர்கள் relay-லிருந்து நீக்கப்பட்டனர்</string>
     <string name="relay_join_request">Relay சேரும் கோரிக்கை</string>
     <string name="relay_leave_request">Relay விலகும் கோரிக்கை</string>
-    <string name="ai_writing_help">AI எழுத்து உதவி</string>
     <string name="ai_writing_setting_title">உரை மேம்பாடுகளை பரிந்துரை செய்யவும்</string>
     <string name="ai_writing_setting_description">உரை திருத்தங்கள் மற்றும் தொனி மாற்றங்களை பரிந்துரைக்க சாதனத்திலுள்ள AI மாதிரியை பயன்படுத்துகிறது.</string>
     <string name="tracked_broadcasts_setting_title">கண்காணிக்கப்பட்ட ஒளிபரப்புகள்</string>
@@ -2906,8 +2905,6 @@
     <string name="ai_tone_elaborate">விரிவாக்கு</string>
     <string name="ai_tone_friendly">நட்புடன்</string>
     <string name="ai_tone_professional">தொழில்முறை</string>
-    <string name="ai_tone_more_direct">நேரடியாக</string>
-    <string name="ai_tone_punchy">சுறுசுறுப்பான</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji தொகுப்புகள்</string>
     <string name="emoji_pack_management_title">Emoji பட்டியலில் சேர்</string>

--- a/amethyst/src/main/res/values-ta/strings.xml
+++ b/amethyst/src/main/res/values-ta/strings.xml
@@ -2727,7 +2727,6 @@
 <string name="relay_members_removed">%1$d உறுப்பினர்கள் relay-லிருந்து நீக்கப்பட்டனர்</string>
 <string name="relay_join_request">Relay சேரும் கோரிக்கை</string>
 <string name="relay_leave_request">Relay விலகும் கோரிக்கை</string>
-<string name="ai_writing_help">AI எழுத்து உதவி</string>
 <string name="ai_writing_setting_title">உரை மேம்பாடுகளை பரிந்துரை செய்யவும்</string>
 <string name="ai_writing_setting_description">உரை திருத்தங்கள் மற்றும் தொனி மாற்றங்களை பரிந்துரைக்க சாதனத்திலுள்ள AI மாதிரியை பயன்படுத்துகிறது.</string>
 <string name="tracked_broadcasts_setting_title">கண்காணிக்கப்பட்ட ஒளிபரப்புகள்</string>
@@ -2745,8 +2744,6 @@
 <string name="ai_tone_elaborate">விரிவாக்கு</string>
 <string name="ai_tone_friendly">நட்புடன்</string>
 <string name="ai_tone_professional">தொழில்முறை</string>
-<string name="ai_tone_more_direct">நேரடியாக</string>
-<string name="ai_tone_punchy">சுறுசுறுப்பான</string>
 <string name="ai_tone_emojify">+ Emoji</string>
 <string name="emoji_packs_title">Emoji தொகுப்புகள்</string>
 <string name="emoji_pack_management_title">Emoji பட்டியலில் சேர்</string>

--- a/amethyst/src/main/res/values-th-rTH/strings.xml
+++ b/amethyst/src/main/res/values-th-rTH/strings.xml
@@ -2725,7 +2725,6 @@
     <string name="relay_members_removed">ลบ %1$d สมาชิกออกจาก relay แล้ว</string>
     <string name="relay_join_request">คำขอเข้าร่วม Relay</string>
     <string name="relay_leave_request">คำขอออกจาก Relay</string>
-    <string name="ai_writing_help">ความช่วยเหลือการเขียนด้วย AI</string>
     <string name="ai_writing_setting_title">เสนอการปรับปรุงข้อความ</string>
     <string name="ai_writing_setting_description">ใช้โมเดล AI บนอุปกรณ์เพื่อเสนอการแก้ไขข้อความและการเปลี่ยนแปลงโทนเสียง</string>
     <string name="tracked_broadcasts_setting_title">การออกอากาศที่ติดตาม</string>
@@ -2743,8 +2742,6 @@
     <string name="ai_tone_elaborate">ขยายความ</string>
     <string name="ai_tone_friendly">เป็นกันเอง</string>
     <string name="ai_tone_professional">เป็นมืออาชีพ</string>
-    <string name="ai_tone_more_direct">ตรงไปตรงมามากขึ้น</string>
-    <string name="ai_tone_punchy">กระชับ</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">แพ็ค Emoji</string>
     <string name="emoji_pack_management_title">เพิ่มในรายการ Emoji</string>

--- a/amethyst/src/main/res/values-th/strings.xml
+++ b/amethyst/src/main/res/values-th/strings.xml
@@ -3766,7 +3766,6 @@
     
     <string name="relay_leave_request">คำขอออกจาก Relay</string>
     
-    <string name="ai_writing_help">ความช่วยเหลือการเขียนด้วย AI</string>
     
     <string name="ai_writing_setting_title">เสนอการปรับปรุงข้อความ</string>
     
@@ -3802,9 +3801,7 @@
     
     <string name="ai_tone_professional">เป็นมืออาชีพ</string>
     
-    <string name="ai_tone_more_direct">ตรงไปตรงมามากขึ้น</string>
     
-    <string name="ai_tone_punchy">กระชับ</string>
     
     <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-tr-rTR/strings.xml
+++ b/amethyst/src/main/res/values-tr-rTR/strings.xml
@@ -2901,7 +2901,6 @@
     <string name="relay_members_removed">%1$d üye relay\'den kaldırıldı</string>
     <string name="relay_join_request">Relay katılım isteği</string>
     <string name="relay_leave_request">Relay ayrılma isteği</string>
-    <string name="ai_writing_help">Yapay Zeka Yazma Yardımı</string>
     <string name="ai_writing_setting_title">Metin iyileştirmeleri öner</string>
     <string name="ai_writing_setting_description">Metin düzeltmeleri ve ton değişiklikleri önermek için cihaz üzerindeki bir yapay zeka modeli kullanır.</string>
     <string name="tracked_broadcasts_setting_title">Takip edilen yayınlar</string>
@@ -2919,8 +2918,6 @@
     <string name="ai_tone_elaborate">Detaylandır</string>
     <string name="ai_tone_friendly">Samimi</string>
     <string name="ai_tone_professional">Profesyonel</string>
-    <string name="ai_tone_more_direct">Daha Doğrudan</string>
-    <string name="ai_tone_punchy">Etkili</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji Paketleri</string>
     <string name="emoji_pack_management_title">Emoji Listesine Ekle</string>

--- a/amethyst/src/main/res/values-tr/strings.xml
+++ b/amethyst/src/main/res/values-tr/strings.xml
@@ -4282,7 +4282,6 @@
     
     <string name="relay_leave_request">Relay ayrılma isteği</string>
     
-    <string name="ai_writing_help">Yapay Zeka Yazma Yardımı</string>
     
     <string name="ai_writing_setting_title">Metin iyileştirmeleri öner</string>
     
@@ -4318,9 +4317,7 @@
     
     <string name="ai_tone_professional">Profesyonel</string>
     
-    <string name="ai_tone_more_direct">Daha Doğrudan</string>
     
-    <string name="ai_tone_punchy">Etkili</string>
     
     <string name="ai_tone_emojify">+ Emoji</string>
     

--- a/amethyst/src/main/res/values-uk-rUA/strings.xml
+++ b/amethyst/src/main/res/values-uk-rUA/strings.xml
@@ -2944,7 +2944,6 @@
     <string name="relay_members_removed">%1$d учасників видалено з relay</string>
     <string name="relay_join_request">Запит на вступ до relay</string>
     <string name="relay_leave_request">Запит на вихід з relay</string>
-    <string name="ai_writing_help">Допомога AI з написанням</string>
     <string name="ai_writing_setting_title">Пропонувати вдосконалення тексту</string>
     <string name="ai_writing_setting_description">Використовує AI-модель на пристрої для пропозиції виправлень тексту та зміни тону.</string>
     <string name="tracked_broadcasts_setting_title">Відстежувані трансляції</string>
@@ -2962,8 +2961,6 @@
     <string name="ai_tone_elaborate">Розгорнути</string>
     <string name="ai_tone_friendly">Дружній</string>
     <string name="ai_tone_professional">Професійний</string>
-    <string name="ai_tone_more_direct">Більш прямий</string>
-    <string name="ai_tone_punchy">Влучний</string>
     <string name="ai_tone_emojify">+ Емодзі</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Пакети емодзі</string>

--- a/amethyst/src/main/res/values-uk/strings.xml
+++ b/amethyst/src/main/res/values-uk/strings.xml
@@ -4091,7 +4091,6 @@
     
     <string name="relay_leave_request">Запит на вихід з relay</string>
     
-    <string name="ai_writing_help">Допомога AI з написанням</string>
     
     <string name="ai_writing_setting_title">Пропонувати вдосконалення тексту</string>
     
@@ -4127,9 +4126,7 @@
     
     <string name="ai_tone_professional">Професійний</string>
     
-    <string name="ai_tone_more_direct">Більш прямий</string>
     
-    <string name="ai_tone_punchy">Влучний</string>
     
     <string name="ai_tone_emojify">+ Емодзі</string>
     

--- a/amethyst/src/main/res/values-uz-rUZ/strings.xml
+++ b/amethyst/src/main/res/values-uz-rUZ/strings.xml
@@ -2905,7 +2905,6 @@
     <string name="relay_members_removed">%1$d a\'zo relay dan chiqarildi</string>
     <string name="relay_join_request">Relay ga qo\'shilish so\'rovi</string>
     <string name="relay_leave_request">Relay dan chiqish so\'rovi</string>
-    <string name="ai_writing_help">AI yozish yordami</string>
     <string name="ai_writing_setting_title">Matn yaxshilanishlarini taklif qilish</string>
     <string name="ai_writing_setting_description">Matn tuzatishlar va ohang o\'zgarishlarini taklif qilish uchun qurilmadagi AI modelidan foydalanadi.</string>
     <string name="tracked_broadcasts_setting_title">Kuzatilgan translyatsiyalar</string>
@@ -2922,8 +2921,6 @@
     <string name="ai_tone_shorter">Qisqaroq</string>
     <string name="ai_tone_elaborate">Batafsil</string>
     <string name="ai_tone_friendly">Do\'stona</string>
-    <string name="ai_tone_more_direct">To\'g\'riroq</string>
-    <string name="ai_tone_punchy">Ifodali</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji to\'plamlari</string>
     <string name="emoji_pack_management_title">Emoji ro\'yxatiga qo\'shish</string>

--- a/amethyst/src/main/res/values-vi-rVN/strings.xml
+++ b/amethyst/src/main/res/values-vi-rVN/strings.xml
@@ -2846,7 +2846,6 @@
     <string name="relay_members_removed">Đã xóa %1$d thành viên khỏi relay</string>
     <string name="relay_join_request">Yêu cầu tham gia relay</string>
     <string name="relay_leave_request">Yêu cầu rời relay</string>
-    <string name="ai_writing_help">Trợ lý AI viết văn</string>
     <string name="ai_writing_setting_title">Đề xuất cải thiện văn bản</string>
     <string name="ai_writing_setting_description">Sử dụng mô hình AI trên thiết bị để đề xuất sửa lỗi văn bản và thay đổi giọng điệu.</string>
     <string name="tracked_broadcasts_setting_title">Phát sóng có theo dõi</string>
@@ -2864,8 +2863,6 @@
     <string name="ai_tone_elaborate">Mở rộng</string>
     <string name="ai_tone_friendly">Thân thiện</string>
     <string name="ai_tone_professional">Chuyên nghiệp</string>
-    <string name="ai_tone_more_direct">Trực tiếp hơn</string>
-    <string name="ai_tone_punchy">Mạnh mẽ</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Gói Emoji</string>
     <string name="emoji_pack_management_title">Thêm vào danh sách Emoji</string>

--- a/amethyst/src/main/res/values-zh-rCN/strings.xml
+++ b/amethyst/src/main/res/values-zh-rCN/strings.xml
@@ -3795,7 +3795,6 @@
     <string name="relay_members_removed">从中继删除了 %1$d 位成员</string>
     <string name="relay_join_request">中继加入请求</string>
     <string name="relay_leave_request">中继离开请求</string>
-    <string name="ai_writing_help">AI 写入帮助</string>
     <string name="ai_writing_setting_title">建议文本改进</string>
     <string name="ai_writing_setting_description">使用设备上的 AI 模型来提出文本更正和音调更改。</string>
     <string name="tracked_broadcasts_setting_title">已跟踪的广播</string>
@@ -3886,8 +3885,6 @@
     <string name="ai_tone_elaborate">详述</string>
     <string name="ai_tone_friendly">友好</string>
     <string name="ai_tone_professional">专业</string>
-    <string name="ai_tone_more_direct">更直接</string>
-    <string name="ai_tone_punchy">强有力</string>
     <string name="ai_tone_emojify">+ Emoji</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">表情包</string>

--- a/amethyst/src/main/res/values-zh-rHK/strings.xml
+++ b/amethyst/src/main/res/values-zh-rHK/strings.xml
@@ -2914,7 +2914,6 @@
     <string name="relay_members_removed">从中继删除了 %1$d 位成员</string>
     <string name="relay_join_request">中继加入请求</string>
     <string name="relay_leave_request">中继离开请求</string>
-    <string name="ai_writing_help">AI 写入帮助</string>
     <string name="ai_writing_setting_title">建议文本改进</string>
     <string name="ai_writing_setting_description">使用设备上的 AI 模型来提出文本更正和音调更改。</string>
     <string name="tracked_broadcasts_setting_title">已跟踪的广播</string>
@@ -2932,8 +2931,6 @@
     <string name="ai_tone_elaborate">详述</string>
     <string name="ai_tone_friendly">友好</string>
     <string name="ai_tone_professional">专业</string>
-    <string name="ai_tone_more_direct">更直接</string>
-    <string name="ai_tone_punchy">强有力</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">表情包</string>
     <string name="emoji_pack_management_title">添加到表情列表</string>

--- a/amethyst/src/main/res/values-zh-rSG/strings.xml
+++ b/amethyst/src/main/res/values-zh-rSG/strings.xml
@@ -2914,7 +2914,6 @@
     <string name="relay_members_removed">从中继删除了 %1$d 位成员</string>
     <string name="relay_join_request">中继加入请求</string>
     <string name="relay_leave_request">中继离开请求</string>
-    <string name="ai_writing_help">AI 写入帮助</string>
     <string name="ai_writing_setting_title">建议文本改进</string>
     <string name="ai_writing_setting_description">使用设备上的 AI 模型来提出文本更正和音调更改。</string>
     <string name="tracked_broadcasts_setting_title">已跟踪的广播</string>
@@ -2932,8 +2931,6 @@
     <string name="ai_tone_elaborate">详述</string>
     <string name="ai_tone_friendly">友好</string>
     <string name="ai_tone_professional">专业</string>
-    <string name="ai_tone_more_direct">更直接</string>
-    <string name="ai_tone_punchy">强有力</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">表情包</string>
     <string name="emoji_pack_management_title">添加到表情列表</string>

--- a/amethyst/src/main/res/values-zh-rTW/strings.xml
+++ b/amethyst/src/main/res/values-zh-rTW/strings.xml
@@ -2880,7 +2880,6 @@
     <string name="relay_members_removed">%1$d 位成員已從 relay 移除</string>
     <string name="relay_join_request">Relay 加入申請</string>
     <string name="relay_leave_request">Relay 退出申請</string>
-    <string name="ai_writing_help">AI 寫作輔助</string>
     <string name="ai_writing_setting_title">建議文字改進</string>
     <string name="ai_writing_setting_description">使用裝置上的 AI 模型提出文字修正和語氣變更建議。</string>
     <string name="tracked_broadcasts_setting_title">追蹤廣播</string>
@@ -2898,8 +2897,6 @@
     <string name="ai_tone_elaborate">詳述</string>
     <string name="ai_tone_friendly">友善</string>
     <string name="ai_tone_professional">專業</string>
-    <string name="ai_tone_more_direct">更直接</string>
-    <string name="ai_tone_punchy">有力</string>
     <!-- Emoji packs -->
     <string name="emoji_packs_title">Emoji 包</string>
     <string name="emoji_pack_management_title">新增至 Emoji 清單</string>

--- a/amethyst/src/main/res/values-zh/strings.xml
+++ b/amethyst/src/main/res/values-zh/strings.xml
@@ -5496,7 +5496,6 @@
     
 <string name="relay_leave_request">中继离开请求</string>
     
-<string name="ai_writing_help">AI 写入帮助</string>
     
 <string name="ai_writing_setting_title">建议文本改进</string>
     
@@ -5532,9 +5531,7 @@
     
 <string name="ai_tone_professional">专业</string>
     
-<string name="ai_tone_more_direct">更直接</string>
     
-<string name="ai_tone_punchy">强有力</string>
     
 <string name="ai_tone_emojify">+ Emoji</string>
     


### PR DESCRIPTION
Two commits. The second one unbreaks `main`.

## Summary

**`e4d288a9` — fix(i18n): drop three orphaned AI-writing keys from the translations.** `main` is currently red. `6f97faf1` (in #4015) removed `ai_writing_help`, `ai_tone_more_direct` and `ai_tone_punchy` from the default locale when it reworked the restored AI writing helper, but left them in all 55 translated `strings.xml` files. Lint's `ExtraTranslation` reports one error per (key, locale) — 3 × 55 = **165**, exactly the count CI reports — and `:amethyst:lintFdroidBenchmark` fails. Nothing in Kotlin references any of the three, so there is nothing to restore instead. This mirrors `a5e2aae9`, the original removal of these same keys, which touched 56 files: the default locale *and* all 55 translations.

**`f4c452a7` — ci(desktop): publish test reports when the desktop job fails.** `build-desktop` runs five test suites (`:quartz:jvmTest`, `:commons:jvmTest`, `:nestsClient:jvmTest`, `:cli:test`, `:desktopApp:test`) across three OSes and was the only test-running job with no failure reporting — `test-geode`, `test-quartz-ios` and `test-and-build-android` all upload on failure. The motivating case is the macOS leg of [run 10540](https://github.com/vitorpamplona/amethyst/actions/runs/33177554829):

```
NostrClientNegentropySyncTest[jvm] > multiRoundReconcileStreamsEveryEventThrough[jvm] FAILED
    com.vitorpamplona.quartz...NegentropySyncException at NostrClientNegentropySyncTest.kt:146
```

Line 146 is the `runBlocking` frame, so all that survived is "something threw". `NegentropySyncException` carries a `detail` naming which of the four branches fired — connect timeout, idle silence mid-reconcile, `NEG-ERR`, or disconnect — and that string is what distinguishes a real protocol fault from a race lost against a loaded runner. It was unrecoverable, and that failure is still unexplained.

`annotate_only: true` is deliberate (same reasoning as the Android job's comment): it keeps this working under the workflow's `permissions: contents: read` and on fork PRs, where the `GITHUB_TOKEN` is read-only.

## Test plan

### Feature test plan

**The i18n fix — the exact task that failed in CI now passes locally:**

```
$ ./gradlew :amethyst:lintFdroidBenchmark
> Task :amethyst:lintReportFdroidBenchmark
> Task :amethyst:lintFdroidBenchmark
BUILD SUCCESSFUL in 10m 11s
```

Before/after on lint's own predicate (a name declared in a translated `values-*/strings.xml` but absent from default `values/strings.xml`, counted per key × locale):

| | ExtraTranslation errors |
|---|---|
| before | **165** — `ai_writing_help` 55, `ai_tone_more_direct` 55, `ai_tone_punchy` 55 |
| after | **0** |

165 matches CI's "Lint found 165 errors" exactly, which is what confirms the predicate is measuring the same thing lint is. Also verified: all 55 files still parse as XML, the default locale is untouched at 4525 keys, and the diff is exactly `55 files changed, 165 deletions(-)` — 3 lines each, no translated text altered.

**The workflow change** — it can only fire inside Actions, and [run 10578](https://github.com/vitorpamplona/amethyst/actions/runs/33275710102) already exercised the green path on the first commit: all three `build-desktop` legs passed, `Desktop Test Report` succeeded, and `Upload Desktop Test Reports` correctly skipped on a passing run. Locally I verified the step list, order and conditions parse as intended, that `matrix.os` is a real key on every `include` entry so artifact names stay unique across legs, and that the action SHA pin and `report_paths` glob are copied verbatim from the Android job so no new action enters the supply chain.

**Not verified:** that the desktop steps fire on a *red* desktop job — nothing here fails on purpose. Happy to push a throwaway failing test to demonstrate it and then drop the commit, if you want that on the record.

### Regression test plan

Touch points and verification:

- **Full pre-push suite** — `:quartz:jvmTest`, `:commons:jvmTest`, `:nestsClient:jvmTest`, `:quic:jvmTest`, `:amethyst:testPlayDebugUnitTest`, `:cli:test` — could regress if a removed string were actually referenced — verified: hook ran clean, "All test passed."
- **String resource resolution** — a key removed while still referenced would fail the build or crash at runtime — verified: `grep` across all `.kt` finds zero references to any of the three keys; `:amethyst:lintFdroidBenchmark` (which includes `MissingTranslation` and unresolved-resource checks) is green.
- **Other locales' integrity** — a bad regex could eat neighbouring lines or corrupt RTL text — verified: every one of the 55 files parses as XML, and the diff is exactly 3 deletions per file with no other lines touched.
- **`build-desktop` green path** — the new `if: always()` step runs on success too, and could red a passing job via `fail_on_failure` if `report_paths` matched nothing — verified green on all three legs in run 10578.
- **`Relax libicu` / `Upload Desktop Distribution`** — inserted steps precede them, so a new failing step could skip the `.deb` rewrite and artifact upload — verified: both ran and uploaded on the Linux leg in run 10578.
- **Fork PRs under `permissions: contents: read`** — a step needing `checks: write` would break every fork PR — `annotate_only: true` avoids the check-run write, which is why the Android job uses it.

Two environment notes, neither a property of this diff: the full Android build OOMs this container at the repo's default `-Xmx6g`/`-Xmx8g`, so the lint run above used `--no-daemon -Xmx3500m`; and the pre-push hook initially failed writing an HTML report for a test whose name contains an em dash, because this container has `LC_CTYPE=POSIX` (`sun.jnu.encoding=ANSI_X3.4-1968`). That test name predates this work (`45678a09`) and the file is untouched here; re-running the push under `LANG=C.UTF-8` let the hook complete normally. No hook was bypassed.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Per `CONTRIBUTING-WITH-AI.md`: no flavour builds (no Kotlin, manifest, dependency or ProGuard changes; the lint task verified above is the F-Droid variant), no new logic and therefore no unit tests to add, and no protocol surface touched.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.