### PR TITLE
Give Trusted Lists and contact cards their own extractor branches

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.experimental.music.playlist.MusicPlaylistEvent
 import com.vitorpamplona.quartz.experimental.music.track.MusicTrackEvent
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.application.SoftwareApplicationEvent
 import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
+import com.vitorpamplona.quartz.experimental.trustedLists.TrustedListEvent
 import com.vitorpamplona.quartz.feedDefinition.FeedDefinitionEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
@@ -83,6 +84,7 @@ import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefiniti
 import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
 import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
@@ -344,6 +346,38 @@ object SearchFieldExtractor {
 
             is NamedNappletEvent -> {
                 tiers(event, event.title(), event.description(), null)
+            }
+
+            // kinds 30392-30395 -- a Trusted List's title is the ONLY
+            // human-authored text the family carries (`content` is a machine
+            // echo of the membership, the member tags are hex ids, and
+            // `metric`/`d` name the computation), so `indexableContent()` is
+            // exactly `title()`. Without this branch the fallback below put
+            // that title in the TERTIARY tier: a list titled "Verified Human"
+            // matched the words on the same rung as a bio that happens to
+            // mention them, and lost the prefix/typo columns a title gets.
+            is TrustedListEvent -> {
+                tiers(event, event.title(), null, null)
+            }
+
+            // kind 30382 -- a contact card's petname is a trust provider's
+            // NAME for a person, the direct analogue of kind 0's `name`, and
+            // its summary is the description beside it. The encrypted half of
+            // the card stays out, as it always has: petName()/summary() read
+            // the public tag array only, and build() puts both in the NIP-44
+            // content, so a card authored by this library has NO public text
+            // beyond its topics.
+            //
+            // topics() is deliberately absent: it is `TopicTag`, which is the
+            // `t` tag under another name (same predicate, same array), so the
+            // tiers() funnel already carries every topic in the hashtag role.
+            // Passing them again would index the same words twice -- which is
+            // what the fallback below was doing, since indexableContent()
+            // concatenates the topics INTO the body while the funnel added
+            // them as hashtags. Whether that role is tokenized or kept as
+            // keywords is the backend's call, per IndexableFields.
+            is ContactCardEvent -> {
+                tiers(event, event.petName(), event.summary(), null)
             }
 
             is FeedDefinitionEvent -> {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
@@ -21,12 +21,14 @@
 package com.vitorpamplona.quartz.nip50Search
 
 import com.vitorpamplona.quartz.buzz.agentProfiles.AgentProfileEvent
+import com.vitorpamplona.quartz.experimental.trustedLists.users.UserTrustedListEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
+import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
 import kotlin.test.Test
@@ -108,6 +110,76 @@ class SearchFieldExtractorTest {
         val content = """{"name":"CoolApp","about":"an app","website":"https://coolapp.example"}"""
         val fields = SearchFieldExtractor.extract(AppDefinitionEvent("7".repeat(64), alice, 1L, arrayOf(arrayOf("d", "x")), content, ""))
         assertEquals(IndexableFields.Profile(name = "CoolApp", about = "an app", website = "https://coolapp.example"), fields)
+    }
+
+    @Test
+    fun trustedListsDecomposeIntoTheirTitle() {
+        // The title is the whole of indexableContent() for the family, and it
+        // is a title: primary, not the body tier. Everything else the list
+        // carries -- content echo, member tags, metric, d -- stays out.
+        val tags =
+            arrayOf(
+                arrayOf("d", "tl-pin-verified-human"),
+                arrayOf("title", "Verified Human"),
+                arrayOf("metric", "pinned-tag-membership"),
+                arrayOf("p", alice, "", "87"),
+            )
+        val fields = SearchFieldExtractor.extract(UserTrustedListEvent("d".repeat(64), alice, 1L, tags, """{"members":[]}""", ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("Verified Human")), fields)
+    }
+
+    @Test
+    fun titlelessTrustedListsExtractNothing() {
+        // Most machine-published lists have no title. The branch reads title()
+        // directly rather than indexableContent(), so the None comes from the
+        // tiers funnel finding nothing to clean -- not from title() ?: "".
+        val tags = arrayOf(arrayOf("d", "tl-pin-untitled"), arrayOf("p", alice, "", "50"))
+        assertEquals(IndexableFields.None, SearchFieldExtractor.extract(UserTrustedListEvent("e".repeat(64), alice, 1L, tags, "", "")))
+    }
+
+    @Test
+    fun contactCardsDecomposeIntoPetnameSummaryAndTopics() {
+        // A provider's petname for a person is that provider's NAME for them,
+        // so it lands where kind 0's name does. topics() reads `t` tags, so
+        // the tiers() funnel carries them once, as hashtags.
+        val tags =
+            arrayOf(
+                arrayOf("d", alice),
+                arrayOf("petname", "Verified Human"),
+                arrayOf("summary", "vouched by two independent raters"),
+                arrayOf("t", "bitcoin"),
+                arrayOf("rank", "87"),
+            )
+        val fields = SearchFieldExtractor.extract(ContactCardEvent("f".repeat(64), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Verified Human"),
+                secondary = listOf("vouched by two independent raters"),
+                hashtags = listOf("bitcoin"),
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun contactCardsCarryTopicsEvenWithNoPublicPetname() {
+        // THE SHAPE THIS LIBRARY ITSELF PUBLISHES: build() puts petname and
+        // summary in the NIP-44 content, so a card's only public text is its
+        // topics. They must still reach the backend -- through the hashtag
+        // role, once -- and a hashtags-only extraction must not normalize to
+        // None (Tiered.isEmpty() compares against a fully-empty Tiered).
+        val tags = arrayOf(arrayOf("d", alice), arrayOf("t", "bitcoin"), arrayOf("t", "nostr"), arrayOf("rank", "87"))
+        val fields = SearchFieldExtractor.extract(ContactCardEvent("2a".repeat(32), alice, 1L, tags, "encrypted", ""))
+        assertEquals(IndexableFields.Tiered(hashtags = listOf("bitcoin", "nostr")), fields)
+    }
+
+    @Test
+    fun contactCardsWithNoPublicTextExtractNothing() {
+        // The petname and summary of a private card live in the NIP-44
+        // encrypted content, which is never indexed -- so a card carrying only
+        // scores has nothing to search.
+        val tags = arrayOf(arrayOf("d", alice), arrayOf("rank", "87"), arrayOf("followers", "1200"))
+        assertEquals(IndexableFields.None, SearchFieldExtractor.extract(ContactCardEvent("1a".repeat(32), alice, 1L, tags, "encrypted", "")))
     }
 
     @Test


### PR DESCRIPTION
kinds 30392-30395 and 30382 had no branch in SearchFieldExtractor, so
both fell through to the generic `is SearchableEvent ->` case, which puts
the whole of indexableContent() in the TERTIARY (body) tier.

For a Trusted List that whole content IS its title, and a title is not
body text. On a tiered backend the difference is large and measurable: on
search-staging, a 30392 titled exactly "Verified Human" matched the query
`Verified Human` on the same rung as a profile whose bio happens to say
"humans are amazing" - 550 against 130 000 on that schema's ladder, a
236x discount - and reached the title only through trigram substring
rather than the prefix/typo columns a title normally gets.

A contact card decomposes the same way every other kind in this file
does: petname() is a trust provider's NAME for a person - the direct
analogue of kind 0's `name`, and what a people search is looking for -
and summary() is the description beside it.

The card's topics change ROLE, and that is the one behaviour change here.
topics() is TopicTag, which is the `t` tag under another name - same
predicate, same array - so the tiers() funnel already carries every topic
as a hashtag. The old fallback therefore indexed them TWICE, once inside
the concatenated body and once in the hashtag role; they are now carried
once, in the role, and whether that is tokenized or kept as keywords is
the backend's call per IndexableFields. Since build() puts petname and
summary in the NIP-44 content, topics are the only public text on a card
this library authors, so that shape is pinned by its own test - including
that a hashtags-only extraction does not normalize to None.

Nothing else changes what is indexed, only which tier each accessor lands
in. indexableContent() is untouched, so the SQLite and filesystem stores
(the only in-tree consumers, both of which index the flat form) are
bit-identical. SearchFieldExtractor has no in-tree consumer at all - it
is the protocol surface external tiered backends read - so the app, both
flavours, and every feed are unaffected by construction.

The encrypted half of a contact card stays out of the index as before:
petName()/summary() read the public tag array only.