### PR TITLE
Nwc outgoing attribution (NWC-06)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
@@ -139,9 +139,10 @@ class AccountZapActions(
         bolt11: String,
         zappedNote: Note?,
         onTimeout: () -> Unit = {},
+        metadata: Map<String, Any?>? = null,
         onResponse: (Response?) -> Unit,
     ) {
-        val (event, relay) = account.nip47SignerState.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)
+        val (event, relay) = account.nip47SignerState.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, metadata, onResponse)
         account.client.publish(event, setOf(relay))
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -39,6 +39,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentRequestEve
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentResponseEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcNotificationEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PaymentReceivedNotification
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
@@ -167,7 +168,7 @@ class NwcSignerState(
 
     /**
      * Whether this wallet advertises NWC-06 (metadata conventions) and may therefore
-     * be sent a populated `metadata` on `pay_invoice`.
+     * be sent a populated `metadata`.
      *
      * NON-BLOCKING, and "don't know" reads as NO. Both matter: this sits on the
      * payment path, and the only cost of answering false is a history row without a
@@ -179,6 +180,29 @@ class NwcSignerState(
         uri ?: return false
         infoCache?.refreshIfStale(uri)
         return infoCache?.current(uri)?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true
+    }
+
+    /**
+     * Strips NWC-06 `metadata` from a request bound for a wallet that never said it
+     * understands the field.
+     *
+     * APPLIED WHERE THE REQUEST IS BUILT rather than at each call site, because the
+     * cost of forgetting is a refused payment: a wallet that types `metadata`
+     * narrowly accepts a null but cannot decode an object, and answers a params
+     * error instead of paying. Every send path funnels through here, so populating
+     * `metadata` anywhere upstream is safe by construction.
+     *
+     * MUTATES the request in place — see the callers' KDoc. Requests are built per
+     * send and not reused, and stripping a copy would mean rebuilding a params
+     * object whose field list would then drift from the original.
+     *
+     * A method with no metadata returns before the info cache is consulted, so this
+     * costs nothing on the RPCs that can never carry any.
+     */
+    private fun Request.dropMetadataIfUnsupported(walletService: Nip47WalletConnect.Nip47URINorm) {
+        val carrier = metadataCarrier ?: return
+        if (carrier.metadata == null || supportsMetadata(walletService)) return
+        carrier.metadata = null
     }
 
     fun hasWalletConnectSetup(): Boolean = settings.nwcWallets.value.isNotEmpty()
@@ -242,6 +266,10 @@ class NwcSignerState(
 
     /**
      * Sends a generic NIP-47 request to a specific wallet.
+     *
+     * [request] MAY BE MUTATED: NWC-06 `metadata` is stripped in place when the
+     * wallet has not advertised support for it. Build a fresh request per send
+     * rather than retaining or re-reading this one.
      */
     suspend fun sendNwcRequestToWallet(
         walletUri: Nip47WalletConnect.Nip47URINorm?,
@@ -251,6 +279,8 @@ class NwcSignerState(
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = walletUri ?: throw IllegalArgumentException("No NIP47 setup")
         val walletSigner = buildSigner(walletService) ?: signer
+
+        request.dropMetadataIfUnsupported(walletService)
 
         val event = LnZapPaymentRequestEvent.createRequest(request, walletService.pubKeyHex, walletSigner, useNip44 = prefersNip44(walletService))
 
@@ -283,6 +313,9 @@ class NwcSignerState(
 
     /**
      * Sends a zap payment request to the default wallet.
+     *
+     * [metadata] is NWC-06's per-payment blob and is dropped unless the wallet
+     * advertises `06`; see [dropMetadataIfUnsupported].
      */
     suspend fun sendZapPaymentRequestFor(
         bolt11: String,
@@ -293,14 +326,15 @@ class NwcSignerState(
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = defaultWalletUri.value ?: throw IllegalArgumentException("No NIP47 setup")
 
-        // Only forwarded when the wallet advertises NWC-06; see [supportsMetadata].
+        val request = PayInvoiceMethod.create(bolt11, metadata)
+        request.dropMetadataIfUnsupported(walletService)
+
         val event =
-            LnZapPaymentRequestEvent.create(
-                bolt11,
+            LnZapPaymentRequestEvent.createRequest(
+                request,
                 walletService.pubKeyHex,
                 nip47Signer.value,
                 useNip44 = prefersNip44(walletService),
-                metadata = metadata?.takeIf { supportsMetadata(walletService) },
             )
 
         val filter =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -143,38 +143,34 @@ class NwcSignerState(
      * The negotiated encryption preference for a wallet. NIP-47 says a client
      * "should always prefer nip44 if supported by the wallet service", so a false
      * here has to mean "the wallet does not offer NIP-44" — not "we have not asked
-     * yet".
-     *
-     * That distinction is why this waits. The info cache is per-account and held in
-     * memory only, so it starts empty on every app launch, and reading it without
-     * waiting made the first transaction to each wallet after every launch fall
-     * back to NIP-04 even against a wallet advertising `nip44_v2`. Only a cold
-     * cache waits: a stale entry still says what the wallet advertises and is used
-     * as-is while it refreshes in the background.
-     *
-     * The wait is capped, because this sits in front of a payment the user has
-     * already tapped. Its own fetch is bounded only by the relay accessory's 30s
-     * idle window, and the no-response timer below does not start until this
-     * returns. On expiry we send NIP-04 for this one request rather than hold the
-     * tap; the fetch keeps running in the cache's scope, so the next request gets
-     * the negotiated scheme. Never bound the fetch itself instead — a null from it
-     * is cached as a definitive "no info event" for the whole TTL, which would pin
-     * the wallet to NIP-04 for days.
+     * yet". [walletInfo] is what makes that distinction true.
      */
     private fun prefersNip44(info: NwcInfoEvent?): Boolean = info?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } == true
 
     /**
-     * The wallet's advertised capabilities, fetched AT MOST ONCE per send.
+     * The wallet's advertised capabilities: the one place a send waits on them, and
+     * it waits AT MOST ONCE.
      *
-     * Every send asks this event two questions — which encryption to use, and
-     * whether NWC-06 metadata may travel — and each used to fetch it for itself.
-     * That is free on a warm cache and doubles the stall on a cold one, because
-     * [NwcInfoCache] deliberately does not cache a FAILED fetch: when the wallet's
-     * relay is down, both waits run in full. A relay dropping hourly turned a 3s
-     * worst case into 6s, which is what the wallet operator saw as a stall.
+     * WAITING IS THE POINT. The info cache is per-account and in memory only, so it
+     * starts empty on every app launch, and reading it without waiting makes "not
+     * fetched yet" indistinguishable from "not supported". That shipped twice: the
+     * first transaction to each wallet after a launch fell back to NIP-04 against a
+     * wallet advertising `nip44_v2`, and a payment to a wallet that had been
+     * advertising NWC-06 for twenty minutes still went out bare — with nothing, on
+     * either side, reporting an error.
      *
-     * Bounded, and a timeout answers null — the callers treat "don't know" as
-     * NIP-04 and as no-metadata respectively, both of which are safe.
+     * ONCE, because both questions read the same event. Each used to fetch for
+     * itself, which is free on a warm cache and doubles the stall on a cold one:
+     * [NwcInfoCache] deliberately does not cache a FAILED fetch, so with the relay
+     * down both waits ran in full and a 3s worst case became 6s.
+     *
+     * BOUNDED, because this sits in front of a payment the user has already tapped
+     * and the no-response timer does not start until it returns. On expiry the
+     * answer is null — read as NIP-04 and as no-metadata, both of them the safe
+     * direction — while the fetch keeps running in the cache's own scope so the next
+     * request gets the negotiated scheme. Never bound the fetch itself instead: a
+     * null from it is cached as a definitive "no info event" for the whole TTL,
+     * which would pin the wallet to NIP-04 for days.
      */
     private suspend fun walletInfo(uri: Nip47WalletConnect.Nip47URINorm?): NwcInfoEvent? {
         uri ?: return null
@@ -182,48 +178,19 @@ class NwcSignerState(
     }
 
     /**
-     * Whether this wallet advertises NWC-06 (metadata conventions) and may therefore
-     * be sent a populated `metadata`.
-     *
-     * WAITS ON A COLD CACHE, and that is the whole point. The first version paired
-     * [NwcInfoCache.refreshIfStale] — which only *starts* a fetch — with [current],
-     * read immediately after, so a wallet whose info event had not been fetched yet
-     * answered "no" and the payment went out bare. Interop testing against a live
-     * wallet caught it: a pairing whose wallet had been advertising `06` for twenty
-     * minutes still sent no metadata, and nothing anywhere reported an error.
-     *
-     * This is the same trap [currentOrFetch] was written for on the NIP-44 path —
-     * "not fetched yet" is indistinguishable from "not supported" — so it takes the
-     * same remedy, including the bounded wait so a slow relay cannot stall a
-     * payment. A timeout still reads as NO: the cost of that is a history row
-     * without a recipient, whereas a wrong YES to a wallet that types `metadata`
-     * narrowly costs the user a refused payment.
-     *
-     * [currentOrFetch] also kicks a background refresh for an expired entry, so a
-     * wallet that adds the tag later is picked up without any user action.
-     */
-    private fun supportsMetadata(info: NwcInfoEvent?): Boolean = info?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true
-
-    /**
      * Strips NWC-06 `metadata` from a request bound for a wallet that never said it
-     * understands the field.
+     * understands the field — [MetadataCarrying] has the reason that matters.
      *
-     * APPLIED WHERE THE REQUEST IS BUILT rather than at each call site, because the
-     * cost of forgetting is a refused payment: a wallet that types `metadata`
-     * narrowly accepts a null but cannot decode an object, and answers a params
-     * error instead of paying. Every send path funnels through here, so populating
+     * APPLIED WHERE THE REQUEST IS BUILT rather than at each call site, so populating
      * `metadata` anywhere upstream is safe by construction.
      *
      * MUTATES the request in place — see the callers' KDoc. Requests are built per
-     * send and not reused, and stripping a copy would mean rebuilding a params
-     * object whose field list would then drift from the original.
-     *
-     * A method with no metadata returns before the info cache is consulted, so this
-     * costs nothing on the RPCs that can never carry any.
+     * send and not reused, and stripping a copy would mean rebuilding a params object
+     * whose field list would then drift from the original.
      */
     private fun Request.dropMetadataIfUnsupported(info: NwcInfoEvent?) {
         val carrier = metadataCarrier ?: return
-        if (carrier.metadata == null || supportsMetadata(info)) return
+        if (carrier.metadata == null || info?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true) return
         carrier.metadata = null
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.cache.NostrWalletConnectReque
 import com.vitorpamplona.quartz.nip47WalletConnect.cache.NostrWalletConnectResponseCache
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentRequestEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentResponseEvent
+import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcInfoEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcNotificationEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceMethod
@@ -160,27 +161,48 @@ class NwcSignerState(
      * is cached as a definitive "no info event" for the whole TTL, which would pin
      * the wallet to NIP-04 for days.
      */
-    private suspend fun prefersNip44(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
-        uri ?: return false
-        val info = withTimeoutOrNull(NIP44_NEGOTIATION_WAIT_MS) { infoCache?.currentOrFetch(uri) }
-        return info?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } == true
+    private fun prefersNip44(info: NwcInfoEvent?): Boolean = info?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } == true
+
+    /**
+     * The wallet's advertised capabilities, fetched AT MOST ONCE per send.
+     *
+     * Every send asks this event two questions — which encryption to use, and
+     * whether NWC-06 metadata may travel — and each used to fetch it for itself.
+     * That is free on a warm cache and doubles the stall on a cold one, because
+     * [NwcInfoCache] deliberately does not cache a FAILED fetch: when the wallet's
+     * relay is down, both waits run in full. A relay dropping hourly turned a 3s
+     * worst case into 6s, which is what the wallet operator saw as a stall.
+     *
+     * Bounded, and a timeout answers null — the callers treat "don't know" as
+     * NIP-04 and as no-metadata respectively, both of which are safe.
+     */
+    private suspend fun walletInfo(uri: Nip47WalletConnect.Nip47URINorm?): NwcInfoEvent? {
+        uri ?: return null
+        return withTimeoutOrNull(NIP44_NEGOTIATION_WAIT_MS) { infoCache?.currentOrFetch(uri) }
     }
 
     /**
      * Whether this wallet advertises NWC-06 (metadata conventions) and may therefore
      * be sent a populated `metadata`.
      *
-     * NON-BLOCKING, and "don't know" reads as NO. Both matter: this sits on the
-     * payment path, and the only cost of answering false is a history row without a
-     * recipient — whereas answering true for a wallet that types `metadata` narrowly
-     * costs the user a refused payment. [NwcInfoCache.refreshIfStale] means a wallet
-     * that adds the tag later starts being sent metadata without any user action.
+     * WAITS ON A COLD CACHE, and that is the whole point. The first version paired
+     * [NwcInfoCache.refreshIfStale] — which only *starts* a fetch — with [current],
+     * read immediately after, so a wallet whose info event had not been fetched yet
+     * answered "no" and the payment went out bare. Interop testing against a live
+     * wallet caught it: a pairing whose wallet had been advertising `06` for twenty
+     * minutes still sent no metadata, and nothing anywhere reported an error.
+     *
+     * This is the same trap [currentOrFetch] was written for on the NIP-44 path —
+     * "not fetched yet" is indistinguishable from "not supported" — so it takes the
+     * same remedy, including the bounded wait so a slow relay cannot stall a
+     * payment. A timeout still reads as NO: the cost of that is a history row
+     * without a recipient, whereas a wrong YES to a wallet that types `metadata`
+     * narrowly costs the user a refused payment.
+     *
+     * [currentOrFetch] also kicks a background refresh for an expired entry, so a
+     * wallet that adds the tag later is picked up without any user action.
      */
-    private fun supportsMetadata(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
-        uri ?: return false
-        infoCache?.refreshIfStale(uri)
-        return infoCache?.current(uri)?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true
-    }
+    private fun supportsMetadata(info: NwcInfoEvent?): Boolean = info?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true
 
     /**
      * Strips NWC-06 `metadata` from a request bound for a wallet that never said it
@@ -199,9 +221,9 @@ class NwcSignerState(
      * A method with no metadata returns before the info cache is consulted, so this
      * costs nothing on the RPCs that can never carry any.
      */
-    private fun Request.dropMetadataIfUnsupported(walletService: Nip47WalletConnect.Nip47URINorm) {
+    private fun Request.dropMetadataIfUnsupported(info: NwcInfoEvent?) {
         val carrier = metadataCarrier ?: return
-        if (carrier.metadata == null || supportsMetadata(walletService)) return
+        if (carrier.metadata == null || supportsMetadata(info)) return
         carrier.metadata = null
     }
 
@@ -280,9 +302,10 @@ class NwcSignerState(
         val walletService = walletUri ?: throw IllegalArgumentException("No NIP47 setup")
         val walletSigner = buildSigner(walletService) ?: signer
 
-        request.dropMetadataIfUnsupported(walletService)
+        val info = walletInfo(walletService)
+        request.dropMetadataIfUnsupported(info)
 
-        val event = LnZapPaymentRequestEvent.createRequest(request, walletService.pubKeyHex, walletSigner, useNip44 = prefersNip44(walletService))
+        val event = LnZapPaymentRequestEvent.createRequest(request, walletService.pubKeyHex, walletSigner, useNip44 = prefersNip44(info))
 
         val filter =
             NWCPaymentQueryState(
@@ -326,15 +349,16 @@ class NwcSignerState(
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = defaultWalletUri.value ?: throw IllegalArgumentException("No NIP47 setup")
 
+        val info = walletInfo(walletService)
         val request = PayInvoiceMethod.create(bolt11, metadata)
-        request.dropMetadataIfUnsupported(walletService)
+        request.dropMetadataIfUnsupported(info)
 
         val event =
             LnZapPaymentRequestEvent.createRequest(
                 request,
                 walletService.pubKeyHex,
                 nip47Signer.value,
-                useNip44 = prefersNip44(walletService),
+                useNip44 = prefersNip44(info),
             )
 
         val filter =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PaymentReceivedNotification
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
+import com.vitorpamplona.quartz.nip47WalletConnect.tags.ExtensionsTag
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -164,6 +165,22 @@ class NwcSignerState(
         return info?.encryptionSchemes()?.any { it.equals("nip44_v2", ignoreCase = true) } == true
     }
 
+    /**
+     * Whether this wallet advertises NWC-06 (metadata conventions) and may therefore
+     * be sent a populated `metadata` on `pay_invoice`.
+     *
+     * NON-BLOCKING, and "don't know" reads as NO. Both matter: this sits on the
+     * payment path, and the only cost of answering false is a history row without a
+     * recipient — whereas answering true for a wallet that types `metadata` narrowly
+     * costs the user a refused payment. [NwcInfoCache.refreshIfStale] means a wallet
+     * that adds the tag later starts being sent metadata without any user action.
+     */
+    private fun supportsMetadata(uri: Nip47WalletConnect.Nip47URINorm?): Boolean {
+        uri ?: return false
+        infoCache?.refreshIfStale(uri)
+        return infoCache?.current(uri)?.supportsExtension(ExtensionsTag.METADATA_CONVENTIONS) == true
+    }
+
     fun hasWalletConnectSetup(): Boolean = settings.nwcWallets.value.isNotEmpty()
 
     override fun isNIP47Author(pubKey: HexKey?): Boolean = nip47Signer.value.pubKey == pubKey
@@ -271,11 +288,20 @@ class NwcSignerState(
         bolt11: String,
         zappedNote: Note?,
         onTimeout: () -> Unit = {},
+        metadata: Map<String, Any?>? = null,
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = defaultWalletUri.value ?: throw IllegalArgumentException("No NIP47 setup")
 
-        val event = LnZapPaymentRequestEvent.create(bolt11, walletService.pubKeyHex, nip47Signer.value, useNip44 = prefersNip44(walletService))
+        // Only forwarded when the wallet advertises NWC-06; see [supportsMetadata].
+        val event =
+            LnZapPaymentRequestEvent.create(
+                bolt11,
+                walletService.pubKeyHex,
+                nip47Signer.value,
+                useNip44 = prefersNip44(walletService),
+                metadata = metadata?.takeIf { supportsMetadata(walletService) },
+            )
 
         val filter =
             NWCPaymentQueryState(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.experimental.clink.pointers.NDebit
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransactionMetadata
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
@@ -61,6 +62,11 @@ class ZapPaymentHandler(
         val info: MyZapSplitSetup,
         val amountMilliSats: Long,
         val invoice: String,
+        // The signed kind 9734 this invoice was fetched with, and the message on it.
+        // Carried so the NWC payment can name the payee (NWC-06 `metadata`); null for
+        // a NONZAP split, which has no zap request to send.
+        val zapRequest: LnZapRequestEvent? = null,
+        val message: String = "",
     )
 
     data class UnverifiedZapSplitSetup(
@@ -418,6 +424,13 @@ class ZapPaymentHandler(
                 account.zaps.sendZapPaymentRequestFor(
                     bolt11 = payable.invoice,
                     zappedNote = note,
+                    // Dropped unless the wallet advertises NWC-06 — see NwcSignerState.
+                    metadata =
+                        NwcTransactionMetadata.build(
+                            zapRequest = payable.zapRequest,
+                            recipientIdentifier = payable.info.lnAddress,
+                            comment = payable.message,
+                        ),
                     onResponse = { response ->
                         progress.step()
                         response.nwcFailureDetail(context)?.let { detail ->
@@ -575,6 +588,8 @@ class ZapPaymentHandler(
             info = splitSetup,
             amountMilliSats = zapValue,
             invoice = invoice,
+            zapRequest = nostrZapRequest,
+            message = message,
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
@@ -567,6 +567,10 @@ class ZapPaymentHandler(
     ): Payable {
         var progressThisPayment = 0.00f
 
+        // Only the request the provider actually accepted may be claimed as bound to
+        // this invoice; see lnAddressInvoice's onZapRequestSent.
+        var sentZapRequest: LnZapRequestEvent? = null
+
         val invoice =
             LightningAddressResolver().lnAddressInvoice(
                 lnAddress = lud16,
@@ -580,6 +584,7 @@ class ZapPaymentHandler(
                     onProgressStep(step)
                 },
                 context = context,
+                onZapRequestSent = { sentZapRequest = it },
             )
 
         onProgressStep(1 - progressThisPayment)
@@ -588,7 +593,7 @@ class ZapPaymentHandler(
             info = splitSetup,
             amountMilliSats = zapValue,
             invoice = invoice,
-            zapRequest = nostrZapRequest,
+            zapRequest = sentZapRequest,
             message = message,
         )
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
@@ -201,6 +201,13 @@ class LightningAddressResolver {
             ?: response.code.toString()
     }
 
+    /**
+     * @param onZapRequestSent receives the zap request that was ACTUALLY sent to the
+     *   callback, or null when it was not. A provider that does not advertise
+     *   `allowsNostr` never sees [nostrRequest], and its invoice therefore commits to
+     *   nothing about it — so a caller must not go on to claim the two are bound. See
+     *   the drop below.
+     */
     suspend fun lnAddressInvoice(
         lnAddress: String,
         milliSats: Long,
@@ -209,6 +216,7 @@ class LightningAddressResolver {
         okHttpClient: (String) -> OkHttpClient,
         onProgress: (percent: Float) -> Unit,
         context: Context,
+        onZapRequestSent: (LnZapRequestEvent?) -> Unit = {},
     ): String {
         val mapper = jacksonObjectMapper()
 
@@ -264,12 +272,19 @@ class LightningAddressResolver {
             )
         }
 
+        // NIP-57 binds a zap request to its invoice through `description_hash`, and a
+        // provider that ignores `nostr=` mints an invoice that commits to nothing about
+        // it. Report what actually went, so a caller cannot attach the event to a
+        // payment it was never bound to.
+        val sentZapRequest = nostrRequest?.takeIf { allowsNostr }
+        onZapRequestSent(sentZapRequest)
+
         val invoice =
             fetchLightningInvoice(
                 lnCallback = callbackUrl,
                 milliSats = milliSats,
                 message = message,
-                nostrRequest = if (allowsNostr) nostrRequest else null,
+                nostrRequest = sentZapRequest,
                 okHttpClient = okHttpClient,
                 context = context,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/renderers/NwcPaymentNotifier.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/renderers/NwcPaymentNotifier.kt
@@ -58,7 +58,7 @@ object NwcPaymentNotifier {
         val time = tx.settled_at ?: tx.created_at ?: TimeUtils.now()
 
         val title = stringRes(context, R.string.app_notification_payments_channel_message, amount)
-        val comment = (tx.parsedMetadata()?.comment ?: tx.description)?.ifBlank { null }
+        val comment = tx.parsedMetadata()?.displayComment() ?: tx.displayDescription()
         val body = comment ?: title
 
         val accountNpub = NotificationRoutes.accountNpub(account)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2839,9 +2839,10 @@ class AccountViewModel(
         zappedNote: Note?,
         onSent: () -> Unit = {},
         onTimeout: () -> Unit = {},
+        metadata: Map<String, Any?>? = null,
         onResponse: (Response?) -> Unit,
     ) = launchSigner {
-        account.zaps.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)
+        account.zaps.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, metadata, onResponse)
         onSent()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet
+
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransactionType
+
+/**
+ * What a transaction row has to say about its counterparty, resolved away from
+ * Compose so the blank-handling is a plain unit test.
+ *
+ * The title is a [Title] rather than a resolved string because the fallback is a
+ * string resource: keeping the choice here and the lookup in the composable means
+ * this can be tested without a Context.
+ */
+data class TransactionRowLabels(
+    val counterpartyPubkeyHex: String?,
+    val title: Title,
+    val subtitle: Subtitle?,
+) {
+    sealed interface Title {
+        /** Render the counterparty's profile for this pubkey, falling back to [name]. */
+        data class User(
+            val pubkeyHex: String,
+            val name: String?,
+        ) : Title
+
+        data class Literal(
+            val text: String,
+        ) : Title
+
+        /** No name and no description: say "Received"/"Sent" for the direction. */
+        data object Direction : Title
+    }
+
+    sealed interface Subtitle {
+        data class Literal(
+            val text: String,
+        ) : Subtitle
+
+        data object Direction : Subtitle
+    }
+
+    companion object {
+        /**
+         * WHY EVERY READ IS BLANK-GUARDED, not just null-checked. Wallets send
+         * `"description": ""` for a payment with no memo — NIP-47 marks the field
+         * optional, but omitting it is a choice and several wallets emit the empty
+         * string instead. An elvis only catches null, so the row rendered an empty
+         * Text: an invisible line with the height of a real one, which is why
+         * outgoing rows looked like a bare arrow and a date.
+         *
+         * NwcPaymentNotifier already did this; the transactions screen did not.
+         */
+        fun resolve(tx: NwcTransaction): TransactionRowLabels {
+            val isIncoming = tx.type == NwcTransactionType.INCOMING
+            val parsed = tx.parsedMetadata()
+            val description = tx.description?.ifBlank { null }
+
+            // Incoming: who sent it. Outgoing: who received it — on a zap request the
+            //  tag is the payee, which is what makes an outgoing row resolvable.
+            val pubkeyHex = if (isIncoming) parsed?.senderPubkeyHex() else parsed?.recipientPubkeyHex()
+            val displayName = if (isIncoming) parsed?.senderDisplayName() else parsed?.recipientIdentifier()
+
+            // The zap comment, unless it merely repeats the description.
+            val comment =
+                parsed?.displayComment()?.takeIf { comment ->
+                    description == null || !comment.equals(description, ignoreCase = true)
+                }
+
+            // Whether the title names a counterparty rather than describing the payment.
+            // A named row wants a second line saying what the payment was; a row whose
+            // title IS the description must not repeat it underneath.
+            val isNamed = pubkeyHex != null || displayName != null
+
+            val title =
+                when {
+                    pubkeyHex != null -> Title.User(pubkeyHex, displayName)
+                    displayName != null -> Title.Literal(displayName)
+                    description != null -> Title.Literal(description)
+                    else -> Title.Direction
+                }
+
+            val subtitle =
+                when {
+                    comment != null -> Subtitle.Literal(comment)
+                    isNamed -> description?.let { Subtitle.Literal(it) } ?: Subtitle.Direction
+                    else -> null
+                }
+
+            return TransactionRowLabels(pubkeyHex, title, subtitle)
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
@@ -75,18 +75,14 @@ data class TransactionRowLabels(
                     description == null || !comment.equals(description, ignoreCase = true)
                 }
 
-            // Whether the title names a counterparty rather than describing the payment.
-            // A named row wants a second line saying what the payment was; a row whose
-            // title IS the description must not repeat it underneath.
-            val isNamed = pubkeyHex != null || displayName != null
-
-            val title =
-                pubkeyHex?.let { Title.User(it, displayName) }
-                    ?: Title.Literal(displayName ?: description ?: directionLabel)
+            // A title that NAMES a counterparty wants a second line saying what the
+            // payment was; a title that IS the description must not repeat it below.
+            val named = pubkeyHex?.let { Title.User(it, displayName) } ?: displayName?.let { Title.Literal(it) }
+            val fallback = description ?: directionLabel
 
             return TransactionRowLabels(
-                title = title,
-                subtitle = comment ?: if (isNamed) description ?: directionLabel else null,
+                title = named ?: Title.Literal(fallback),
+                subtitle = comment ?: fallback.takeIf { named != null },
             )
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TransactionRowLabels.kt
@@ -27,14 +27,13 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransactionType
  * What a transaction row has to say about its counterparty, resolved away from
  * Compose so the blank-handling is a plain unit test.
  *
- * The title is a [Title] rather than a resolved string because the fallback is a
- * string resource: keeping the choice here and the lookup in the composable means
- * this can be tested without a Context.
+ * The direction label ("Received"/"Sent") is passed IN rather than looked up here,
+ * which is what keeps this Context-free while still letting it be the single place
+ * that decides what a row says.
  */
 data class TransactionRowLabels(
-    val counterpartyPubkeyHex: String?,
     val title: Title,
-    val subtitle: Subtitle?,
+    val subtitle: String?,
 ) {
     sealed interface Title {
         /** Render the counterparty's profile for this pubkey, falling back to [name]. */
@@ -46,17 +45,6 @@ data class TransactionRowLabels(
         data class Literal(
             val text: String,
         ) : Title
-
-        /** No name and no description: say "Received"/"Sent" for the direction. */
-        data object Direction : Title
-    }
-
-    sealed interface Subtitle {
-        data class Literal(
-            val text: String,
-        ) : Subtitle
-
-        data object Direction : Subtitle
     }
 
     companion object {
@@ -67,16 +55,17 @@ data class TransactionRowLabels(
          * string instead. An elvis only catches null, so the row rendered an empty
          * Text: an invisible line with the height of a real one, which is why
          * outgoing rows looked like a bare arrow and a date.
-         *
-         * NwcPaymentNotifier already did this; the transactions screen did not.
          */
-        fun resolve(tx: NwcTransaction): TransactionRowLabels {
+        fun resolve(
+            tx: NwcTransaction,
+            directionLabel: String,
+        ): TransactionRowLabels {
             val isIncoming = tx.type == NwcTransactionType.INCOMING
             val parsed = tx.parsedMetadata()
-            val description = tx.description?.ifBlank { null }
+            val description = tx.displayDescription()
 
             // Incoming: who sent it. Outgoing: who received it — on a zap request the
-            //  tag is the payee, which is what makes an outgoing row resolvable.
+            // `p` tag is the payee, which is what makes an outgoing row resolvable.
             val pubkeyHex = if (isIncoming) parsed?.senderPubkeyHex() else parsed?.recipientPubkeyHex()
             val displayName = if (isIncoming) parsed?.senderDisplayName() else parsed?.recipientIdentifier()
 
@@ -92,21 +81,13 @@ data class TransactionRowLabels(
             val isNamed = pubkeyHex != null || displayName != null
 
             val title =
-                when {
-                    pubkeyHex != null -> Title.User(pubkeyHex, displayName)
-                    displayName != null -> Title.Literal(displayName)
-                    description != null -> Title.Literal(description)
-                    else -> Title.Direction
-                }
+                pubkeyHex?.let { Title.User(it, displayName) }
+                    ?: Title.Literal(displayName ?: description ?: directionLabel)
 
-            val subtitle =
-                when {
-                    comment != null -> Subtitle.Literal(comment)
-                    isNamed -> description?.let { Subtitle.Literal(it) } ?: Subtitle.Direction
-                    else -> null
-                }
-
-            return TransactionRowLabels(pubkeyHex, title, subtitle)
+            return TransactionRowLabels(
+                title = title,
+                subtitle = comment ?: if (isNamed) description ?: directionLabel else null,
+            )
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
@@ -271,35 +271,11 @@ private fun TransactionItem(
             tx.created_at?.let { formatMonthDayTime(it, context) } ?: ""
         }
 
-    val parsed = remember(tx.metadata) { tx.parsedMetadata() }
+    val labels = remember(tx.metadata, tx.description, tx.type) { TransactionRowLabels.resolve(tx) }
+    val counterpartyPubkeyHex = labels.counterpartyPubkeyHex
 
-    // For incoming: show who sent it (nostr pubkey or payer name/email)
-    // For outgoing: show who received it (nostr recipient or recipient identifier)
-    val counterpartyPubkeyHex =
-        remember(parsed) {
-            if (isIncoming) parsed?.senderPubkeyHex() else parsed?.recipientPubkeyHex()
-        }
-
-    val counterpartyDisplayName =
-        remember(parsed) {
-            if (isIncoming) {
-                parsed?.senderDisplayName()
-            } else {
-                parsed?.recipientIdentifier()
-            }
-        }
-
-    // Show comment only if it differs from description
-    val commentText =
-        remember(parsed, tx.description) {
-            parsed?.comment?.let { comment ->
-                if (tx.description == null || !comment.equals(tx.description, ignoreCase = true)) {
-                    comment
-                } else {
-                    null
-                }
-            }
-        }
+    val directionLabel =
+        if (isIncoming) stringRes(R.string.wallet_incoming) else stringRes(R.string.wallet_outgoing)
 
     Row(
         modifier =
@@ -337,42 +313,49 @@ private fun TransactionItem(
         }
 
         Column(modifier = Modifier.weight(1f)) {
-            if (counterpartyPubkeyHex != null) {
-                TransactionUserName(counterpartyPubkeyHex, counterpartyDisplayName, accountViewModel)
-            } else if (counterpartyDisplayName != null) {
-                Text(
-                    text = counterpartyDisplayName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            } else {
-                Text(
-                    text = tx.description ?: if (isIncoming) stringRes(R.string.wallet_incoming) else stringRes(R.string.wallet_outgoing),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+            when (val title = labels.title) {
+                is TransactionRowLabels.Title.User ->
+                    TransactionUserName(title.pubkeyHex, title.name, accountViewModel)
+
+                is TransactionRowLabels.Title.Literal ->
+                    Text(
+                        text = title.text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                TransactionRowLabels.Title.Direction ->
+                    Text(
+                        text = directionLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
             }
 
-            if (commentText != null) {
-                Text(
-                    text = commentText,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            } else if (counterpartyPubkeyHex != null || counterpartyDisplayName != null) {
-                val descOrType = tx.description ?: if (isIncoming) stringRes(R.string.wallet_incoming) else stringRes(R.string.wallet_outgoing)
-                Text(
-                    text = descOrType,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+            when (val subtitle = labels.subtitle) {
+                is TransactionRowLabels.Subtitle.Literal ->
+                    Text(
+                        text = subtitle.text,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                TransactionRowLabels.Subtitle.Direction ->
+                    Text(
+                        text = directionLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                null -> {}
             }
 
             Text(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
@@ -271,11 +271,14 @@ private fun TransactionItem(
             tx.created_at?.let { formatMonthDayTime(it, context) } ?: ""
         }
 
-    val labels = remember(tx.metadata, tx.description, tx.type) { TransactionRowLabels.resolve(tx) }
-    val counterpartyPubkeyHex = labels.counterpartyPubkeyHex
-
     val directionLabel =
         if (isIncoming) stringRes(R.string.wallet_incoming) else stringRes(R.string.wallet_outgoing)
+
+    val labels =
+        remember(tx.metadata, tx.description, tx.type, directionLabel) {
+            TransactionRowLabels.resolve(tx, directionLabel)
+        }
+    val counterpartyPubkeyHex = (labels.title as? TransactionRowLabels.Title.User)?.pubkeyHex
 
     Row(
         modifier =
@@ -325,37 +328,16 @@ private fun TransactionItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-
-                TransactionRowLabels.Title.Direction ->
-                    Text(
-                        text = directionLabel,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
             }
 
-            when (val subtitle = labels.subtitle) {
-                is TransactionRowLabels.Subtitle.Literal ->
-                    Text(
-                        text = subtitle.text,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                TransactionRowLabels.Subtitle.Direction ->
-                    Text(
-                        text = directionLabel,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                null -> {}
+            labels.subtitle?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
 
             Text(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -550,19 +550,6 @@ class WalletViewModel : ViewModel() {
         val acc = account ?: return
         val walletUri = getWalletUri(walletId) ?: return
 
-        // Re-read the wallet's advertised capabilities whenever the user opens or
-        // refreshes this screen, bypassing the info cache's TTL.
-        //
-        // A wallet that ADDS an extension is otherwise invisible for the life of the
-        // cached entry: nothing errors, the feature simply does not appear, and the
-        // user has no way to learn that. Interop testing found a pairing sending no
-        // NWC-06 metadata to a wallet that had been advertising `06` for twenty
-        // minutes. This is the deliberate user-visible remedy — its own coroutine, so
-        // a slow info fetch never delays the transaction list.
-        viewModelScope.launch(Dispatchers.IO) {
-            acc.nip47SignerState.infoCache?.getFresh(walletUri)
-        }
-
         viewModelScope.launch(Dispatchers.IO) {
             _isLoading.value = true
             _error.value = null

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -549,6 +549,20 @@ class WalletViewModel : ViewModel() {
         val walletId = _selectedWalletId.value ?: _defaultWalletId.value ?: _wallets.value.firstOrNull()?.id ?: return
         val acc = account ?: return
         val walletUri = getWalletUri(walletId) ?: return
+
+        // Re-read the wallet's advertised capabilities whenever the user opens or
+        // refreshes this screen, bypassing the info cache's TTL.
+        //
+        // A wallet that ADDS an extension is otherwise invisible for the life of the
+        // cached entry: nothing errors, the feature simply does not appear, and the
+        // user has no way to learn that. Interop testing found a pairing sending no
+        // NWC-06 metadata to a wallet that had been advertising `06` for twenty
+        // minutes. This is the deliberate user-visible remedy — its own coroutine, so
+        // a slow info fetch never delays the transaction list.
+        viewModelScope.launch(Dispatchers.IO) {
+            acc.nip47SignerState.infoCache?.getFresh(walletUri)
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             _isLoading.value = true
             _error.value = null

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
@@ -38,28 +38,27 @@ class TransactionRowLabelsTest {
      */
     @Test
     fun anEmptyDescriptionFallsBackToTheDirection() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = ""))
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = ""), "Sent")
 
-        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
         assertNull(labels.subtitle)
-        assertNull(labels.counterpartyPubkeyHex)
     }
 
     @Test
     fun aWhitespaceDescriptionIsTreatedTheSameWay() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "   "))
-        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "   "), "Sent")
+        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
     }
 
     @Test
     fun anAbsentDescriptionStillFallsBack() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = null))
-        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = null), "Sent")
+        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
     }
 
     @Test
     fun aRealDescriptionIsTheTitle() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "Coffee"))
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "Coffee"), "Sent")
         assertEquals(TransactionRowLabels.Title.Literal("Coffee"), labels.title)
         assertNull(labels.subtitle)
     }
@@ -83,11 +82,11 @@ class TransactionRowLabelsTest {
                                 ),
                         ),
                 ),
+                "Sent",
             )
 
-        assertEquals(recipientHex, labels.counterpartyPubkeyHex)
         assertEquals(TransactionRowLabels.Title.User(recipientHex, "user@domain.com"), labels.title)
-        assertEquals(TransactionRowLabels.Subtitle.Literal("great post"), labels.subtitle)
+        assertEquals("great post", labels.subtitle)
     }
 
     /** With no zap request, the lightning address alone still labels the row. */
@@ -100,12 +99,12 @@ class TransactionRowLabelsTest {
                     description = "",
                     metadata = mapOf("recipient_data" to mapOf("identifier" to "user@domain.com")),
                 ),
+                "Sent",
             )
 
-        assertNull(labels.counterpartyPubkeyHex)
         assertEquals(TransactionRowLabels.Title.Literal("user@domain.com"), labels.title)
         // Named but undescribed: the second line says what the row was.
-        assertEquals(TransactionRowLabels.Subtitle.Direction, labels.subtitle)
+        assertEquals("Sent", labels.subtitle)
     }
 
     /** Incoming rows keep working off the payer, which is what they did before. */
@@ -118,11 +117,11 @@ class TransactionRowLabelsTest {
                     description = "Test",
                     metadata = mapOf("nostr" to mapOf("pubkey" to recipientHex, "content" to "Test")),
                 ),
+                "Received",
             )
 
-        assertEquals(recipientHex, labels.counterpartyPubkeyHex)
         assertTrue(labels.title is TransactionRowLabels.Title.User)
         // The comment merely repeats the description, so it is not shown twice.
-        assertEquals(TransactionRowLabels.Subtitle.Literal("Test"), labels.subtitle)
+        assertEquals("Test", labels.subtitle)
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.wallet
+
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.TransactionRowLabels
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransactionRowLabelsTest {
+    private val recipientHex = "ca89cb11f1c75d5b6622268ff43d2288ea8b2cb5b9aa996ff9ff704fc904b78b"
+
+    /**
+     * The bug this class exists for. Wallets send `"description": ""` for a payment
+     * with no memo; the old row did `tx.description ?: fallback`, which only catches
+     * null, so it rendered an empty Text — a line with the height of a real one and
+     * nothing in it. Outgoing rows looked like a bare arrow and a date.
+     */
+    @Test
+    fun anEmptyDescriptionFallsBackToTheDirection() {
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = ""))
+
+        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+        assertNull(labels.subtitle)
+        assertNull(labels.counterpartyPubkeyHex)
+    }
+
+    @Test
+    fun aWhitespaceDescriptionIsTreatedTheSameWay() {
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "   "))
+        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+    }
+
+    @Test
+    fun anAbsentDescriptionStillFallsBack() {
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = null))
+        assertEquals(TransactionRowLabels.Title.Direction, labels.title)
+    }
+
+    @Test
+    fun aRealDescriptionIsTheTitle() {
+        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "Coffee"))
+        assertEquals(TransactionRowLabels.Title.Literal("Coffee"), labels.title)
+        assertNull(labels.subtitle)
+    }
+
+    /** An outgoing zap resolves the payee from the zap request's `p` tag. */
+    @Test
+    fun anOutgoingZapNamesThePayee() {
+        val labels =
+            TransactionRowLabels.resolve(
+                NwcTransaction(
+                    type = "outgoing",
+                    description = "",
+                    metadata =
+                        mapOf(
+                            "recipient_data" to mapOf("identifier" to "user@domain.com"),
+                            "nostr" to
+                                mapOf(
+                                    "pubkey" to "f512822a89d2369a386bfeb1e687ccd26ceb6bb33e73b98417499bb9054bff1f",
+                                    "content" to "great post",
+                                    "tags" to listOf(listOf("p", recipientHex)),
+                                ),
+                        ),
+                ),
+            )
+
+        assertEquals(recipientHex, labels.counterpartyPubkeyHex)
+        assertEquals(TransactionRowLabels.Title.User(recipientHex, "user@domain.com"), labels.title)
+        assertEquals(TransactionRowLabels.Subtitle.Literal("great post"), labels.subtitle)
+    }
+
+    /** With no zap request, the lightning address alone still labels the row. */
+    @Test
+    fun theLeanPairAloneStillNamesThePayee() {
+        val labels =
+            TransactionRowLabels.resolve(
+                NwcTransaction(
+                    type = "outgoing",
+                    description = "",
+                    metadata = mapOf("recipient_data" to mapOf("identifier" to "user@domain.com")),
+                ),
+            )
+
+        assertNull(labels.counterpartyPubkeyHex)
+        assertEquals(TransactionRowLabels.Title.Literal("user@domain.com"), labels.title)
+        // Named but undescribed: the second line says what the row was.
+        assertEquals(TransactionRowLabels.Subtitle.Direction, labels.subtitle)
+    }
+
+    /** Incoming rows keep working off the payer, which is what they did before. */
+    @Test
+    fun anIncomingZapStillNamesTheSender() {
+        val labels =
+            TransactionRowLabels.resolve(
+                NwcTransaction(
+                    type = "incoming",
+                    description = "Test",
+                    metadata = mapOf("nostr" to mapOf("pubkey" to recipientHex, "content" to "Test")),
+                ),
+            )
+
+        assertEquals(recipientHex, labels.counterpartyPubkeyHex)
+        assertTrue(labels.title is TransactionRowLabels.Title.User)
+        // The comment merely repeats the description, so it is not shown twice.
+        assertEquals(TransactionRowLabels.Subtitle.Literal("Test"), labels.subtitle)
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/wallet/TransactionRowLabelsTest.kt
@@ -37,23 +37,15 @@ class TransactionRowLabelsTest {
      * nothing in it. Outgoing rows looked like a bare arrow and a date.
      */
     @Test
-    fun anEmptyDescriptionFallsBackToTheDirection() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = ""), "Sent")
+    fun aDescriptionWithNothingInItFallsBackToTheDirection() {
+        // Empty and whitespace are what wallets actually send for a payment with no
+        // memo; absent is the spec-clean form. All three must reach the fallback.
+        listOf("", "   ", null).forEach { description ->
+            val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = description), "Sent")
 
-        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
-        assertNull(labels.subtitle)
-    }
-
-    @Test
-    fun aWhitespaceDescriptionIsTreatedTheSameWay() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = "   "), "Sent")
-        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
-    }
-
-    @Test
-    fun anAbsentDescriptionStillFallsBack() {
-        val labels = TransactionRowLabels.resolve(NwcTransaction(type = "outgoing", description = null), "Sent")
-        assertEquals(TransactionRowLabels.Title.Literal("Sent"), labels.title)
+            assertEquals("description=<$description>", TransactionRowLabels.Title.Literal("Sent"), labels.title)
+            assertNull("description=<$description>", labels.subtitle)
+        }
     }
 
     @Test

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/clink/kotlinSerialization/ClinkKSerializers.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/clink/kotlinSerialization/ClinkKSerializers.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.experimental.clink.manage.OfferFields
 import com.vitorpamplona.quartz.experimental.clink.offers.OfferReceipt
 import com.vitorpamplona.quartz.experimental.clink.offers.OfferRequest
 import com.vitorpamplona.quartz.experimental.clink.offers.OfferResponse
+import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.anyToJsonElement
 import com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization.toAnyMap
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -45,7 +46,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -62,18 +62,6 @@ import kotlinx.serialization.json.put
  * JVM/Android — including coercing a lone `details` object into a one-element list
  * (Jackson's `ACCEPT_SINGLE_VALUE_AS_ARRAY`) — so native targets parse the same wire shapes.
  */
-
-private fun anyToJsonElement(value: Any?): JsonElement =
-    when (value) {
-        null -> JsonNull
-        is JsonElement -> value
-        is String -> JsonPrimitive(value)
-        is Boolean -> JsonPrimitive(value)
-        is Number -> JsonPrimitive(value)
-        is Map<*, *> -> buildJsonObject { value.forEach { (k, v) -> put(k.toString(), anyToJsonElement(v)) } }
-        is Iterable<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
-        else -> JsonPrimitive(value.toString())
-    }
 
 private fun JsonObject.stringOrNull(key: String): String? = get(key)?.let { if (it is JsonNull) null else it.jsonPrimitive.content }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/RawJson.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/RawJson.kt
@@ -35,12 +35,8 @@ package com.vitorpamplona.quartz.nip01Core.core
  * `JsonUnquotedLiteral`. [json] MUST already be well-formed JSON; nothing
  * validates it, and an invalid value corrupts the whole document.
  */
-class RawJson(
+data class RawJson(
     val json: String,
 ) {
     override fun toString() = json
-
-    override fun equals(other: Any?) = other is RawJson && other.json == json
-
-    override fun hashCode() = json.hashCode()
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/RawJson.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/RawJson.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.core
+
+/**
+ * JSON that is already serialized and must reach the wire as-is.
+ *
+ * Used where the exact BYTES matter and not merely the value. The case that
+ * forced it: NIP-57 sets a zap invoice's `description_hash` to the sha256 of the
+ * raw zap-request JSON the LNURL callback received, so a wallet binding a stored
+ * zap request to the invoice it labels hashes those same bytes. Handing the
+ * serializer a decomposed `Map` and hoping it reassembles them identically makes
+ * that binding depend on key order, escaping and number formatting agreeing by
+ * coincidence — and it fails silently, as an unlabelled row, when they do not.
+ *
+ * Both backends emit the string verbatim: Jackson via `writeRawValue`, kotlinx via
+ * `JsonUnquotedLiteral`. [json] MUST already be well-formed JSON; nothing
+ * validates it, and an invalid value corrupts the whole document.
+ */
+class RawJson(
+    val json: String,
+) {
+    override fun toString() = json
+
+    override fun equals(other: Any?) = other is RawJson && other.json == json
+
+    override fun hashCode() = json.hashCode()
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/JsonAnyExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/JsonAnyExt.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.kotlinSerialization
+
+import com.vitorpamplona.quartz.nip01Core.core.RawJson
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Encodes an untyped `Any?` tree — the shape several Nostr RPCs carry as a free-form
+ * `Map<String, Any?>` — into a [JsonElement].
+ *
+ * `Json.encodeToJsonElement` CANNOT do this: it resolves a serializer from the STATIC
+ * type, and `Any` has none, so it throws `SerializationException: Serializer for class
+ * 'Any' is not found` at runtime for every populated map. This walks the value instead.
+ *
+ * DECLARED AT nip01Core LEVEL, beside the other kotlinx serializers, because [RawJson]
+ * is: it is registered globally on the Jackson side, so a per-NIP copy of this function
+ * would leave the kotlinx backend supporting raw JSON in some packages and silently
+ * quoting it into a string in others — the exact corruption [RawJson] exists to prevent.
+ */
+fun anyToJsonElement(value: Any?): JsonElement =
+    when (value) {
+        null -> JsonNull
+        is RawJson -> JsonUnquotedLiteral(value.json)
+        is JsonElement -> value
+        is String -> JsonPrimitive(value)
+        is Boolean -> JsonPrimitive(value)
+        is Number -> JsonPrimitive(value)
+        is Map<*, *> -> buildJsonObject { value.forEach { (k, v) -> put(k.toString(), anyToJsonElement(v)) } }
+        is Iterable<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
+        is Array<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
+        else -> JsonPrimitive(value.toString())
+    }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/LnZapPaymentRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/LnZapPaymentRequestEvent.kt
@@ -64,10 +64,9 @@ class LnZapPaymentRequestEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
             useNip44: Boolean = false,
-            metadata: Map<String, Any?>? = null,
         ): LnZapPaymentRequestEvent =
             createRequest(
-                PayInvoiceMethod.create(lnInvoice, metadata),
+                PayInvoiceMethod.create(lnInvoice),
                 walletServicePubkey,
                 signer,
                 createdAt,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/LnZapPaymentRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/LnZapPaymentRequestEvent.kt
@@ -64,9 +64,10 @@ class LnZapPaymentRequestEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
             useNip44: Boolean = false,
+            metadata: Map<String, Any?>? = null,
         ): LnZapPaymentRequestEvent =
             createRequest(
-                PayInvoiceMethod.create(lnInvoice),
+                PayInvoiceMethod.create(lnInvoice, metadata),
                 walletServicePubkey,
                 signer,
                 createdAt,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/NwcInfoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/NwcInfoEvent.kt
@@ -48,27 +48,19 @@ class NwcInfoEvent(
     // NIP-47 carries the schemes/types as a single space-separated string in one
     // tag value (e.g. ["encryption", "nip44_v2 nip04"]). Split on whitespace so we
     // return individual tokens, while still tolerating a multi-element tag.
-    fun encryptionSchemes() =
+    private fun spaceSeparatedTag(parse: (Array<String>) -> List<String>?) =
         tags
-            .mapNotNull(EncryptionTag::parse)
+            .mapNotNull(parse)
             .flatten()
             .flatMap { it.split(" ") }
             .filter { it.isNotBlank() }
 
-    fun notificationTypes() =
-        tags
-            .mapNotNull(NotificationsTag::parse)
-            .flatten()
-            .flatMap { it.split(" ") }
-            .filter { it.isNotBlank() }
+    fun encryptionSchemes() = spaceSeparatedTag(EncryptionTag::parse)
+
+    fun notificationTypes() = spaceSeparatedTag(NotificationsTag::parse)
 
     /** The optional NWC extension specs this wallet advertises (eg. `["05", "06"]`). */
-    fun extensions() =
-        tags
-            .mapNotNull(ExtensionsTag::parse)
-            .flatten()
-            .flatMap { it.split(" ") }
-            .filter { it.isNotBlank() }
+    fun extensions() = spaceSeparatedTag(ExtensionsTag::parse)
 
     /**
      * Whether the wallet advertises a given NWC extension spec.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/NwcInfoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/events/NwcInfoEvent.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip47WalletConnect.tags.EncryptionTag
+import com.vitorpamplona.quartz.nip47WalletConnect.tags.ExtensionsTag
 import com.vitorpamplona.quartz.nip47WalletConnect.tags.NotificationsTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -61,6 +62,23 @@ class NwcInfoEvent(
             .flatMap { it.split(" ") }
             .filter { it.isNotBlank() }
 
+    /** The optional NWC extension specs this wallet advertises (eg. `["05", "06"]`). */
+    fun extensions() =
+        tags
+            .mapNotNull(ExtensionsTag::parse)
+            .flatten()
+            .flatMap { it.split(" ") }
+            .filter { it.isNotBlank() }
+
+    /**
+     * Whether the wallet advertises a given NWC extension spec.
+     *
+     * A wallet that says nothing reads as **no**. That direction is deliberate:
+     * the caller is deciding whether to send something the wallet may not
+     * understand, so silence must not be read as permission.
+     */
+    fun supportsExtension(id: String) = extensions().contains(id)
+
     companion object {
         const val KIND = 13194
 
@@ -68,11 +86,13 @@ class NwcInfoEvent(
             capabilities: List<String>,
             encryptionSchemes: List<String>? = null,
             notificationTypes: List<String>? = null,
+            extensions: List<String>? = null,
             createdAt: Long = TimeUtils.now(),
             initializer: TagArrayBuilder<NwcInfoEvent>.() -> Unit = {},
         ) = eventTemplate(KIND, capabilities.joinToString(" "), createdAt) {
             encryptionSchemes?.let { addUnique(EncryptionTag.assemble(it)) }
             notificationTypes?.let { addUnique(NotificationsTag.assemble(it)) }
+            extensions?.let { addUnique(ExtensionsTag.assemble(it)) }
             initializer()
         }
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/JsonExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/JsonExt.kt
@@ -20,17 +20,10 @@
  */
 package com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization
 
-import com.vitorpamplona.quartz.nip01Core.core.RawJson
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonUnquotedLiteral
-import kotlinx.serialization.json.add
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 // Helper function to convert JsonElement to standard Kotlin types recursively
 fun JsonElement.toAnyValue(): Any =
@@ -53,30 +46,3 @@ fun JsonElement.toAnyValue(): Any =
     }
 
 fun JsonObject.toAnyMap(): Map<String, Any?> = entries.associate { it.key to it.value.toAnyValue() }
-
-/**
- * The inverse of [toAnyValue], for the `Map<String, Any?>` blobs NIP-47 carries as
- * `metadata`.
- *
- * `Json.encodeToJsonElement` CANNOT do this — it needs a serializer for the static
- * type, and `Any` has none, so it throws `SerializerException: Serializer for class
- * 'Any' is not found` at runtime for every populated metadata object. This walks
- * the value instead.
- *
- * [RawJson] becomes a `JsonUnquotedLiteral` so pre-serialized JSON reaches the wire
- * byte-for-byte; that is what lets a zap request still hash to the invoice's
- * `description_hash` after a round trip through this map.
- */
-fun anyToJsonElement(value: Any?): JsonElement =
-    when (value) {
-        null -> JsonNull
-        is RawJson -> JsonUnquotedLiteral(value.json)
-        is JsonElement -> value
-        is String -> JsonPrimitive(value)
-        is Boolean -> JsonPrimitive(value)
-        is Number -> JsonPrimitive(value)
-        is Map<*, *> -> buildJsonObject { value.forEach { (k, v) -> put(k.toString(), anyToJsonElement(v)) } }
-        is Iterable<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
-        is Array<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
-        else -> JsonPrimitive(value.toString())
-    }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/JsonExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/JsonExt.kt
@@ -20,10 +20,17 @@
  */
 package com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization
 
+import com.vitorpamplona.quartz.nip01Core.core.RawJson
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonUnquotedLiteral
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 // Helper function to convert JsonElement to standard Kotlin types recursively
 fun JsonElement.toAnyValue(): Any =
@@ -46,3 +53,30 @@ fun JsonElement.toAnyValue(): Any =
     }
 
 fun JsonObject.toAnyMap(): Map<String, Any?> = entries.associate { it.key to it.value.toAnyValue() }
+
+/**
+ * The inverse of [toAnyValue], for the `Map<String, Any?>` blobs NIP-47 carries as
+ * `metadata`.
+ *
+ * `Json.encodeToJsonElement` CANNOT do this — it needs a serializer for the static
+ * type, and `Any` has none, so it throws `SerializerException: Serializer for class
+ * 'Any' is not found` at runtime for every populated metadata object. This walks
+ * the value instead.
+ *
+ * [RawJson] becomes a `JsonUnquotedLiteral` so pre-serialized JSON reaches the wire
+ * byte-for-byte; that is what lets a zap request still hash to the invoice's
+ * `description_hash` after a round trip through this map.
+ */
+fun anyToJsonElement(value: Any?): JsonElement =
+    when (value) {
+        null -> JsonNull
+        is RawJson -> JsonUnquotedLiteral(value.json)
+        is JsonElement -> value
+        is String -> JsonPrimitive(value)
+        is Boolean -> JsonPrimitive(value)
+        is Number -> JsonPrimitive(value)
+        is Map<*, *> -> buildJsonObject { value.forEach { (k, v) -> put(k.toString(), anyToJsonElement(v)) } }
+        is Iterable<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
+        is Array<*> -> buildJsonArray { value.forEach { add(anyToJsonElement(it)) } }
+        else -> JsonPrimitive(value.toString())
+    }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47RequestKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47RequestKSerializer.kt
@@ -55,7 +55,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonNull
@@ -65,7 +64,6 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -148,7 +146,7 @@ object Nip47RequestKSerializer : KSerializer<Request> {
         buildJsonObject {
             params.invoice?.let { put("invoice", it) }
             params.amount?.let { put("amount", it) }
-            params.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            params.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
 
     private fun serializePayParams(params: PayParams): JsonObject =
@@ -156,14 +154,14 @@ object Nip47RequestKSerializer : KSerializer<Request> {
             params.payment?.let { put("payment", it) }
             params.amount?.let { put("amount", it) }
             params.payer_note?.let { put("payer_note", it) }
-            params.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            params.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
 
     private fun serializeReceiveParams(params: ReceiveParams): JsonObject =
         buildJsonObject {
             params.amount?.let { put("amount", it) }
             params.description?.let { put("description", it) }
-            params.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            params.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
 
     private fun serializePayKeysendParams(params: PayKeysendParams): JsonObject =
@@ -194,7 +192,7 @@ object Nip47RequestKSerializer : KSerializer<Request> {
             params.description?.let { put("description", it) }
             params.description_hash?.let { put("description_hash", it) }
             params.expiry?.let { put("expiry", it) }
-            params.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            params.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
 
     private fun serializeLookupInvoiceParams(params: LookupInvoiceParams): JsonObject =
@@ -234,7 +232,7 @@ object Nip47RequestKSerializer : KSerializer<Request> {
             params.budget_renewal?.let { put("budget_renewal", it) }
             params.expires_at?.let { put("expires_at", it) }
             params.isolated?.let { put("isolated", it) }
-            params.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            params.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
 
     private fun serializeMakeHoldInvoiceParams(params: MakeHoldInvoiceParams): JsonObject =

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47RequestKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47RequestKSerializer.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization
 
+import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.anyToJsonElement
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CancelHoldInvoiceMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CancelHoldInvoiceParams
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CreateConnectionMethod

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47ResponseKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47ResponseKSerializer.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization
 
+import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.anyToJsonElement
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CancelHoldInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CreateConnectionSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBalanceSuccessResponse

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47ResponseKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/kotlinSerialization/Nip47ResponseKSerializer.kt
@@ -47,7 +47,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonNull
@@ -56,7 +55,6 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -226,7 +224,7 @@ object Nip47ResponseKSerializer : KSerializer<Response> {
             result.notifications?.let { notifications ->
                 put("notifications", buildJsonArray { notifications.forEach { add(it) } })
             }
-            result.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            result.metadata?.let { put("metadata", anyToJsonElement(it)) }
             result.lud16?.let { put("lud16", it) }
         }
 
@@ -373,7 +371,7 @@ object Nip47ResponseKSerializer : KSerializer<Response> {
             transaction.expires_at?.let { put("expires_at", it) }
             transaction.settled_at?.let { put("settled_at", it) }
             transaction.settle_deadline?.let { put("settle_deadline", it) }
-            transaction.metadata?.let { put("metadata", Json.encodeToJsonElement(it)) }
+            transaction.metadata?.let { put("metadata", anyToJsonElement(it)) }
         }
     }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransaction.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransaction.kt
@@ -65,6 +65,18 @@ class NwcTransaction(
     var metadata: Map<String, Any?>? = null,
 ) {
     fun parsedMetadata(): NwcTransactionMetadata? = NwcTransactionMetadata.parse(metadata)
+
+    /**
+     * The description, or null when the wallet had nothing to say.
+     *
+     * Wallets send `"description": ""` for a payment with no memo rather than
+     * omitting the field, so an elvis on [description] yields an empty string that
+     * renders as a blank line. Normalized HERE rather than in the parser because
+     * [com.vitorpamplona.quartz.nip47WalletConnect.Nip47Server] serializes this same
+     * class back onto the wire — rewriting blank to null at parse time would change
+     * what a wallet service echoes.
+     */
+    fun displayDescription(): String? = description?.ifBlank { null }
 }
 
 class TlvRecord(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
@@ -127,12 +127,32 @@ class NwcTransactionMetadata(
          */
         const val MAX_METADATA_CHARS = 4096
 
-        // The keys and punctuation around the values —
-        // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is 58 chars —
-        // plus room for JSON escaping to expand `identifier` and `comment` on the way
-        // out, which is the only thing that can make this estimate low. `nostr` needs
-        // no such allowance: the length added below is the serialized string itself.
-        private const val KEY_OVERHEAD = 96
+        // The keys and punctuation around the values:
+        // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is 58 chars.
+        // Escaping is counted separately by [escapedLength], so this is a fixed cost.
+        private const val KEY_OVERHEAD = 64
+
+        /**
+         * The length a string occupies once JSON-escaped.
+         *
+         * `comment` is free text a user typed, so its raw length is not what reaches
+         * the wire: a quote or backslash becomes two characters and a control
+         * character becomes six. Counting the raw length instead would let an
+         * escaping-heavy comment breach [MAX_METADATA_CHARS] unnoticed — and NWC-06
+         * makes the wallet drop the WHOLE object then, losing `recipient_data` too,
+         * which is the degradation this budget exists to protect.
+         *
+         * Over-counts the short forms (`\n` is two characters, not six), which is
+         * the safe direction.
+         */
+        private fun escapedLength(value: String): Int =
+            value.sumOf { char ->
+                when {
+                    char == '"' || char == '\\' -> 2
+                    char < ' ' -> 6
+                    else -> 1
+                }
+            }
 
         /**
          * Assembles NWC-06 `metadata` for an outgoing payment, or null when there is
@@ -175,7 +195,7 @@ class NwcTransactionMetadata(
                 // string that gets embedded, not a reconstruction of it.
                 val raw = zapRequest.toJson()
                 val chars =
-                    recipientIdentifier.orEmpty().length + comment.orEmpty().length +
+                    escapedLength(recipientIdentifier.orEmpty()) + escapedLength(comment.orEmpty()) +
                         raw.length + KEY_OVERHEAD
                 if (chars <= MAX_METADATA_CHARS) {
                     lean["nostr"] = RawJson(raw)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
@@ -126,11 +126,11 @@ class NwcTransactionMetadata(
          */
         const val MAX_METADATA_CHARS = 4096
 
-        // Upper bounds on the punctuation each part adds once serialized. Deliberately
-        // generous: overshooting drops `nostr` on a payment that would just have fit,
-        // while undershooting sends an object the wallet must throw away.
-        private const val LEAN_KEY_OVERHEAD = 64
-        private const val NOSTR_KEY_OVERHEAD = 16
+        // Slack for the keys and punctuation around the values once serialized —
+        // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is ~56 chars.
+        // Deliberately generous: overshooting drops `nostr` on a payment that would
+        // just have fit, undershooting sends an object the wallet must throw away.
+        private const val KEY_OVERHEAD = 96
 
         /**
          * Assembles NWC-06 `metadata` for an outgoing payment, or null when there is
@@ -162,22 +162,17 @@ class NwcTransactionMetadata(
             comment?.ifBlank { null }?.let { lean["comment"] = it }
 
             if (zapRequest != null) {
-                val leanChars = lean.values.sumOf { estimateChars(it) } + LEAN_KEY_OVERHEAD
-                val nostrChars = zapRequest.toJson().length + NOSTR_KEY_OVERHEAD
-                if (leanChars + nostrChars <= MAX_METADATA_CHARS) {
+                // toJson() is the exact serialized length of the `nostr` sub-object.
+                val chars =
+                    recipientIdentifier.orEmpty().length + comment.orEmpty().length +
+                        zapRequest.toJson().length + KEY_OVERHEAD
+                if (chars <= MAX_METADATA_CHARS) {
                     lean["nostr"] = zapRequestFields(zapRequest)
                 }
             }
 
             return lean.ifEmpty { null }
         }
-
-        private fun estimateChars(value: Any?): Int =
-            when (value) {
-                is String -> value.length
-                is Map<*, *> -> value.values.sumOf { estimateChars(it) } + LEAN_KEY_OVERHEAD
-                else -> 0
-            }
 
         private fun zapRequestFields(event: Event): Map<String, Any?> =
             mapOf(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip47WalletConnect.rpc
 
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.RawJson
 import com.vitorpamplona.quartz.nip19Bech32.decodePublicKeyAsHexOrNull
 
 class NwcTransactionMetadata(
@@ -126,24 +127,30 @@ class NwcTransactionMetadata(
          */
         const val MAX_METADATA_CHARS = 4096
 
-        // Slack for the keys and punctuation around the values once serialized —
+        // The keys and punctuation around the values once serialized —
         // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is ~56 chars.
-        // Deliberately generous: overshooting drops `nostr` on a payment that would
-        // just have fit, undershooting sends an object the wallet must throw away.
+        // Only this wrapper is estimated now; every value's length is exact.
         private const val KEY_OVERHEAD = 96
 
         /**
          * Assembles NWC-06 `metadata` for an outgoing payment, or null when there is
          * nothing worth saying.
          *
-         * `nostr` is built from the event's TYPED fields rather than by re-parsing its
-         * JSON. A wallet that verifies the request recomputes the event id from these
-         * values, so `kind` and `created_at` must stay integers — and the obvious
-         * shortcut breaks exactly that: [com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization.toAnyValue]
-         * resolves untyped numbers with `toDoubleOrNull()` BEFORE `toLongOrNull()`, so
-         * a JSON round-trip would emit `"kind": 9734.0` on the kotlinx (native) path
-         * while the JVM/Jackson path stayed correct — invisible on the platform we
-         * test on, broken on the one we do not.
+         * `nostr` carries the zap request's OWN serialization verbatim, as [RawJson].
+         *
+         * NIP-57 sets a zap invoice's `description_hash` to the sha256 of the raw
+         * JSON the LNURL callback received in `nostr=`, and that is
+         * `LnZapRequestEvent.toJson()` — the exact string used here. A wallet can
+         * therefore bind this stored event to the invoice it labels, which is what
+         * turns "the client says it paid X" into something the wallet checked.
+         *
+         * Rebuilding the object from typed fields would put that binding at the mercy
+         * of key order, escaping and number formatting matching by coincidence, and
+         * it fails as a silently unlabelled row rather than as an error. Passing the
+         * bytes through also sidesteps the number-widening hazard in
+         * [com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization.toAnyValue],
+         * which resolves untyped numbers with `toDoubleOrNull()` BEFORE
+         * `toLongOrNull()`: nothing here decomposes the event at all.
          *
          * When the whole object would breach [MAX_METADATA_CHARS], `nostr` is dropped
          * and the much smaller `recipient_data`/`comment` pair survives, so the row
@@ -162,27 +169,18 @@ class NwcTransactionMetadata(
             comment?.ifBlank { null }?.let { lean["comment"] = it }
 
             if (zapRequest != null) {
-                // toJson() is the exact serialized length of the `nostr` sub-object.
+                // The serialized length of the `nostr` member, exactly — it is the
+                // string that gets embedded, not a reconstruction of it.
+                val raw = zapRequest.toJson()
                 val chars =
                     recipientIdentifier.orEmpty().length + comment.orEmpty().length +
-                        zapRequest.toJson().length + KEY_OVERHEAD
+                        raw.length + KEY_OVERHEAD
                 if (chars <= MAX_METADATA_CHARS) {
-                    lean["nostr"] = zapRequestFields(zapRequest)
+                    lean["nostr"] = RawJson(raw)
                 }
             }
 
             return lean.ifEmpty { null }
         }
-
-        private fun zapRequestFields(event: Event): Map<String, Any?> =
-            mapOf(
-                "id" to event.id,
-                "pubkey" to event.pubKey,
-                "created_at" to event.createdAt,
-                "kind" to event.kind,
-                "tags" to event.tags.map { it.toList() },
-                "content" to event.content,
-                "sig" to event.sig,
-            )
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip47WalletConnect.rpc
 
+import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip19Bech32.decodePublicKeyAsHexOrNull
 
 class NwcTransactionMetadata(
@@ -41,15 +42,25 @@ class NwcTransactionMetadata(
     class NostrZapData(
         val pubkeyHex: String?,
         val recipientPubkeyHex: String?,
+        val content: String?,
     )
 
     fun senderPubkeyHex(): String? = nostr?.pubkeyHex ?: payerData?.pubkey?.let { decodePublicKeyAsHexOrNull(it) }
 
-    fun senderDisplayName(): String? = payerData?.name ?: payerData?.email
+    fun senderDisplayName(): String? = payerData?.name?.ifBlank { null } ?: payerData?.email?.ifBlank { null }
 
-    fun recipientIdentifier(): String? = recipientData?.identifier
+    fun recipientIdentifier(): String? = recipientData?.identifier?.ifBlank { null }
 
     fun recipientPubkeyHex(): String? = nostr?.recipientPubkeyHex
+
+    /**
+     * The message to show for this transaction.
+     *
+     * A wallet that stores only `nostr` still carries the message: a zap request's
+     * `content` IS the public zap comment. Private-zap messages are encrypted into
+     * the `anon` tag rather than content, so nothing encrypted can surface here.
+     */
+    fun displayComment(): String? = comment?.ifBlank { null } ?: nostr?.content?.ifBlank { null }
 
     companion object {
         fun parse(metadata: Any?): NwcTransactionMetadata? {
@@ -92,6 +103,7 @@ class NwcTransactionMetadata(
                     NostrZapData(
                         pubkeyHex = pubkeyHex,
                         recipientPubkeyHex = recipientHex,
+                        content = n["content"] as? String,
                     )
                 }
 
@@ -106,5 +118,76 @@ class NwcTransactionMetadata(
                 nostr = nostr,
             )
         }
+
+        /**
+         * NWC-06: "The metadata MUST be no more than 4096 characters, otherwise MUST
+         * be dropped." A wallet is required to discard an over-long object wholesale,
+         * so breaching this loses the recipient entirely rather than degrading.
+         */
+        const val MAX_METADATA_CHARS = 4096
+
+        // Upper bounds on the punctuation each part adds once serialized. Deliberately
+        // generous: overshooting drops `nostr` on a payment that would just have fit,
+        // while undershooting sends an object the wallet must throw away.
+        private const val LEAN_KEY_OVERHEAD = 64
+        private const val NOSTR_KEY_OVERHEAD = 16
+
+        /**
+         * Assembles NWC-06 `metadata` for an outgoing payment, or null when there is
+         * nothing worth saying.
+         *
+         * `nostr` is built from the event's TYPED fields rather than by re-parsing its
+         * JSON. A wallet that verifies the request recomputes the event id from these
+         * values, so `kind` and `created_at` must stay integers — and the obvious
+         * shortcut breaks exactly that: [com.vitorpamplona.quartz.nip47WalletConnect.kotlinSerialization.toAnyValue]
+         * resolves untyped numbers with `toDoubleOrNull()` BEFORE `toLongOrNull()`, so
+         * a JSON round-trip would emit `"kind": 9734.0` on the kotlinx (native) path
+         * while the JVM/Jackson path stayed correct — invisible on the platform we
+         * test on, broken on the one we do not.
+         *
+         * When the whole object would breach [MAX_METADATA_CHARS], `nostr` is dropped
+         * and the much smaller `recipient_data`/`comment` pair survives, so the row
+         * still names the payee instead of arriving blank.
+         */
+        fun build(
+            zapRequest: Event?,
+            recipientIdentifier: String?,
+            comment: String?,
+        ): Map<String, Any?>? {
+            val lean = mutableMapOf<String, Any?>()
+
+            recipientIdentifier?.ifBlank { null }?.let {
+                lean["recipient_data"] = mapOf("identifier" to it)
+            }
+            comment?.ifBlank { null }?.let { lean["comment"] = it }
+
+            if (zapRequest != null) {
+                val leanChars = lean.values.sumOf { estimateChars(it) } + LEAN_KEY_OVERHEAD
+                val nostrChars = zapRequest.toJson().length + NOSTR_KEY_OVERHEAD
+                if (leanChars + nostrChars <= MAX_METADATA_CHARS) {
+                    lean["nostr"] = zapRequestFields(zapRequest)
+                }
+            }
+
+            return lean.ifEmpty { null }
+        }
+
+        private fun estimateChars(value: Any?): Int =
+            when (value) {
+                is String -> value.length
+                is Map<*, *> -> value.values.sumOf { estimateChars(it) } + LEAN_KEY_OVERHEAD
+                else -> 0
+            }
+
+        private fun zapRequestFields(event: Event): Map<String, Any?> =
+            mapOf(
+                "id" to event.id,
+                "pubkey" to event.pubKey,
+                "created_at" to event.createdAt,
+                "kind" to event.kind,
+                "tags" to event.tags.map { it.toList() },
+                "content" to event.content,
+                "sig" to event.sig,
+            )
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/NwcTransactionMetadata.kt
@@ -127,9 +127,11 @@ class NwcTransactionMetadata(
          */
         const val MAX_METADATA_CHARS = 4096
 
-        // The keys and punctuation around the values once serialized —
-        // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is ~56 chars.
-        // Only this wrapper is estimated now; every value's length is exact.
+        // The keys and punctuation around the values —
+        // `{"recipient_data":{"identifier":""},"comment":"","nostr":}` is 58 chars —
+        // plus room for JSON escaping to expand `identifier` and `comment` on the way
+        // out, which is the only thing that can make this estimate low. `nostr` needs
+        // no such allowance: the length added below is the serialized string itself.
         private const val KEY_OVERHEAD = 96
 
         /**

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
@@ -22,21 +22,50 @@ package com.vitorpamplona.quartz.nip47WalletConnect.rpc
 
 import com.vitorpamplona.quartz.nip01Core.core.OptimizedSerializable
 
+/**
+ * A request parameter block carrying NIP-47's optional `metadata`, whose keys
+ * NWC-06 defines.
+ *
+ * The field is `var` so a client can strip it before sending: it may only go to a
+ * wallet that advertised `06` in its info event's `extensions` tag, because a
+ * wallet that types `metadata` narrowly accepts a null but cannot decode an object
+ * and answers a params error instead of paying.
+ */
+interface MetadataCarrying {
+    var metadata: Map<String, Any?>?
+}
+
 // REQUEST OBJECTS
-abstract class Request(
+sealed class Request(
     var method: String? = null,
-) : OptimizedSerializable
+) : OptimizedSerializable {
+    /**
+     * This request's NWC-06 metadata, or null for a method that has none.
+     *
+     * Declared HERE, and overridden beside each method that carries one, so that
+     * adding a metadata-bearing method is a decision made where the method is
+     * written. The alternative — a `when` over request types in the client — needs
+     * an `else`, and an `else` silently leaks the field to a wallet that never
+     * opted in.
+     *
+     * create_connection is deliberately absent: its `metadata` names the
+     * connection and is not NWC-06's per-payment blob.
+     */
+    open val metadataCarrier: MetadataCarrying? get() = null
+}
 
 // pay_invoice
 class PayInvoiceParams(
     var invoice: String? = null,
     var amount: Long? = null,
-    var metadata: Map<String, Any?>? = null,
-)
+    override var metadata: Map<String, Any?>? = null,
+) : MetadataCarrying
 
 class PayInvoiceMethod(
     var params: PayInvoiceParams? = null,
 ) : Request(NwcMethod.PAY_INVOICE) {
+    override val metadataCarrier get() = params
+
     companion object {
         // `metadata` is NIP-47's optional per-payment blob, whose keys NWC-06 defines.
         // Only ever populate it for a wallet that advertises NWC-06 (`06` in the info
@@ -64,12 +93,14 @@ class PayParams(
     var payment: String? = null,
     var amount: Long? = null,
     var payer_note: String? = null,
-    var metadata: Map<String, Any?>? = null,
-)
+    override var metadata: Map<String, Any?>? = null,
+) : MetadataCarrying
 
 class PayMethod(
     var params: PayParams? = null,
 ) : Request(NwcMethod.PAY) {
+    override val metadataCarrier get() = params
+
     companion object {
         fun create(
             payment: String,
@@ -83,12 +114,14 @@ class PayMethod(
 class ReceiveParams(
     var amount: Long? = null,
     var description: String? = null,
-    var metadata: Map<String, Any?>? = null,
-)
+    override var metadata: Map<String, Any?>? = null,
+) : MetadataCarrying
 
 class ReceiveMethod(
     var params: ReceiveParams? = null,
 ) : Request(NwcMethod.RECEIVE) {
+    override val metadataCarrier get() = params
+
     companion object {
         fun create(
             amount: Long? = null,
@@ -124,12 +157,14 @@ class MakeInvoiceParams(
     var description: String? = null,
     var description_hash: String? = null,
     var expiry: Long? = null,
-    var metadata: Map<String, Any?>? = null,
-)
+    override var metadata: Map<String, Any?>? = null,
+) : MetadataCarrying
 
 class MakeInvoiceMethod(
     var params: MakeInvoiceParams? = null,
 ) : Request(NwcMethod.MAKE_INVOICE) {
+    override val metadataCarrier get() = params
+
     companion object {
         fun create(
             amount: Long,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
@@ -40,16 +40,15 @@ sealed class Request(
     var method: String? = null,
 ) : OptimizedSerializable {
     /**
-     * This request's NWC-06 metadata, or null for a method that has none.
+     * This request's NWC-06 metadata carrier, or null for a method that has none.
      *
-     * Declared HERE, and overridden beside each method that carries one, so that
-     * adding a metadata-bearing method is a decision made where the method is
-     * written. The alternative — a `when` over request types in the client — needs
-     * an `else`, and an `else` silently leaks the field to a wallet that never
-     * opted in.
+     * Declared HERE, and overridden beside each method that carries one, so adding a
+     * metadata-bearing method is a decision made where the method is written. The
+     * alternative — a `when` over request types in the client — needs an `else`, and
+     * an `else` silently leaks the field to a wallet that never opted in.
      *
-     * create_connection is deliberately absent: its `metadata` names the
-     * connection and is not NWC-06's per-payment blob.
+     * create_connection is deliberately absent: its `metadata` names the connection
+     * and is not NWC-06's per-payment blob.
      */
     open val metadataCarrier: MetadataCarrying? get() = null
 }
@@ -67,10 +66,7 @@ class PayInvoiceMethod(
     override val metadataCarrier get() = params
 
     companion object {
-        // `metadata` is NIP-47's optional per-payment blob, whose keys NWC-06 defines.
-        // Only ever populate it for a wallet that advertises NWC-06 (`06` in the info
-        // event's `extensions` tag): a wallet is free to type the field narrowly, and
-        // one that cannot decode an object it never asked for refuses the payment.
+        // `metadata` may only travel to a wallet that advertised it — see [MetadataCarrying].
         fun create(
             bolt11: String,
             metadata: Map<String, Any?>? = null,
@@ -79,8 +75,7 @@ class PayInvoiceMethod(
         fun create(
             bolt11: String,
             amount: Long,
-            metadata: Map<String, Any?>? = null,
-        ): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11, amount, metadata))
+        ): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11, amount))
     }
 }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Request.kt
@@ -38,12 +38,20 @@ class PayInvoiceMethod(
     var params: PayInvoiceParams? = null,
 ) : Request(NwcMethod.PAY_INVOICE) {
     companion object {
-        fun create(bolt11: String): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11))
+        // `metadata` is NIP-47's optional per-payment blob, whose keys NWC-06 defines.
+        // Only ever populate it for a wallet that advertises NWC-06 (`06` in the info
+        // event's `extensions` tag): a wallet is free to type the field narrowly, and
+        // one that cannot decode an object it never asked for refuses the payment.
+        fun create(
+            bolt11: String,
+            metadata: Map<String, Any?>? = null,
+        ): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11, metadata = metadata))
 
         fun create(
             bolt11: String,
             amount: Long,
-        ): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11, amount))
+            metadata: Map<String, Any?>? = null,
+        ): PayInvoiceMethod = PayInvoiceMethod(PayInvoiceParams(bolt11, amount, metadata))
     }
 }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/tags/ExtensionsTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/tags/ExtensionsTag.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip47WalletConnect.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+/**
+ * NIP-47's `extensions` tag on the kind 13194 info event: the optional NWC
+ * extension specs a wallet service supports, space-separated (eg. `02 03 04`).
+ *
+ * This is how a client learns it may use anything beyond the core command set
+ * without guessing. It matters most for request fields a wallet might not
+ * understand — sending one to a wallet that never advertised support risks a
+ * refusal on a method that would otherwise have worked.
+ */
+class ExtensionsTag {
+    companion object {
+        const val TAG_NAME = "extensions"
+
+        // The specs this client knows how to use, so a caller names a constant
+        // rather than a bare string at each gate.
+        const val TRANSACTION_HISTORY = "05"
+        const val METADATA_CONVENTIONS = "06"
+
+        fun isTag(tag: Array<String>) = tag.has(1) && tag[0] == TAG_NAME && tag[1].isNotEmpty()
+
+        fun parse(tag: Array<String>): List<String>? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag.drop(1)
+        }
+
+        fun assemble(extensions: List<String>) = arrayOf(TAG_NAME, *extensions.toTypedArray())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/tags/ExtensionsTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/tags/ExtensionsTag.kt
@@ -41,8 +41,6 @@ class ExtensionsTag {
         const val TRANSACTION_HISTORY = "05"
         const val METADATA_CONVENTIONS = "06"
 
-        fun isTag(tag: Array<String>) = tag.has(1) && tag[0] == TAG_NAME && tag[1].isNotEmpty()
-
         fun parse(tag: Array<String>): List<String>? {
             ensure(tag.has(1)) { return null }
             ensure(tag[0] == TAG_NAME) { return null }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip47WalletConnect
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.OptimizedJsonMapper
+import com.vitorpamplona.quartz.nip47WalletConnect.events.NwcInfoEvent
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransactionMetadata
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceMethod
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
+import com.vitorpamplona.quartz.nip47WalletConnect.tags.ExtensionsTag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * NWC-06 metadata on OUTGOING payments: what we send, when we are allowed to send
+ * it, and what a row makes of it coming back.
+ */
+class NwcOutgoingMetadataTest {
+    private val recipientHex = "ca89cb11f1c75d5b6622268ff43d2288ea8b2cb5b9aa996ff9ff704fc904b78b"
+    private val payerHex = "f512822a89d2369a386bfeb1e687ccd26ceb6bb33e73b98417499bb9054bff1f"
+
+    private fun zapRequest(
+        content: String = "great post",
+        relays: List<String> = listOf("wss://relay.damus.io"),
+    ) = Event(
+        id = "a".repeat(64),
+        pubKey = payerHex,
+        createdAt = 1756000000L,
+        kind = 9734,
+        tags = arrayOf(arrayOf("p", recipientHex), arrayOf("relays", *relays.toTypedArray())),
+        content = content,
+        sig = "b".repeat(128),
+    )
+
+    // --- build ---
+
+    @Test
+    fun nothingToSayProducesNoMetadataAtAll() {
+        assertNull(NwcTransactionMetadata.build(null, null, null))
+        assertNull(NwcTransactionMetadata.build(null, "   ", ""))
+    }
+
+    @Test
+    fun leanPairIsSentWithoutAZapRequest() {
+        val meta = assertNotNull(NwcTransactionMetadata.build(null, "user@domain.com", "thanks"))
+        assertEquals(mapOf("identifier" to "user@domain.com"), meta["recipient_data"])
+        assertEquals("thanks", meta["comment"])
+        assertFalse(meta.containsKey("nostr"))
+    }
+
+    @Test
+    fun zapRequestTravelsWithTypedFields() {
+        val meta = assertNotNull(NwcTransactionMetadata.build(zapRequest(), "user@domain.com", "great post"))
+
+        @Suppress("UNCHECKED_CAST")
+        val nostr = meta["nostr"] as Map<String, Any?>
+
+        // Integers, not floats: a verifying wallet recomputes the event id from these.
+        assertEquals(9734, nostr["kind"])
+        assertEquals(1756000000L, nostr["created_at"])
+        assertEquals(payerHex, nostr["pubkey"])
+        assertEquals("great post", nostr["content"])
+        assertEquals(listOf(listOf("p", recipientHex), listOf("relays", "wss://relay.damus.io")), nostr["tags"])
+    }
+
+    @Test
+    fun anOversizeZapRequestIsDroppedButTheRowStillNamesThePayee() {
+        // NWC-06: over 4096 characters a wallet MUST drop the WHOLE object, so
+        // breaching it would lose the payee entirely rather than degrade.
+        val many = List(200) { "wss://relay-with-a-fairly-long-hostname-.example.com" }
+        val meta = assertNotNull(NwcTransactionMetadata.build(zapRequest(relays = many), "user@domain.com", "hi"))
+
+        assertFalse(meta.containsKey("nostr"))
+        assertEquals(mapOf("identifier" to "user@domain.com"), meta["recipient_data"])
+        assertEquals("hi", meta["comment"])
+    }
+
+    @Test
+    fun whatWeSendStaysUnderTheSpecCeiling() {
+        val meta = NwcTransactionMetadata.build(zapRequest(), "user@domain.com", "great post")
+        val serialized = OptimizedJsonMapper.toJson(PayInvoiceMethod.create("lnbc50n1abc", meta))
+        assertTrue(serialized.length < NwcTransactionMetadata.MAX_METADATA_CHARS)
+    }
+
+    // --- the wire ---
+
+    @Test
+    fun metadataSurvivesASerializationRoundTrip() {
+        val meta = NwcTransactionMetadata.build(zapRequest(), "user@domain.com", "great post")
+        val json = OptimizedJsonMapper.toJson(PayInvoiceMethod.create("lnbc50n1abc", meta))
+
+        assertTrue(json.contains("\"kind\":9734"), "kind must stay an integer: $json")
+        assertTrue(json.contains("\"created_at\":1756000000"), "created_at must stay an integer: $json")
+
+        val back = OptimizedJsonMapper.fromJsonTo<Request>(json)
+        assertIs<PayInvoiceMethod>(back)
+        val parsed = assertNotNull(NwcTransactionMetadata.parse(back.params?.metadata))
+        assertEquals(recipientHex, parsed.recipientPubkeyHex())
+        assertEquals("great post", parsed.displayComment())
+    }
+
+    @Test
+    fun noMetadataMeansTheRequestIsUnchanged() {
+        // The regression test that protects every wallet which has not advertised
+        // NWC-06: what they receive must be byte-identical to what they receive today.
+        val expected = OptimizedJsonMapper.toJson(PayInvoiceMethod.create("lnbc50n1abc"))
+        val actual = OptimizedJsonMapper.toJson(PayInvoiceMethod.create("lnbc50n1abc", null))
+        assertEquals(expected, actual)
+        assertFalse(actual.contains("recipient_data"))
+    }
+
+    // --- the gate ---
+
+    @Test
+    fun extensionsTagIsReadFromTheInfoEvent() {
+        assertEquals(listOf("02", "05", "06"), infoWith(arrayOf("extensions", "02 05 06")).extensions())
+        assertTrue(infoWith(arrayOf("extensions", "05 06")).supportsExtension(ExtensionsTag.METADATA_CONVENTIONS))
+    }
+
+    @Test
+    fun aWalletThatSaysNothingReadsAsNo() {
+        assertFalse(infoWith().supportsExtension(ExtensionsTag.METADATA_CONVENTIONS))
+        assertFalse(infoWith(arrayOf("extensions", "")).supportsExtension(ExtensionsTag.METADATA_CONVENTIONS))
+        assertFalse(infoWith(arrayOf("extensions", "02 03")).supportsExtension(ExtensionsTag.METADATA_CONVENTIONS))
+        assertTrue(infoWith().extensions().isEmpty())
+    }
+
+    private fun infoWith(vararg tags: Array<String>) =
+        NwcInfoEvent(
+            id = "c".repeat(64),
+            pubKey = payerHex,
+            createdAt = 1756000000L,
+            tags = arrayOf(*tags),
+            content = "pay_invoice get_balance",
+            sig = "d".repeat(128),
+        )
+
+    // --- reading it back ---
+
+    @Test
+    fun anOutgoingRowResolvesThePayeeFromThePTag() {
+        val meta = NwcTransactionMetadata.build(zapRequest(content = "for the article"), "user@domain.com", "")
+        val parsed = assertNotNull(NwcTransactionMetadata.parse(meta))
+
+        // The p tag, not the pubkey: on an outgoing zap the pubkey is US.
+        assertEquals(recipientHex, parsed.recipientPubkeyHex())
+        assertEquals("user@domain.com", parsed.recipientIdentifier())
+        // A wallet storing only  still yields the message.
+        assertEquals("for the article", parsed.displayComment())
+    }
+
+    @Test
+    fun blankFieldsReadAsAbsent() {
+        val parsed =
+            assertNotNull(
+                NwcTransactionMetadata.parse(
+                    mapOf(
+                        "comment" to "  ",
+                        "recipient_data" to mapOf("identifier" to ""),
+                        "nostr" to mapOf("content" to ""),
+                    ),
+                ),
+            )
+        assertNull(parsed.recipientIdentifier())
+        assertNull(parsed.displayComment())
+    }
+
+    @Test
+    fun emptyDescriptionIsNotAName() {
+        // The wallet-side habit this exists for:  rather than an
+        // omitted field. The row must fall back, not render an empty line.
+        val tx = NwcTransaction(type = "outgoing", description = "", amount = 21000L)
+        assertEquals("", tx.description)
+        assertNull(tx.description?.ifBlank { null })
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
@@ -121,6 +121,40 @@ class NwcOutgoingMetadataTest {
         assertEquals("hi", meta["comment"])
     }
 
+    /**
+     * A provider that does not advertise `allowsNostr` never receives the zap request,
+     * so its invoice commits to nothing about it. Passing null here is how the caller
+     * says so, and the metadata must then make no claim it cannot support — while the
+     * payee's address still labels the row.
+     */
+    @Test
+    fun withoutAZapRequestTheRowIsStillNamedButClaimsNoBinding() {
+        val meta = assertNotNull(NwcTransactionMetadata.build(null, "user@domain.com", "great post"))
+
+        assertFalse(meta.containsKey("nostr"))
+        assertEquals(mapOf("identifier" to "user@domain.com"), meta["recipient_data"])
+        assertEquals("great post", meta["comment"])
+    }
+
+    /**
+     * `comment` is free text, and JSON escaping expands it on the way out. Counting the
+     * raw length would let an escaping-heavy comment breach the 4096 ceiling unnoticed
+     * — and NWC-06 makes the wallet drop the WHOLE object then, taking `recipient_data`
+     * with it.
+     */
+    @Test
+    fun theCeilingCountsEscapedLengthNotRawLength() {
+        // Every character escapes to six, so 900 raw chars occupy ~5400 on the wire.
+        val controlHeavy = "\u0001".repeat(900)
+        val meta = assertNotNull(NwcTransactionMetadata.build(zapRequest(), "user@domain.com", controlHeavy))
+
+        assertFalse(meta.containsKey("nostr"), "the escaped comment alone exceeds the ceiling")
+
+        // The same length in plain characters leaves room for the zap request.
+        val plain = "a".repeat(900)
+        assertTrue(assertNotNull(NwcTransactionMetadata.build(zapRequest(), "user@domain.com", plain)).containsKey("nostr"))
+    }
+
     @Test
     fun whatWeSendStaysUnderTheSpecCeiling() {
         val meta = NwcTransactionMetadata.build(zapRequest(), "user@domain.com", "great post")

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
@@ -195,7 +195,7 @@ class NwcOutgoingMetadataTest {
         // The p tag, not the pubkey: on an outgoing zap the pubkey is US.
         assertEquals(recipientHex, parsed.recipientPubkeyHex())
         assertEquals("user@domain.com", parsed.recipientIdentifier())
-        // A wallet storing only  still yields the message.
+        // A wallet storing only `nostr` still yields the message.
         assertEquals("for the article", parsed.displayComment())
     }
 
@@ -217,10 +217,10 @@ class NwcOutgoingMetadataTest {
 
     @Test
     fun emptyDescriptionIsNotAName() {
-        // The wallet-side habit this exists for:  rather than an
-        // omitted field. The row must fall back, not render an empty line.
+        // The wallet-side habit this exists for: an empty `description` string
+        // rather than an omitted field. The row must fall back, not render an empty line.
         val tx = NwcTransaction(type = "outgoing", description = "", amount = 21000L)
-        assertEquals("", tx.description)
-        assertNull(tx.description?.ifBlank { null })
+        assertEquals("", tx.description, "the raw field keeps what the wallet sent")
+        assertNull(tx.displayDescription(), "but nothing downstream sees an empty name")
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/NwcOutgoingMetadataTest.kt
@@ -73,19 +73,40 @@ class NwcOutgoingMetadataTest {
         assertFalse(meta.containsKey("nostr"))
     }
 
+    /**
+     * THE INTEROP PROPERTY. NIP-57 sets a zap invoice's `description_hash` to the
+     * sha256 of the raw JSON the LNURL callback received in `nostr=` — which is
+     * `LnZapRequestEvent.toJson()` (see LightningAddressResolver). A wallet that
+     * binds a stored zap request to the invoice it labels hashes the bytes of the
+     * `nostr` member, so anything short of byte-identity reads as a forged event
+     * and the row is silently stored unlabelled.
+     */
     @Test
-    fun zapRequestTravelsWithTypedFields() {
-        val meta = assertNotNull(NwcTransactionMetadata.build(zapRequest(), "user@domain.com", "great post"))
+    fun theNostrMemberIsByteIdenticalToWhatTheLnurlCallbackReceived() {
+        val event = zapRequest(content = "quoted \" and & <angled> \u00fcn\u00efcode \ud83d\ude00")
+        val callbackBytes = event.toJson()
 
-        @Suppress("UNCHECKED_CAST")
-        val nostr = meta["nostr"] as Map<String, Any?>
+        val wire =
+            OptimizedJsonMapper.toJson(
+                PayInvoiceMethod.create("lnbc50n1abc", NwcTransactionMetadata.build(event, "user@domain.com", "hi")),
+            )
 
-        // Integers, not floats: a verifying wallet recomputes the event id from these.
-        assertEquals(9734, nostr["kind"])
-        assertEquals(1756000000L, nostr["created_at"])
-        assertEquals(payerHex, nostr["pubkey"])
-        assertEquals("great post", nostr["content"])
-        assertEquals(listOf(listOf("p", recipientHex), listOf("relays", "wss://relay.damus.io")), nostr["tags"])
+        assertTrue(
+            wire.contains("\"nostr\":" + callbackBytes),
+            "metadata.nostr must be the callback's own bytes.\n  sent: $callbackBytes\n  wire: $wire",
+        )
+    }
+
+    @Test
+    fun theZapRequestSurvivesAsAReadableObject() {
+        val event = zapRequest()
+        val wire = OptimizedJsonMapper.toJson(PayInvoiceMethod.create("lnbc1", NwcTransactionMetadata.build(event, null, null)))
+        val back = OptimizedJsonMapper.fromJsonTo<Request>(wire) as PayInvoiceMethod
+        val parsed = assertNotNull(NwcTransactionMetadata.parse(back.params?.metadata))
+
+        // Raw on the way out, a normal object on the way back in.
+        assertEquals(recipientHex, parsed.recipientPubkeyHex())
+        assertEquals(payerHex, parsed.senderPubkeyHex())
     }
 
     @Test
@@ -164,8 +185,12 @@ class NwcOutgoingMetadataTest {
 
     @Test
     fun anOutgoingRowResolvesThePayeeFromThePTag() {
-        val meta = NwcTransactionMetadata.build(zapRequest(content = "for the article"), "user@domain.com", "")
-        val parsed = assertNotNull(NwcTransactionMetadata.parse(meta))
+        val wire =
+            OptimizedJsonMapper.toJson(
+                PayInvoiceMethod.create("lnbc1", NwcTransactionMetadata.build(zapRequest(content = "for the article"), "user@domain.com", "")),
+            )
+        val back = OptimizedJsonMapper.fromJsonTo<Request>(wire) as PayInvoiceMethod
+        val parsed = assertNotNull(NwcTransactionMetadata.parse(back.params?.metadata))
 
         // The p tag, not the pubkey: on an outgoing zap the pubkey is US.
         assertEquals(recipientHex, parsed.recipientPubkeyHex())

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonMapper.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonMapper.kt
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.OptimizedSerializable
+import com.vitorpamplona.quartz.nip01Core.core.RawJson
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
 import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.Message
 import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.MessageDeserializer
@@ -84,6 +85,7 @@ class JacksonMapper {
                 .registerModule(
                     SimpleModule()
                         // nip 01
+                        .addSerializer(RawJson::class.java, RawJsonSerializer())
                         .addSerializer(Event::class.java, EventSerializer())
                         .addDeserializer(Event::class.java, EventDeserializer())
                         .addSerializer(Filter::class.java, FilterSerializer())

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/RawJsonSerializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/RawJsonSerializer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.jackson
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.vitorpamplona.quartz.nip01Core.core.RawJson
+
+/** Writes [RawJson.json] straight into the output, unquoted and unescaped. */
+class RawJsonSerializer : StdSerializer<RawJson>(RawJson::class.java) {
+    override fun serialize(
+        value: RawJson,
+        gen: JsonGenerator,
+        provider: SerializerProvider,
+    ) {
+        gen.writeRawValue(value.json)
+    }
+}

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/jackson/RequestSerializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/jackson/RequestSerializer.kt
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CancelHoldInvoiceMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CreateConnectionMethod
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBalanceMethod
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBudgetMethod
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetInfoMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.ListTransactionsMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.LookupInvoiceMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.MakeHoldInvoiceMethod
@@ -119,6 +122,14 @@ class RequestSerializer : StdSerializer<Request>(Request::class.java) {
                     gen.writeObjectField("params", value.params)
                 }
             }
+
+            // Parameterless: `method` alone is the whole request. Spelled out rather
+            // than left to fall through, because Request is sealed and the compiler
+            // now makes every method state which of the two shapes it is.
+            is GetBalanceMethod,
+            is GetBudgetMethod,
+            is GetInfoMethod,
+            -> Unit
         }
         gen.writeEndObject()
     }


### PR DESCRIPTION
The wallet I'm building is almost ready. Testing it with Amethyst discovered Amethyst wallet ui needed some love. Amethyst could read NWC-06 but never wrote it, and had no way to ask a wallet whether it understood it. This adds the write half plus the capability detection that gates it.

Have done extensive field testing, found bugs in external wallet providers and raised bugs in their repos.

## Summary

Outgoing rows in the NWC wallet history showed an arrow, an amount and a date, with an invisible blank line where the payee should be. Two causes: the row rendered an empty string rather than falling back (wallets send `"description": ""` for a payment with no memo, and an elvis only catches `null`), and Amethyst never told the wallet who it was paying — `PayInvoiceParams.metadata` existed and nothing ever set it, while a NIP-57 zap invoice commits to a `description_hash` rather than a readable memo, so the wallet had nothing to lift either.

This sends NIP-47's optional `metadata` on `pay_invoice`, following NWC-06's key conventions, so a wallet that stores it can name the payee on an outgoing row. Everything degrades: a wallet that never advertises support receives a byte-identical request to today's, and a payload that cannot carry the zap request still names the payee.

## What is sent

Only to a wallet whose kind 13194 info event advertises `06`. Every other wallet — every wallet in use today — sees no change at all.

```yaml
{"method":"pay_invoice","params":{
    "invoice": "lnbc…",
    "metadata": {
        "nostr": {…},                                     # the signed kind 9734, byte-for-byte
        "recipient_data": {"identifier": "name@domain"},   # the payee's lightning address
        "comment": "the zap message"
    }
}}
```

`metadata.nostr` carries the zap request's own serialisation verbatim, as a pre-serialised raw JSON value (`RawJson`: Jackson `writeRawValue`, kotlinx `JsonUnquotedLiteral`). This matters because NIP-57 sets a zap invoice's `description_hash` to the SHA-256 of the exact bytes the LNURL callback received in `nostr=`, so a wallet can bind the stored request to the invoice it labels. Rebuilding the event from typed fields would make that binding depend on key order, escaping and number formatting agreeing by coincidence, and it fails silently as an unlabelled row.

## The fallbacks

Three independent degradation paths, because a cosmetic field must never cost a payment or a label.

| Condition | Behaviour |
| --- | --- |
| Wallet has not advertised NWC-06 `06` | `metadata` omitted entirely; request byte-identical to current release |
| Metadata would exceed NWC-06's 4096-character ceiling | `nostr` dropped, `recipient_data` + `comment` survive, so the row still names the payee |
| LNURL provider does not advertise `allowsNostr` | `nostr` omitted — that invoice commits to nothing about the request, so claiming a binding would be false |
| Wallet stores nothing, or `description` is empty/blank | Row falls back to "Sent"/"Received" instead of rendering an invisible line |

The last one is the part that helps today, on every wallet, on history that already exists — it needs no wallet change and no capability advertisement.

The 4096 budget counts JSON-escaped length, not raw length: `comment` is free text a user typed, and a quote or backslash expands to two characters while a control character expands to six. Counting raw length would let an escaping-heavy comment breach the ceiling unnoticed, and NWC-06 requires the wallet to drop the *whole* object then — taking `recipient_data` with it.

## NIP citations

NIP-47, `pay_invoice` request:

> `"metadata": {} // generic metadata that can be used to add things like zap/boostagram details for a payer name/comment/etc, optional`

NIP-47, info event:

> If the **wallet service** supports optional NWC extensions, the info event SHOULD contain an `extensions` tag with the supported extension identifiers space-separated, eg. `02 03 04`.

NWC-06 (Metadata Conventions), which defines the `nostr` / `recipient_data` / `comment` keys used above:

> Metadata MAY be stored by the wallet service alongside invoices and payments. The metadata MUST be no more than 4096 characters, otherwise MUST be dropped.

NWC-05 (Transaction History):

> NWC relays SHOULD allow at least a payload size of 64KB and clients SHOULD fetch small page sizes, such as a maximum of 20 transactions per page

Amethyst's `pageSize` is already 20, so no change was needed there.

## Cross-client compatibility

**Nothing on the wire changes for any wallet that has not advertised `06`.** Jackson already serialises `PayInvoiceParams` with `"metadata": null` on every request today, so the key itself is not new — only a populated value is, and only for wallets that asked. There is a regression test asserting the request is byte-identical when the capability is absent.

**Older Amethyst builds** are unaffected as senders. As readers they are *better* off: the stock release already renders `metadata` it cannot itself send, so a user on the current release sees payee names as soon as a wallet stores the data. Verified on the unpatched build against real history (see test plan).

**Other clients** are unaffected — this changes what Amethyst sends to a wallet, not anything published to relays. No new event kind, no new tag, no change to zap requests or receipts.

**NWC-06 is `draft` `optional`.** Wallets that do not implement it are not wrong, and the capability gate is what keeps them unaffected: a wallet that types `metadata` narrowly would accept a `null` but fail to decode an object, and answer a params error instead of paying. Gating removes that possibility rather than betting on conformance.

## Wire-format verification

`nak req` is not applicable here: NIP-47 requests are kind 23194 with NIP-44/NIP-04 encrypted content, so the payload is not readable from a relay. The equivalent verification was done two ways.

**Automated** — `NwcOutgoingMetadataTest.theNostrMemberIsByteIdenticalToWhatTheLnurlCallbackReceived` asserts the serialised request contains `"nostr":` followed by exactly `LnZapRequestEvent.toJson()`, which is the string `LightningAddressResolver` percent-encodes into the callback URL.

**Against third-party servers** — the receiving wallet recomputes SHA-256 over the bytes of the `nostr` member and compares against the paid invoice's `description_hash`, storing only on a match. Zaps to two unrelated lightning-address providers matched. An apostrophe in the comment `It's a zap to wos` survived the byte-exact check, which is the case that breaks under any re-serialisation.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` for the affected modules
- [x] Manually exercised the change (see notes below)

Automated:

```
./gradlew :quartz:jvmTest :amethyst:testPlayDebugUnitTest spotlessCheck
BUILD SUCCESSFUL in 6m 32s
```

Also compiled `:commons`, `:desktopApp`, `:cli` and `:geode` — `Request` became a `sealed class`, so every downstream consumer was checked.

New tests: byte-identity with the LNURL callback; the 4096 ceiling dropping `nostr` while keeping the lean pair; escaped-vs-raw length; no metadata when the provider does not advertise `allowsNostr`; `extensions` tag parsing; a request byte-identical to today's when the wallet has not advertised `06`; and blank/whitespace/absent `description` all reaching the fallback label.

### Manual testing — against an NWC wallet in development

Device: Pixel 9a, Android 17, `installPlayBenchmark`. Wallet: an NWC wallet service in development that implements NWC-05 and NWC-06 and verifies the `description_hash` binding before storing. Real LND node on a Raspberry Pi 4, real relay (`wss://nos.lol`), real payments to third-party lightning addresses.

- Outgoing zaps to two independent providers stored with the payee bound to the invoice, comments included; the payee's name and avatar render on the outgoing row.
- An incoming zap bound to its request, receipt published to 6 relays with 5 accepting, and the receipt fetched back off `nos.lol` carrying `bolt11` and a `description` tag holding that same request.
- Every NWC request answered: 60/60, median 56 ms, p90 108 ms. `list_transactions` 11–19 ms at 57 rows.
- Capability change picked up without re-pairing: a pairing created before the wallet advertised `06` attributes correctly once the info event is re-read.
- The unpatched (release) build renders attribution it cannot itself send — confirmed against the same history after a force-stop with cache cleared, so the read path works on the current release.

### LNURL provider results

The binding check is only satisfiable if the provider mints a NIP-57-compliant zap invoice. Testing surfaced two that do not, which is why the `allowsNostr` fallback and the lean pair exist.

| Provider | Comment-free zap | Zap with a comment |
| --- | --- | --- |
| Rizful | Binds correctly | Binds correctly |
| Wallet of Satoshi | Binds correctly | Binds correctly |
| Alby | Binds correctly | Invoice carries no `description_hash` |
| Primal | Constant `description_hash` | Constant `description_hash` |

Alby's trigger is the zap request's non-empty `content`, not the LUD-12 `comment` parameter — established by holding one signed zap request byte-for-byte constant and varying only the parameter (absent, empty, non-empty), all three of which failed. So there is no client-side workaround, and none was attempted. Primal returned an identical `description_hash` for four different zap requests, and again eight hours later, so no input can satisfy it.

Amethyst's behaviour on both is the fallback: the row is named from `recipient_data` and the comment, without profile resolution.

### Regression testing — existing NWC providers

**Alby Hub** — paired against the patched build on a Pixel 9a, and behaviour is identical to the current release. Sending works, receiving works, balance and history load. Outgoing rows carry no payee, which is the capability gate behaving as designed: Alby Hub does not advertise `06`, so no `metadata` is sent and the request is byte-identical to the one the release build sends. Incoming rows still show sender attribution — that comes from the wallet storing the incoming zap request on the LNURL side and is untouched by this change.

Structurally, that path is asserted by `noMetadataMeansTheRequestIsUnchanged`: a wallet that has not advertised `06` receives the same bytes as today. The capability read treats "info event not fetched yet" as "not supported", so the failure direction is always toward current behaviour.

**A pre-existing bug found while testing, and explicitly not from this branch.** Viewing transactions on a Rizful NWC pairing fails with `Invalid list_transactions params: from must be an integer`. Amethyst sends every optional parameter as an explicit null:

```json
{"method":"list_transactions","params":{"from":null,"until":null,"limit":20,"offset":0,
 "unpaid":false,"unpaid_outgoing":null,"unpaid_incoming":null,"type":null}}
```

NWC-05 marks those optional, and a wallet that types `from` as an integer refuses the request. The cause is that the two serialization backends disagree: `Nip47RequestKSerializer` (kotlinx, native) omits nulls via `params.from?.let { put("from", it) }`, while Jackson (JVM/Android) serializes the params class reflectively and writes them.

This branch touches neither `ListTransactionsParams` nor that serializer — confirmed with `git diff`. It became *visible* rather than new: `24a8540ad9` ("fix(nwc): never let a NIP-47 refusal or timeout reach the user as silence", 26 Aug) surfaces the refusal where older builds rendered it as an empty "no transactions" list. Older releases sent the same request and got the same refusal, silently.

Being fixed separately, since it is a different bug in a different subsystem and wants its own regression pass across every NWC method rather than riding along here.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This changes NIP-47 request payloads only. It does not touch Marmot/MLS, NIP-17 DMs, audio rooms, MoQ or QUIC.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Written with Claude Code. Reviewed by hand, plus an automated Kotlin review pass and a code-quality pass; field-tested on device against a live wallet and real payments as described above.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
