### PR TITLE
fix(quartz): route the roles the search extractor was stranding in the body tier

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
@@ -40,6 +40,25 @@ package com.vitorpamplona.quartz.nip50Search
  * once values are pre-joined a backend can't unmix them. Values produced by
  * [SearchFieldExtractor] are trimmed and non-empty; the types themselves do
  * not enforce it.
+ *
+ * ## PROFILE XOR TIERED — a contract, not an implementation detail
+ *
+ * A kind fills the profile roles or the content roles, NEVER both. The sealed
+ * type enforces it today, and weighted backends are entitled to depend on it:
+ * a ranker that scores the two role groups independently and SUMS them stays
+ * correct only while no document can answer from a naming column in each
+ * group. A shape that filled, say, [Profile.name] and [Tiered.primary] at
+ * once would claim the top band twice — in the store this extractor was
+ * built for, ~260 000 against the ~130 000 a whole-field title match earns,
+ * i.e. a document matching one word per column outranking one that IS the
+ * query.
+ *
+ * So a new kind that looks like both is a deliberate decision with a known
+ * downstream cost, not an accident of the extractor. Pick the shape the kind
+ * really has and route the rest through it — the way kind 31990 (an app
+ * handler, whose metadata is a kind-0 clone) returns [Profile] wholesale
+ * rather than a profile plus a tier. If a future shape genuinely must fill
+ * both, the backends that sum these groups have to be told.
  */
 sealed interface IndexableFields {
     fun isEmpty(): Boolean

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
@@ -44,7 +44,10 @@ import com.vitorpamplona.quartz.experimental.trustedLists.TrustedListEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.feedDefinition.FeedDefinitionEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.fastAny
+import com.vitorpamplona.quartz.nip01Core.core.fastForEach
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.HashtagTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
@@ -494,15 +497,18 @@ object SearchFieldExtractor {
 
             // kind 2473 -- a sighting IS its species, under both names: the
             // scientific one from the `n` tag and the vernacular one
-            // commonName() parses out of the `alt`. Once that parse succeeds
-            // the alt is only Birdstar's boilerplate wrapper around the two
-            // ("Bird detection: <Common> (<Scientific>)"), so indexing it
-            // whole would repeat both names in a second role; the alt is
-            // carried only when it is NOT that shape and so holds text of its
-            // own.
+            // commonName() parses out of the `alt`. The `alt` itself still
+            // goes to the summary tier whole. It is usually just Birdstar's
+            // boilerplate wrapper around those two names ("Bird detection:
+            // <Common> (<Scientific>)"), so this repeats them in a second
+            // role -- but only commonName()'s PREFIX match decides that the
+            // alt is boilerplate, and a publisher can write anything after
+            // the parenthetical. Dropping the alt on a prefix match lost that
+            // tail from every role, which is precisely the drift against
+            // indexableContent() this file exists to prevent: the repeat
+            // costs a duplicate in the weakest role, the drop cost recall.
             is BirdDetectionEvent -> {
-                val common = event.commonName()
-                tiers(event, listOf(event.speciesName(), common), listOf(event.summary().takeIf { common == null }), null)
+                tiers(event, listOf(event.speciesName(), event.commonName()), listOf(event.summary()), null)
             }
 
             // kind 12473 is a life LIST, not a sighting: its species names are
@@ -628,46 +634,94 @@ object SearchFieldExtractor {
             }
         }
 
-    /** Single-value convenience over the list funnel — most kinds carry one title, one summary, one body. */
+    /**
+     * Single-value convenience over the list funnel — most kinds carry one
+     * title, one summary, one body. Cleans each value straight into its role
+     * rather than wrapping it in a list first: extraction runs once per stored
+     * event, and the wrappers were three throwaway lists on every one of them.
+     */
     private fun tiers(
         event: Event,
         primary: String?,
         secondary: String?,
         text: String?,
         website: String? = null,
-    ) = tiers(event, listOf(primary), listOf(secondary), text, listOf(website))
+    ) = build(event, cleanOne(primary), cleanOne(secondary), text, cleanOne(website))
 
-    /**
-     * The one funnel every content branch uses — [IndexableFields.Tiered.hashtags]
-     * and [IndexableFields.Tiered.locations] are filled here, so no branch can
-     * forget them. Values stay UNJOINED: separator choices belong to the backend.
-     */
     private fun tiers(
         event: Event,
         primary: List<String?>,
         secondary: List<String?>,
         text: String?,
         websites: List<String?> = emptyList(),
+    ) = build(event, cleanAll(primary), cleanAll(secondary), text, cleanAll(websites))
+
+    /**
+     * The one funnel BOTH [tiers] overloads end in — [IndexableFields.Tiered.hashtags]
+     * and [IndexableFields.Tiered.locations] are filled here, so no branch can
+     * forget them. Values stay UNJOINED: separator choices belong to the backend.
+     */
+    private fun build(
+        event: Event,
+        primary: List<String>,
+        secondary: List<String>,
+        text: String?,
+        websites: List<String>,
     ) = IndexableFields.Tiered(
-        primary = cleanAll(primary),
-        secondary = cleanAll(secondary),
+        primary = primary,
+        secondary = secondary,
         text = clean(text),
-        hashtags = cleanAll(event.tags.hashtags()),
+        hashtags = hashtagValues(event),
         locations = locationValues(event),
-        websites = cleanAll(websites),
+        websites = websites,
     )
 
     /** Trim and drop empties at the single funnel every derived string passes through. */
     private fun clean(s: String?): String? = s?.trim()?.ifEmpty { null }
 
-    private fun cleanAll(parts: List<String?>): List<String> = parts.mapNotNull { clean(it) }
+    private fun cleanOne(s: String?): List<String> = clean(s)?.let { listOf(it) } ?: emptyList()
+
+    /**
+     * Collects lazily: a role whose values are all absent — the common case on
+     * most kinds — costs no list at all.
+     */
+    private fun cleanAll(parts: List<String?>): List<String> {
+        var values: MutableList<String>? = null
+        for (i in parts.indices) {
+            val value = clean(parts[i]) ?: continue
+            (values ?: ArrayList<String>(parts.size).also { values = it }).add(value)
+        }
+        return values ?: emptyList()
+    }
+
+    /**
+     * The hashtag role. [hashtags] allocates unconditionally, so the scan for
+     * a `t` tag comes first — most events carry none. The guard is exactly
+     * [HashtagTag.parse]'s own acceptance test, so it can never skip a tag the
+     * accessor would have returned.
+     */
+    private fun hashtagValues(event: Event): List<String> = if (!event.tags.fastAny(HashtagTag::isTagged)) emptyList() else cleanAll(event.tags.hashtags())
 
     /**
      * Every `location` tag value, on ANY kind. Deliberately a raw scan, not a
      * typed accessor: Quartz's LocationTag classes are per-NIP (calendar,
      * picture, classifieds) and only those kinds expose locations(), while
      * this funnel must also catch location tags on kinds whose class doesn't
-     * model them.
+     * model them. Collects lazily, like [cleanAll]: an event with no location
+     * tag — nearly all of them — allocates nothing here.
      */
-    private fun locationValues(event: Event): List<String> = event.tags.mapNotNull { tag -> if (tag.getOrNull(0) != "location") null else clean(tag.getOrNull(1)) }
+    private fun locationValues(event: Event): List<String> {
+        var values: MutableList<String>? = null
+        event.tags.fastForEach { tag ->
+            if (tag.size > 1 && tag[0] == LOCATION_TAG) {
+                val value = clean(tag[1])
+                if (value != null) {
+                    (values ?: ArrayList<String>(2).also { values = it }).add(value)
+                }
+            }
+        }
+        return values ?: emptyList()
+    }
+
+    private const val LOCATION_TAG = "location"
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
@@ -27,25 +27,39 @@ import com.vitorpamplona.quartz.buzz.teams.TeamEvent
 import com.vitorpamplona.quartz.buzz.workflow.WorkflowDefEvent
 import com.vitorpamplona.quartz.experimental.agora.FundraiserEvent
 import com.vitorpamplona.quartz.experimental.audio.track.AudioTrackEvent
+import com.vitorpamplona.quartz.experimental.birdstar.BirdDetectionEvent
+import com.vitorpamplona.quartz.experimental.birdstar.BirdexEvent
+import com.vitorpamplona.quartz.experimental.edits.TextNoteModificationEvent
 import com.vitorpamplona.quartz.experimental.fitness.workout.ExerciseTemplateEvent
 import com.vitorpamplona.quartz.experimental.fitness.workout.WorkoutRecordEvent
 import com.vitorpamplona.quartz.experimental.interactiveStories.InteractiveStoryBaseEvent
 import com.vitorpamplona.quartz.experimental.music.playlist.MusicPlaylistEvent
 import com.vitorpamplona.quartz.experimental.music.track.MusicTrackEvent
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.application.SoftwareApplicationEvent
+import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
 import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
+import com.vitorpamplona.quartz.experimental.profileGallery.ProfileGalleryEntryEvent
+import com.vitorpamplona.quartz.experimental.ps1saves.Ps1SaveEvent
 import com.vitorpamplona.quartz.experimental.trustedLists.TrustedListEvent
+import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.feedDefinition.FeedDefinitionEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
+import com.vitorpamplona.quartz.nip15Marketplace.auction.AuctionEvent
+import com.vitorpamplona.quartz.nip15Marketplace.marketplace.MarketplaceEvent
+import com.vitorpamplona.quartz.nip15Marketplace.product.ProductEvent
+import com.vitorpamplona.quartz.nip15Marketplace.stall.StallEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.moderation.EditMetadataEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
+import com.vitorpamplona.quartz.nip32Labeling.LabelEvent
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.pr.GitPullRequestEvent
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
@@ -66,6 +80,7 @@ import com.vitorpamplona.quartz.nip51Lists.videoCurationSet.VideoCurationSetEven
 import com.vitorpamplona.quartz.nip52Calendar.appt.day.CalendarDateSlotEvent
 import com.vitorpamplona.quartz.nip52Calendar.appt.time.CalendarTimeSlotEvent
 import com.vitorpamplona.quartz.nip52Calendar.calendar.CalendarEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.clip.LiveActivitiesClipEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingRoomEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
@@ -78,6 +93,7 @@ import com.vitorpamplona.quartz.nip5dNapplets.NamedNappletEvent
 import com.vitorpamplona.quartz.nip5dNapplets.NappletSnapshotEvent
 import com.vitorpamplona.quartz.nip5dNapplets.RootNappletEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.P2POrderEvent
 import com.vitorpamplona.quartz.nip71Video.AddressableVideoEvent
 import com.vitorpamplona.quartz.nip71Video.RegularVideoEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
@@ -85,6 +101,7 @@ import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
 import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
@@ -92,6 +109,8 @@ import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
 import com.vitorpamplona.quartz.nipC0CodeSnippets.CodeSnippetEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.episode.PodcastEpisodeEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.metadata.PodcastMetadataEvent
+import com.vitorpamplona.quartz.nipXXPodcasting20.episode.Podcasting20EpisodeEvent
+import com.vitorpamplona.quartz.nipXXPodcasting20.trailer.Podcasting20TrailerEvent
 
 /**
  * Decomposes every [SearchableEvent] into [IndexableFields] by priority tier:
@@ -148,8 +167,35 @@ object SearchFieldExtractor {
                 tiers(event, event.title(), event.summary(), event.content)
             }
 
+            // NIP-15 kinds 30017/30018/30019/30020 -- the marketplace family
+            // keeps its name and description inside a JSON `content` blob, so
+            // the fallback dropped a stall/product/auction NAME into the body
+            // tier, where a title can never reach the title band. Decoding
+            // failures still reach the funnel, as they do for the buzz kinds.
+            is StallEvent -> {
+                event.stallData()?.let { tiers(event, it.name, it.description, null) } ?: tiers(event, null, null, null)
+            }
+
+            // ProductEvent.categories() is `t` under another name, so the
+            // funnel already carries it in the hashtag role -- passing it
+            // again would index the same words twice.
+            is ProductEvent -> {
+                event.productData()?.let { tiers(event, it.name, it.description, null) } ?: tiers(event, null, null, null)
+            }
+
+            is MarketplaceEvent -> {
+                event.marketplaceData()?.let { tiers(event, it.name, it.about, null) } ?: tiers(event, null, null, null)
+            }
+
+            is AuctionEvent -> {
+                event.auctionData()?.let { tiers(event, it.name, it.description, null) } ?: tiers(event, null, null, null)
+            }
+
+            // The clone URL is as much a repository's public address as its
+            // homepage is -- `github.com/owner/repo.git` is how most people
+            // would search for it -- so both fill the affiliation role.
             is GitRepositoryEvent -> {
-                tiers(event, listOf(event.name()), listOf(event.description()), event.content, websites = event.webs())
+                tiers(event, listOf(event.name()), listOf(event.description()), event.content, websites = (event.webs() + event.clones()).distinct())
             }
 
             is GitIssueEvent -> {
@@ -238,8 +284,10 @@ object SearchFieldExtractor {
                 tiers(event, event.title(), event.summary(), event.content)
             }
 
+            // endpoint() is the `streaming` tag -- the same role
+            // LiveActivitiesEvent.streaming() fills above.
             is MeetingSpaceEvent -> {
-                tiers(event, event.room(), event.summary(), event.content)
+                tiers(event, event.room(), event.summary(), event.content, website = event.endpoint())
             }
 
             is MeetingRoomEvent -> {
@@ -282,7 +330,26 @@ object SearchFieldExtractor {
                 tiers(event, listOf(event.title()), listOf(event.description()), null, websites = event.websites())
             }
 
+            // kinds 30054/30055 -- the Podcasting 2.0 pair carries the same
+            // title/description shape kind 54 does and was falling through:
+            // an episode title indexed as body text. topics() is hashtags()
+            // under another name, so the funnel carries it once.
+            is Podcasting20EpisodeEvent -> {
+                tiers(event, event.title(), event.description(), event.content)
+            }
+
+            is Podcasting20TrailerEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
             is GroupMetadataEvent -> {
+                tiers(event, event.name(), event.about(), null)
+            }
+
+            // kind 9002 edits the very metadata kind 39000 publishes, so it
+            // splits the same way -- it was the only half of the pair falling
+            // through. Its hashtags() is `t`, carried once by the funnel.
+            is EditMetadataEvent -> {
                 tiers(event, event.name(), event.about(), null)
             }
 
@@ -328,12 +395,14 @@ object SearchFieldExtractor {
                 tiers(event, event.title(), event.description(), null, website = event.url())
             }
 
+            // A site's `source` tag is the URL its files were published
+            // from -- the same affiliation role a repo's homepage fills.
             is NamedSiteEvent -> {
-                tiers(event, event.title(), event.description(), null)
+                tiers(event, event.title(), event.description(), null, website = event.source())
             }
 
             is RootSiteEvent -> {
-                tiers(event, event.title(), event.description(), null)
+                tiers(event, event.title(), event.description(), null, website = event.source())
             }
 
             is RootNappletEvent -> {
@@ -412,6 +481,50 @@ object SearchFieldExtractor {
                 tiers(event, null, event.summary(), event.content)
             }
 
+            // kinds 1065/1163 -- summary-only kinds. Their whole searchable
+            // text IS a summary, so it belongs in the summary tier, next to
+            // kind 1063's, rather than in the body tier the fallback gave it.
+            is FileStorageHeaderEvent -> {
+                tiers(event, null, event.summary(), null)
+            }
+
+            is ProfileGalleryEntryEvent -> {
+                tiers(event, null, event.summary(), null)
+            }
+
+            // kind 2473 -- a sighting IS its species, under both names: the
+            // scientific one from the `n` tag and the vernacular one
+            // commonName() parses out of the `alt`. Once that parse succeeds
+            // the alt is only Birdstar's boilerplate wrapper around the two
+            // ("Bird detection: <Common> (<Scientific>)"), so indexing it
+            // whole would repeat both names in a second role; the alt is
+            // carried only when it is NOT that shape and so holds text of its
+            // own.
+            is BirdDetectionEvent -> {
+                val common = event.commonName()
+                tiers(event, listOf(event.speciesName(), common), listOf(event.summary().takeIf { common == null }), null)
+            }
+
+            // kind 12473 is a life LIST, not a sighting: its species names are
+            // an unbounded collection, so they sit in the secondary tier with
+            // a torrent's file names rather than claiming the title band once
+            // per bird.
+            is BirdexEvent -> {
+                tiers(event, emptyList(), listOf(event.summary()) + event.speciesNames(), null)
+            }
+
+            // kind 38192 -- the save's title is a title; region and filename
+            // are the keywords beside it, like a torrent's file names.
+            is Ps1SaveEvent -> {
+                tiers(event, listOf(event.saveTitle()), listOf(event.summary(), event.region(), event.filename()), null)
+            }
+
+            // kind 38383 -- an order is looked up by who is offering it;
+            // currency and payment methods are the keywords that qualify it.
+            is P2POrderEvent -> {
+                tiers(event, listOf(event.makerName()), listOf(event.currency()) + event.paymentMethods().orEmpty(), null)
+            }
+
             is AudioTrackEvent -> {
                 tiers(event, event.subject(), null, null)
             }
@@ -456,6 +569,46 @@ object SearchFieldExtractor {
                         website = clean(md.website),
                     )
                 }
+            }
+
+            // kind 1010 -- `content` is the proposed replacement text and
+            // `summary` describes the edit, so they split the way kind 1063's
+            // summary and body do (indexableContent concatenates them in the
+            // other order; the roles, not the order, are what a weighted
+            // backend reads).
+            is TextNoteModificationEvent -> {
+                tiers(event, null, event.summary(), event.content)
+            }
+
+            // kinds 1068/6969 -- the question is the body, the option labels
+            // are short answer-like values a searcher matches whole, so they
+            // sit in the secondary tier UNJOINED instead of being appended to
+            // the body the way indexableContent() has to.
+            is PollEvent -> {
+                tiers(event, emptyList(), event.options().map { it.label }, event.content)
+            }
+
+            is ZapPollEvent -> {
+                tiers(event, emptyList(), event.pollOptionsArray().map { it.descriptor }, event.content)
+            }
+
+            // kind 1985 -- the label values are the keywords of the event;
+            // the reasoning, if any, is the body.
+            is LabelEvent -> {
+                tiers(event, emptyList(), event.labels().map { it.label }, event.content)
+            }
+
+            // kinds 1111/1311 -- body-only kinds whose indexableContent()
+            // concatenates the `t` tags INTO the body. The funnel already
+            // carries them in the hashtag role, so passing the body alone
+            // stops the same words being indexed twice (the ContactCard
+            // reasoning above, applied to the two chat/comment kinds).
+            is CommentEvent -> {
+                tiers(event, null, null, event.content)
+            }
+
+            is LiveActivitiesChatMessageEvent -> {
+                tiers(event, null, null, event.content)
             }
 
             // kind 1 LAST among the explicit branches, defensively: a future

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
@@ -298,24 +298,52 @@ class SearchFieldExtractorTest {
 
     @Test
     fun birdSightingsAreNamedByTheirSpeciesUnderBothNames() {
-        // Birdstar's `alt` is a boilerplate wrapper around the two names, so
-        // once commonName() has parsed it there is nothing left in it to
-        // index -- carrying it whole would repeat both names in a second role.
+        // The scientific name comes from the `n` tag, the vernacular one from
+        // commonName()'s parse of the `alt` -- both are names, so both are
+        // titles. The alt still reaches the summary tier whole.
         val tags =
             arrayOf(
                 arrayOf("n", "Porphyrio martinica"),
                 arrayOf("alt", "Bird detection: Purple Gallinule (Porphyrio martinica)"),
             )
         val fields = SearchFieldExtractor.extract(BirdDetectionEvent("26".repeat(32), alice, 1L, tags, "", ""))
-        assertEquals(IndexableFields.Tiered(primary = listOf("Porphyrio martinica", "Purple Gallinule")), fields)
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Porphyrio martinica", "Purple Gallinule"),
+                secondary = listOf("Bird detection: Purple Gallinule (Porphyrio martinica)"),
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun aBirdSightingKeepsAltTextBeyondTheParsedNames() {
+        // commonName() only matches a PREFIX, so a publisher can write
+        // anything after the parenthetical. Dropping the alt whenever that
+        // prefix parsed lost the tail ("at Lake Merritt, 7am") from every
+        // role, while indexableContent() still carried it -- the exact drift
+        // this extractor exists to prevent.
+        val tags =
+            arrayOf(
+                arrayOf("n", "Porphyrio martinica"),
+                arrayOf("alt", "Bird detection: Purple Gallinule (Porphyrio martinica) at Lake Merritt, 7am"),
+            )
+        val fields = SearchFieldExtractor.extract(BirdDetectionEvent("3a".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Porphyrio martinica", "Purple Gallinule"),
+                secondary = listOf("Bird detection: Purple Gallinule (Porphyrio martinica) at Lake Merritt, 7am"),
+            ),
+            fields,
+        )
     }
 
     @Test
     fun aBirdSightingWithAnUnrecognizedAltStillIndexesIt() {
-        // A publisher that words the alt differently keeps it: the summary is
-        // dropped only when commonName() proves it was the boilerplate.
+        // An alt that does not start with the known prefix parses to no
+        // common name, and is carried as the summary it is.
         val tags = arrayOf(arrayOf("n", "Ramphastos toco"), arrayOf("alt", "a toucan at the feeder"))
-        val fields = SearchFieldExtractor.extract(BirdDetectionEvent("3a".repeat(32), alice, 1L, tags, "", ""))
+        val fields = SearchFieldExtractor.extract(BirdDetectionEvent("3c".repeat(32), alice, 1L, tags, "", ""))
         assertEquals(
             IndexableFields.Tiered(primary = listOf("Ramphastos toco"), secondary = listOf("a toucan at the feeder")),
             fields,

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
@@ -21,16 +21,31 @@
 package com.vitorpamplona.quartz.nip50Search
 
 import com.vitorpamplona.quartz.buzz.agentProfiles.AgentProfileEvent
+import com.vitorpamplona.quartz.experimental.birdstar.BirdDetectionEvent
+import com.vitorpamplona.quartz.experimental.birdstar.BirdexEvent
+import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
+import com.vitorpamplona.quartz.experimental.ps1saves.Ps1SaveEvent
 import com.vitorpamplona.quartz.experimental.trustedLists.users.UserTrustedListEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip15Marketplace.product.ProductEvent
+import com.vitorpamplona.quartz.nip15Marketplace.stall.StallEvent
 import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.moderation.EditMetadataEvent
+import com.vitorpamplona.quartz.nip32Labeling.LabelEvent
+import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
 import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
+import com.vitorpamplona.quartz.nip5aStaticWebsites.NamedSiteEvent
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.P2POrderEvent
 import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
+import com.vitorpamplona.quartz.nipXXPodcasting20.episode.Podcasting20EpisodeEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -218,5 +233,207 @@ class SearchFieldExtractorTest {
         val tags = arrayOf(arrayOf("t", "nostr"))
         val fields = SearchFieldExtractor.extract(MetadataEvent("9".repeat(64), alice, 1L, tags, "{}", ""))
         assertEquals(IndexableFields.None, fields)
+    }
+
+    @Test
+    fun marketplaceNamesReachTheTitleTierNotTheBody() {
+        // NIP-15 keeps the stall's name inside a JSON content blob. Falling
+        // through to the catch-all put that NAME in the body tier, where a
+        // weighted backend can never rank it as a title.
+        val content = """{"id":"s1","name":"Vitor's Coffee","description":"beans from Minas","currency":"BRL"}"""
+        val fields = SearchFieldExtractor.extract(StallEvent("20".repeat(32), alice, 1L, arrayOf(arrayOf("d", "s1")), content, ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("Vitor's Coffee"), secondary = listOf("beans from Minas")), fields)
+    }
+
+    @Test
+    fun productCategoriesAreCarriedOnceAsHashtags() {
+        // categories() is `t` under another name: indexableContent()
+        // concatenates it into the flat blob, but the funnel already carries
+        // it in the hashtag role, so the branch must not pass it again.
+        val content = """{"id":"p1","stall_id":"s1","name":"Bag of Beans","description":"1kg","currency":"BRL","price":90.0}"""
+        val tags = arrayOf(arrayOf("d", "p1"), arrayOf("t", "coffee"))
+        val fields = SearchFieldExtractor.extract(ProductEvent("21".repeat(32), alice, 1L, tags, content, ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Bag of Beans"), secondary = listOf("1kg"), hashtags = listOf("coffee")),
+            fields,
+        )
+    }
+
+    @Test
+    fun unparseableMarketplaceContentStillIndexesItsHashtags() {
+        val fields = SearchFieldExtractor.extract(StallEvent("22".repeat(32), alice, 1L, arrayOf(arrayOf("t", "coffee")), "not json", ""))
+        assertEquals(IndexableFields.Tiered(hashtags = listOf("coffee")), fields)
+    }
+
+    @Test
+    fun groupMetadataEditsSplitLikeTheMetadataTheyEdit() {
+        // kind 9002 edits what kind 39000 publishes; it was the only half of
+        // the pair without a branch. Its hashtags() is `t`: carried once.
+        val tags = arrayOf(arrayOf("h", "grp"), arrayOf("name", "Nostr Devs"), arrayOf("about", "we build"), arrayOf("t", "nostr"))
+        val fields = SearchFieldExtractor.extract(EditMetadataEvent("23".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Nostr Devs"), secondary = listOf("we build"), hashtags = listOf("nostr")),
+            fields,
+        )
+    }
+
+    @Test
+    fun podcasting20EpisodesSplitLikeEveryOtherTitledKind() {
+        val tags = arrayOf(arrayOf("d", "ep1"), arrayOf("title", "Episode 42"), arrayOf("description", "on search"), arrayOf("t", "podcast"))
+        val fields = SearchFieldExtractor.extract(Podcasting20EpisodeEvent("24".repeat(32), alice, 1L, tags, "show notes", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Episode 42"), secondary = listOf("on search"), text = "show notes", hashtags = listOf("podcast")),
+            fields,
+        )
+    }
+
+    @Test
+    fun summaryOnlyKindsUseTheSummaryTier() {
+        // kind 1065's whole searchable text IS a summary -- it belongs beside
+        // kind 1063's, not in the body tier.
+        val tags = arrayOf(arrayOf("summary", "the quarterly report"))
+        val fields = SearchFieldExtractor.extract(FileStorageHeaderEvent("25".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(IndexableFields.Tiered(secondary = listOf("the quarterly report")), fields)
+    }
+
+    @Test
+    fun birdSightingsAreNamedByTheirSpeciesUnderBothNames() {
+        // Birdstar's `alt` is a boilerplate wrapper around the two names, so
+        // once commonName() has parsed it there is nothing left in it to
+        // index -- carrying it whole would repeat both names in a second role.
+        val tags =
+            arrayOf(
+                arrayOf("n", "Porphyrio martinica"),
+                arrayOf("alt", "Bird detection: Purple Gallinule (Porphyrio martinica)"),
+            )
+        val fields = SearchFieldExtractor.extract(BirdDetectionEvent("26".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("Porphyrio martinica", "Purple Gallinule")), fields)
+    }
+
+    @Test
+    fun aBirdSightingWithAnUnrecognizedAltStillIndexesIt() {
+        // A publisher that words the alt differently keeps it: the summary is
+        // dropped only when commonName() proves it was the boilerplate.
+        val tags = arrayOf(arrayOf("n", "Ramphastos toco"), arrayOf("alt", "a toucan at the feeder"))
+        val fields = SearchFieldExtractor.extract(BirdDetectionEvent("3a".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Ramphastos toco"), secondary = listOf("a toucan at the feeder")),
+            fields,
+        )
+    }
+
+    @Test
+    fun aLifeListKeepsItsSpeciesOutOfTheTitleTier() {
+        // kind 12473 is an unbounded collection, not a sighting: one title
+        // band per bird would dilute the tier the way a torrent's file list
+        // would.
+        val tags = arrayOf(arrayOf("n", "Ramphastos toco"), arrayOf("n", "Porphyrio martinica"), arrayOf("alt", "my life list"))
+        val fields = SearchFieldExtractor.extract(BirdexEvent("3b".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(secondary = listOf("my life list", "Ramphastos toco", "Porphyrio martinica")),
+            fields,
+        )
+    }
+
+    @Test
+    fun saveTitlesAreTitlesAndTheRestAreKeywords() {
+        val tags =
+            arrayOf(
+                arrayOf("d", "save1"),
+                arrayOf("title", "Final Fantasy VII"),
+                arrayOf("filename", "BASCUS-94163"),
+                arrayOf("region", "NTSC-U"),
+                arrayOf("alt", "a memory card save"),
+            )
+        val fields = SearchFieldExtractor.extract(Ps1SaveEvent("27".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Final Fantasy VII"),
+                secondary = listOf("a memory card save", "NTSC-U", "BASCUS-94163"),
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun p2pOrdersAreNamedByTheirMaker() {
+        val tags = arrayOf(arrayOf("d", "o1"), arrayOf("name", "Satoshi"), arrayOf("f", "BRL"), arrayOf("pm", "pix", "wire"))
+        val fields = SearchFieldExtractor.extract(P2POrderEvent("28".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Satoshi"), secondary = listOf("BRL", "pix", "wire")),
+            fields,
+        )
+    }
+
+    @Test
+    fun pollOptionsAreCarriedUnjoinedInTheSecondaryTier() {
+        // indexableContent() has to append the labels to the body; the roles
+        // keep them separate, so the backend chooses how to weight them.
+        val tags = arrayOf(arrayOf("option", "1", "Coffee"), arrayOf("option", "2", "Tea"))
+        val fields = SearchFieldExtractor.extract(PollEvent("29".repeat(32), alice, 1L, tags, "what should I drink?", ""))
+        assertEquals(
+            IndexableFields.Tiered(secondary = listOf("Coffee", "Tea"), text = "what should I drink?"),
+            fields,
+        )
+    }
+
+    @Test
+    fun labelValuesAreKeywordsNotBody() {
+        val tags = arrayOf(arrayOf("l", "spam", "report"), arrayOf("L", "report"))
+        val fields = SearchFieldExtractor.extract(LabelEvent("2b".repeat(32), alice, 1L, tags, "obvious bot", ""))
+        assertEquals(IndexableFields.Tiered(secondary = listOf("spam"), text = "obvious bot"), fields)
+    }
+
+    @Test
+    fun commentHashtagsAreNotIndexedTwice() {
+        // indexableContent() concatenates the `t` tags INTO the body for kind
+        // 1111; the funnel already carries them in the hashtag role, so the
+        // branch passes the body alone.
+        val tags = arrayOf(arrayOf("t", "nostr"))
+        val fields = SearchFieldExtractor.extract(CommentEvent("2c".repeat(32), alice, 1L, tags, "good point", ""))
+        assertEquals(IndexableFields.Tiered(text = "good point", hashtags = listOf("nostr")), fields)
+    }
+
+    @Test
+    fun repositoriesAreFindableByCloneUrlAndHomepage() {
+        val tags =
+            arrayOf(
+                arrayOf("d", "amethyst"),
+                arrayOf("name", "Amethyst"),
+                arrayOf("description", "a nostr client"),
+                arrayOf("web", "https://amethyst.social"),
+                arrayOf("clone", "https://github.com/vitorpamplona/amethyst.git"),
+                // A repo whose homepage IS its clone URL must not index it twice.
+                arrayOf("clone", "https://amethyst.social"),
+            )
+        val fields = SearchFieldExtractor.extract(GitRepositoryEvent("2d".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Amethyst"),
+                secondary = listOf("a nostr client"),
+                websites = listOf("https://amethyst.social", "https://github.com/vitorpamplona/amethyst.git"),
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun meetingSpacesCarryTheirStreamingUrlLikeLiveActivitiesDo() {
+        val tags = arrayOf(arrayOf("d", "room1"), arrayOf("title", "Design Sync"), arrayOf("streaming", "https://nests.example/room1"))
+        val fields = SearchFieldExtractor.extract(MeetingSpaceEvent("2e".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("Design Sync"), websites = listOf("https://nests.example/room1")),
+            fields,
+        )
+    }
+
+    @Test
+    fun staticSitesCarryTheirSourceUrl() {
+        val tags = arrayOf(arrayOf("d", "blog"), arrayOf("title", "My Blog"), arrayOf("source", "https://github.com/me/blog"))
+        val fields = SearchFieldExtractor.extract(NamedSiteEvent("2f".repeat(32), alice, 1L, tags, "", ""))
+        assertEquals(
+            IndexableFields.Tiered(primary = listOf("My Blog"), websites = listOf("https://github.com/me/blog")),
+            fields,
+        )
     }
 }


### PR DESCRIPTION
> **Note on this PR's history:** it was first opened as a NIP-30 shortcode fix for the same
> extractor. That change was rolled back at the author's request and this branch now carries only
> the role-mapping audit described below; the title and description were updated to match.

## Summary

`SearchFieldExtractor.base()` dispatches ~70 branches, and the file states its own invariant —
*"each explicit branch splits exactly the accessors that kind's `indexableContent()`
concatenates — keep the two in sync"*. Nothing tested it. I audited every branch against all 133
searchable kinds; it had drifted three ways, and this PR fixes what the audit turned up. **The
table below is the artifact — it is worth more than the diff**, because the per-role
decomposition is what a weighted backend ranks on, and a role landing in the wrong tier is a
ranking bug no in-tree test can see.

Why the tier matters: downstream, each role maps to a weighted column and a banded rank ladder,
and a document's band is decided by *which* column matched, not how much. A title that arrives in
the body role instead of the title role is ~236× weaker and can never reach the band a title
deserves. That is what 17 kinds were doing.

Three failure modes, and what changed for each:

1. **A title in the wrong tier.** 17 kinds fell through to the catch-all, which dumps the whole
   `indexableContent()` into the body role. The marketplace family (30017/30018/30019/30020) and
   the Podcasting 2.0 pair (30054/30055) are the sharpest — a stall name and an episode title are
   exactly what people type. Kind 9002 is the tell-tale: it edits the very metadata kind 39000
   publishes, and 39000 had a branch while 9002 did not. Every kind still falling through is now
   body-only, so no title is left stranded.
2. **A role the branch forgot.** `hashtags` and `locations` are filled systemically by the
   `tiers()` funnel; `websites` is per-branch, and four kinds with a public URL were not passing
   one — `GitRepositoryEvent` (`clones()`), `MeetingSpaceEvent` (`endpoint()`, the same
   `streaming` tag kind 30311 already carries) and both nSite kinds (`source()`).
3. **Drift against `indexableContent()`.** Six kinds concatenated their `t` tags into the flat
   blob while the funnel also carried them as hashtags — the same words indexed twice, in the
   weakest role. Fixed by their new branches, the same treatment `InterestSetEvent` and
   `ContactCardEvent` already had.

It also writes down the **PROFILE XOR TIERED** contract in the `IndexableFields` KDoc (nothing
upstream said it was load-bearing). The sealed type enforces it and weighted backends already
depend on it: a ranker that scores the two role groups independently and *sums* them stays
correct only while no document can answer from a naming column in each group. A shape filling
`Profile.name` and `Tiered.primary` at once would claim the top band twice — measured downstream
at ~260 000 against the ~130 000 a whole-field title match earns, i.e. a document answering with
one word per column outranking one that *is* the query. Kind 31990 is the pattern to keep: it
routes an app handler's kind-0-clone metadata through `Profile` wholesale rather than returning
both shapes.

**Consumers must re-run `IEventStore.reindexFullTextSearch()` after upgrading** — this is derived
data baked into the index.

Nothing here changes the flat `SearchableEvent.indexableContent()`, so every in-tree store
(SQLite FTS, filesystem, geode) indexes exactly what it did before; only the per-role
decomposition changes. No new kind, no new tag, no change to how a NIP is interpreted — so this
does not fall under CONTRIBUTING-WITH-AI.md's "Don't touch without an issue first" list.

## The audit — every searchable kind against the role model

Shape: **P** = `IndexableFields.Profile`, **T** = `Tiered`, **T (catch-all)** = no explicit
branch, whole `indexableContent()` in the body role. Roles: `pri` = primary, `sec` =
secondary, `txt` = text, `web` = websites; `hashtags`/`locations` are filled systemically by
the `tiers()` funnel on every `Tiered` branch and are omitted from the table unless the kind's
`indexableContent()` also concatenates them (the double-index column).

Verdict: **=** the branch splits exactly what `indexableContent()` concatenates · **+** the
branch deliberately carries MORE than the flat form (a URL role, a file/keyword list) · **−**
the branch deliberately carries LESS · **body-only** a kind whose only searchable text is its
`content`, so the catch-all is already the right answer · **FIX** changed by this PR.

| Kind | Class | Shape | Roles filled | vs `indexableContent()` |
|---|---|---|---|---|
| 0 | MetadataEvent | P | name, displayName, about, nip05, lud16, website | − drops `lud06`, `picture`, `banner` (see *Reverse drift* below) |
| 1 | TextNoteEvent | T | pri=subject, txt=content | = |
| 9 | ChatEvent | T (catch-all) | txt | body-only |
| 11 | ThreadEvent | T | pri=title, txt=content | = |
| 14 | ChatMessageEvent | T (catch-all) | txt | body-only |
| 20 | PictureEvent | T | pri=title, txt=content | = |
| 21, 22 | RegularVideoEvent | T | pri=title, txt=content | = |
| 24 | PublicMessageEvent | T (catch-all) | txt | body-only |
| 40, 41 | ChannelCreate/MetadataEvent | T | pri=name, sec=about | − drops `picture` (an image URL) |
| 42 | ChannelMessageEvent | T (catch-all) | txt | body-only |
| 54 | PodcastEpisodeEvent | T | pri=title, sec=description, txt=content | = |
| 1010 | TextNoteModificationEvent | T | sec=summary, txt=content | **FIX** — was catch-all; the edit's summary now lands beside kind 1063's |
| 1063 | FileHeaderEvent | T | sec=summary, txt=content | = |
| 1065 | FileStorageHeaderEvent | T | sec=summary | **FIX** — was catch-all; a summary-only kind indexed as body |
| 1068 | PollEvent | T | sec=option labels, txt=content | **FIX** — was catch-all; labels now unjoined in `sec` instead of appended to the body |
| 1111 | CommentEvent | T | txt=content | **FIX** — was catch-all, which double-indexed the `t` tags (flat form concatenates them, funnel carries them) |
| 1163 | ProfileGalleryEntryEvent | T | sec=summary | **FIX** — was catch-all; summary-only kind |
| 1301 | WorkoutRecordEvent | T | pri=title, txt=content | = |
| 1311 | LiveActivitiesChatMessageEvent | T | txt=content | **FIX** — same double-index as 1111 |
| 1312 | LiveActivitiesRaidEvent | T (catch-all) | txt | body-only |
| 1313 | LiveActivitiesClipEvent | T | pri=title, txt=content | = |
| 1315 | RoadEventReportEvent | T (catch-all) | txt | body-only |
| 1337 | CodeSnippetEvent | T | pri=snippetName, sec=description+language+extension+runtime, txt=content, web=repo | + language/runtime keywords and the repo URL |
| 1617 | GitPatchEvent | T (catch-all) | txt | body-only |
| 1618 | GitPullRequestEvent | T | pri=subject, txt=content | = |
| 1621 | GitIssueEvent | T | pri=subject, txt=content | = |
| 1622 | GitReplyEvent | T (catch-all) | txt | body-only |
| 1630–1633 | GitStatusEvent | T (catch-all) | txt | body-only |
| 1808 | AudioHeaderEvent | T (catch-all) | txt | body-only |
| 1985 | LabelEvent | T | sec=label values, txt=content | **FIX** — was catch-all; `l` values are keywords, not body |
| 2003 | TorrentEvent | T | pri=title, sec=file names, txt=content, web=trackers | + file names and trackers |
| 2004 | TorrentCommentEvent | T (catch-all) | txt | body-only |
| 2473 | BirdDetectionEvent | T | pri=speciesName+commonName, sec=summary | **FIX** — was catch-all; a sighting IS its species, under both names |
| 3302 | ConcordChatEditEvent | T (catch-all) | txt | body-only |
| 5050, 5100, 5250, 5302, 5303 | NIP-90 request kinds | T (catch-all) | txt | body-only (a prompt/query is a body) |
| 5129 | NappletSnapshotEvent | T | pri=title, sec=description | = |
| 6969 | ZapPollEvent | T | sec=option descriptors, txt=content | **FIX** — was catch-all; same as 1068 |
| 8333 | OnchainZapEvent | T (catch-all) | txt | body-only |
| 9002 | EditMetadataEvent | T | pri=name, sec=about | **FIX** — was catch-all; kind 9002 edits exactly what 39000 publishes, and 39000 had a branch. Also stops the `t` double-index |
| 9041 | GoalEvent | T | sec=summary, txt=content | = |
| 9321, 9734, 9735, 9736, 9737 | zap kinds | T (catch-all) | txt | body-only |
| 9802 | HighlightEvent | T | sec=comment+context, txt=content | = |
| 10003 | BookmarkListEvent | T | pri=title | = |
| 10100 | AgentProfileEvent | T | pri=name+displayName | = |
| 10154 | PodcastMetadataEvent | T | pri=title, sec=description, web=websites | + the show's websites |
| 11871 | AttestorProficiencyEvent | T (catch-all) | txt | body-only (`description()` IS `content`) |
| 12473 | BirdexEvent | T | sec=summary+speciesNames | **FIX** — was catch-all; a life LIST, so its unbounded species collection stays out of the title tier |
| 15128 | RootSiteEvent | T | pri=title, sec=description, web=source | **FIX (web)** — the site's `source` URL was not carried |
| 15129 | RootNappletEvent | T | pri=title, sec=description | = |
| 30000 | PeopleListEvent | T | pri=titleOrName, sec=description | = |
| 30001 | OldBookmarkListEvent | T | pri=title | = |
| 30002 | RelaySetEvent | T | pri=title, sec=description | = |
| 30003 | LabeledBookmarkListEvent | T | pri=titleOrName, sec=description | = |
| 30004, 30005, 30006, 30267 | curation sets | T | pri=title, sec=description | = |
| 30009 | BadgeDefinitionEvent | T | pri=name, sec=description, txt=content | = |
| 30015 | InterestSetEvent | T | pri=title, sec=description | = (`publicHashtags()` is `t`; the funnel carries it once) |
| 30017 | StallEvent | T | pri=name, sec=description | **FIX** — was catch-all; a stall NAME in the body tier |
| 30018 | ProductEvent | T | pri=name, sec=description | **FIX** — was catch-all; also stops the `categories()` (= `t`) double-index |
| 30019 | MarketplaceEvent | T | pri=name, sec=about | **FIX** — was catch-all |
| 30020 | AuctionEvent | T | pri=name, sec=description | **FIX** — was catch-all; also stops the `t` double-index |
| 30023 | LongTextNoteEvent | T | pri=title, sec=summary, txt=content | = |
| 30030 | EmojiPackEvent | T | pri=titleOrName, sec=description, txt=content | = |
| 30054 | Podcasting20EpisodeEvent | T | pri=title, sec=description, txt=content | **FIX** — was catch-all; an episode title in the body tier, plus the `topics()` (= `t`) double-index |
| 30055 | Podcasting20TrailerEvent | T | pri=title, txt=content | **FIX** — was catch-all |
| 30063 | ReleaseArtifactSetEvent | T | pri=title, sec=description | = (`SoftwareReleaseEvent` also claims 30063 but `EventFactory` never builds it — see footnote) |
| 30175 | PersonaEvent | T | pri=displayName, txt=systemPrompt | = |
| 30176 | TeamEvent | T | pri=name, sec=description, txt=instructions | = |
| 30177 | ManagedAgentEvent | T | pri=name, txt=systemPrompt | = |
| 30296, 30297 | InteractiveStoryBaseEvent | T | pri=title, sec=summary, txt=content | = |
| 30311 | LiveActivitiesEvent | T | pri=title, sec=summary, txt=content, web=streaming | + the stream URL |
| 30312 | MeetingSpaceEvent | T | pri=room, sec=summary, txt=content, web=endpoint | **FIX (web)** — `endpoint()` is the same `streaming` tag 30311 carries |
| 30313 | MeetingRoomEvent | T | pri=title, sec=summary | = |
| 30315 | StatusEvent | T (catch-all) | txt | body-only |
| 30382 | ContactCardEvent | T | pri=petName, sec=summary | = (topics are `t`; funnel carries them once) |
| 30392–30395 | TrustedListEvent | T | pri=title | = |
| 30402 | ClassifiedsEvent | T | pri=title, sec=summary, txt=content | = |
| 30617 | GitRepositoryEvent | T | pri=name, sec=description, txt=content, web=webs+clones | **FIX (web)** — the clone URL is as much a repo's address as its homepage |
| 30620 | WorkflowDefEvent | T | pri=name, txt=content | = |
| 30817 | NipTextEvent | T | pri=title, txt=content | = |
| 30818 | WikiNoteEvent | T | pri=title, sec=summary, txt=content | = |
| 31337 | AudioTrackEvent | T | pri=subject | = |
| 31871, 31872, 31873 | attestation kinds | T (catch-all) | txt | body-only (`description()` IS `content`) |
| 31890 | FeedDefinitionEvent | T | pri=title | = |
| 31922, 31923 | Calendar slots | T | pri=title, sec=summary, txt=content | = |
| 31924 | CalendarEvent | T | pri=title, txt=content | = |
| 31925 | CalendarRSVPEvent | T (catch-all) | txt | body-only |
| 31990 | AppDefinitionEvent | P | name (or username), displayName, about, nip05, lud16, website | − drops `lud06`, `picture`, `banner`, `image` (see *Reverse drift*) |
| 32267 | SoftwareApplicationEvent | T | pri=name, sec=summary, txt=content, web=url+repository | + the app's URLs |
| 33401 | ExerciseTemplateEvent | T | pri=title, txt=content | = |
| 33863 | FundraiserEvent | T | pri=title, txt=content | = |
| 34139 | MusicPlaylistEvent | T | pri=title, sec=description, txt=content | = |
| 34235, 34236 | AddressableVideoEvent | T | pri=title, txt=content | = |
| 34550 | CommunityDefinitionEvent | T | pri=name, sec=description+rules, txt=content | = |
| 35128 | NamedSiteEvent | T | pri=title, sec=description, web=source | **FIX (web)** — as 15128 |
| 35129 | NamedNappletEvent | T | pri=title, sec=description | = |
| 36787 | MusicTrackEvent | T | pri=title, sec=artist+album, txt=content | = |
| 38000 | MintRecommendationEvent | T (catch-all) | txt | body-only |
| 38192 | Ps1SaveEvent | T | pri=saveTitle, sec=summary+region+filename | **FIX** — was catch-all; the save's title is a title |
| 38383 | P2POrderEvent | T | pri=makerName, sec=currency+paymentMethods | **FIX** — was catch-all |
| 39000 | GroupMetadataEvent | T | pri=name, sec=about | = |
| 39089 | FollowListEvent | T | pri=title, sec=description | = |
| 39092 | MediaStarterPackEvent | T | pri=title, sec=description | = |
| 39701 | WebBookmarkEvent | T | pri=title, sec=description, web=url | + the bookmarked URL |
| 40002, 40100, 45001, 45003, 48106 | buzz stream/forum/huddle kinds | T (catch-all) | txt | body-only |

### What the audit turned up, by failure mode

**1. A title in the wrong tier (the 236× penalty).** 17 kinds were falling through to the
catch-all with a title, name, or summary they could never rank on (19 kinds gain a branch in
total — the other two are the drift-only fixes in mode 3). The marketplace family
(30017/30018/30019/30020) and the Podcasting 2.0 pair (30054/30055) are the sharpest: a stall
name and an episode title are exactly what a person types into search. Kind 9002 is the
tell-tale — it edits the very metadata kind 39000 publishes, and 39000 had a branch while
9002 did not. After this PR every remaining catch-all kind is body-only: its whole
`indexableContent()` really is a body (a chat message, a zap comment, a git patch, a DVM
prompt), so no title is stranded.

**2. A role the branch forgot.** `hashtags` and `locations` are systemic, `websites` is
per-branch — and four kinds with a public URL were not passing it: `GitRepositoryEvent`
(`clones()`, the URL most people would actually search a repo by), `MeetingSpaceEvent`
(`endpoint()`, the same `streaming` tag kind 30311 already carries), and both nSite kinds
(`source()`). Left deliberately out: image/icon/banner URLs (`picture`, `icon`, `image`) —
those are media, not affiliation; `servers()` on nSites and `allRelayUrls()` — infrastructure
a searcher never types; `MeetingSpaceEvent.service()` — a moq-auth endpoint.

**3. Drift against `indexableContent()`.** Six kinds concatenated their `t` tags into the flat
blob AND fell through the funnel, so the same words were indexed twice — in the body role, the
weakest one, which is the shape most likely to skew a term-frequency ranker. All six are fixed
by their new branches (1111, 1311, 30018, 30020, 9002, 30054); `InterestSetEvent` and
`ContactCardEvent` already had the same treatment.

**Reverse drift, reported and deliberately not "fixed":** kind 0 and kind 31990 index
`lud06`, `picture`, `banner` (and 31990's `image`) in the flat form, and the `Profile` shape
has no role for them. Those values are an LNURL bech32 blob and image URLs — not text anyone
searches by — so the roles drop them on purpose. Adding a role for them would mean a new
downstream column for values no one queries; flagged here so the difference is a decision on
record rather than a surprise when someone diffs the two forms.

**Footnote — kind 30063 collision.** `SoftwareReleaseEvent` (experimental/nip82SoftwareApps)
also declares `KIND = 30063` and implements `SearchableEvent` (`content`), but `EventFactory`
maps 30063 to `ReleaseArtifactSetEvent`, so on every store path 30063 extracts
`title`/`description`. No extractor change; noted so the table stays honest.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew :quartz:jvmTest` (the changed module's full suite) — BUILD SUCCESSFUL
- [ ] Manually exercised the change — n/a: `quartz/commonMain` protocol code with no UI surface;
      exercised by the unit tests below instead

### Feature test plan

18 new cases in `SearchFieldExtractorTest`, following the suite's idiom of asserting on the whole
`IndexableFields` value. **Every one of them was run against `main`'s extractor first and fails
there**, then passes with the fix (35 tests, 0 failures on this branch):

- Titles that were stranded in the body tier: `marketplaceNamesReachTheTitleTierNotTheBody`,
  `groupMetadataEditsSplitLikeTheMetadataTheyEdit`,
  `podcasting20EpisodesSplitLikeEveryOtherTitledKind`, `saveTitlesAreTitlesAndTheRestAreKeywords`,
  `birdSightingsAreNamedByTheirSpeciesUnderBothNames`, `p2pOrdersAreNamedByTheirMaker`,
  `summaryOnlyKindsUseTheSummaryTier`, `pollOptionsAreCarriedUnjoinedInTheSecondaryTier`,
  `labelValuesAreKeywordsNotBody`.
- The forgotten `websites` role: `repositoriesAreFindableByCloneUrlAndHomepage` (which also
  asserts a `web` that equals a `clone` is not indexed twice),
  `meetingSpacesCarryTheirStreamingUrlLikeLiveActivitiesDo`, `staticSitesCarryTheirSourceUrl`.
- The double-index drift: `commentHashtagsAreNotIndexedTwice`,
  `productCategoriesAreCarriedOnceAsHashtags`.
- The boundary cases the new branches introduce:
  `unparseableMarketplaceContentStillIndexesItsHashtags` (a JSON decode failure still reaches the
  funnel, as it already does for the buzz kinds), `aBirdSightingWithAnUnrecognizedAltStillIndexesIt`
  and `aBirdSightingKeepsAltTextBeyondTheParsedNames` (the regression test for the audit bug
  below), `aLifeListKeepsItsSpeciesOutOfTheTitleTier`.

### Regression test plan

Touch points and verification:

- **The flat `indexableContent()` path** — every in-tree store indexes through it and it is
  untouched by this diff, so no in-tree search behaviour changes at all. Verified: full
  `:quartz:jvmTest` green, including the store/FTS suites.
- **Branch ordering / shadowing** — 19 new `when` branches could shadow, or be shadowed by, an
  existing one. Verified: every newly matched type is a `final class` AND extends only
  `Event`/`BaseAddressableEvent`/`BaseReplaceableEvent`/`BaseThreadedEvent`, none of which is
  branched — so no new branch is dead code and none steals a kind from an existing branch
  (checked individually, including the `FileHeaderEvent`/`FileStorageHeaderEvent` and
  `PodcastEpisodeEvent`/`Podcasting20EpisodeEvent` near-misses). All new branches sit before the
  deliberately-last `TextNoteEvent` branch and the `SearchableEvent` catch-all.
- **Every newly-branched kind against its flat form** — each of the 19 was diffed
  accessor-by-accessor against its `indexableContent()` to prove no text stops being searchable.
  One did lose text; see the audit pass below.
- **The catch-all still covers every searchable kind, current and future** — the contract this
  file exists to keep. Verified: `unmappedSearchableKindsFallBackToTheTextTier` and
  `nonSearchableKindsExtractNothing` still pass, and the audit enumerates what now lands where.
- **The downstream invariants** — values trimmed and non-empty, empty shapes normalizing to
  `None`, multi-valued roles carried unjoined, Profile XOR Tiered. Verified: every new branch goes
  through the same `tiers()`/`clean()` funnel; the pre-existing `blankContentKindsNormalizeToNone`,
  `contactCardsWithNoPublicTextExtractNothing` and `profileShapesNeverGetHashtagFolding` cases
  still pass; no new branch returns a `Profile`.
- **Android/Desktop runtime behaviour** — not applicable: `quartz/commonMain` protocol code with
  no UI, no flavour-specific touch points and no reflection, so `installPlayDebug` /
  `installFdroidDebug` / `installPlayBenchmark` were not run (per CONTRIBUTING-WITH-AI.md's
  "conclusively flavour-irrelevant" clause — a pure `quartz/` change).

### Review pass

Reviewed with `/code-review` at high effort over the committed diff, per CONTRIBUTING-WITH-AI.md.
It verified every new branch accessor-for-accessor against its kind's `indexableContent()` with no
dropped text, and confirmed the final-class / no-shadowing property above. Three findings landed
against this work: `BirdexEvent`'s unbounded species list claiming the title tier and
`webs() + clones()` not de-duplicating across the two, both fixed here; and the `alt`-tag
duplication on kind 2473, which I fixed by dropping the alt — and then had to undo, because the
audit pass below found that the fix silently lost text. Worth reading as a pair.

One finding is **accepted rather than fixed**: `Ps1SaveEvent`'s `alt` is documented as
`PS1 save '<title>' (<filename>)`, so the title and filename each appear twice across the primary
and secondary roles. Dropping the `alt` to avoid that would lose a publisher-written summary that
does not follow the documented shape — which is precisely the bug the audit pass below caught on
kind 2473, so the duplicate stays.

### Audit pass — bugs and performance

A second pass over this PR's own diff, hunting for defects and hot-path cost. It found one real
bug and one measurable waste; both are fixed in the last commit.

**Bug — kind 2473 dropped text that the flat form still carried.** The branch dropped the `alt`
whenever `commonName()` parsed a name out of it, on the reasoning that the alt is only Birdstar's
boilerplate wrapper around the two species names. But `commonName()` matches a *prefix* and then
cuts at the last `" ("`, so anything a publisher writes after the parenthetical parses exactly the
same. Verified against the real accessor:

```
alt      = "Bird detection: Purple Gallinule (Porphyrio martinica) at Lake Merritt, 7am"
commonName() -> "Purple Gallinule"
extract()    -> primary=[Porphyrio martinica, Purple Gallinule], secondary=[]   <- tail gone
indexableContent() still contains "at Lake Merritt, 7am"
```

A word searchable in the flat form reaching no role is failure mode 3 — the drift this PR exists
to remove — reintroduced by the PR itself. The alt now always reaches the summary tier: the
duplicate it repeats there lands in the weakest role, whereas the drop cost recall outright.
`aBirdSightingKeepsAltTextBeyondTheParsedNames` is the regression test.

**Performance — the funnel allocated a throwaway list per role, filled or not.** Extraction runs
once per stored event and again on every full reindex. The single-value `tiers()` overload wrapped
each of its three values in a list only for `cleanAll()` to build another; `cleanAll()` allocated
even when every value was null; the hashtag role called `hashtags()` — which allocates
unconditionally — on every event including the large majority carrying no `t` tag; and
`locationValues()` allocated a list per event to hold, almost always, nothing.

Both overloads now end in a single `build()`, so `hashtags` and `locations` are still filled in one
place no branch can forget, and every collector allocates lazily. Measured with
`getThreadAllocatedBytes` over 1M JIT-warm extractions, same JVM, same events:

| event shape | before | after |
|---|---|---|
| kind 1, no tags | 160 B/event | **40 B** (−75%) |
| kind 1, six tags | 528 B/event | **168 B** (−68%) |
| kind 30023, title + summary | 272 B/event | **88 B** (−68%) |

The summed hash of every extracted value is identical across the A/B, so the outputs are unchanged;
and the guard added before `hashtags()` is `HashtagTag.parse`'s own acceptance test, so it cannot
skip a tag the accessor would have returned.

Two things deliberately **not** changed. `base()` is now a ~90-deep `is` chain and kind 1 sits at
the end of it; I could not get a trustworthy wall-clock number for that in this environment
(repeated runs of identical work ranged 78–932 ns/event), so I am not going to claim a cost for it
or restructure a dispatch whose readability is the point — flagging it for anyone who sees it in a
real profile. And the per-kind micro-allocations (`LabelEvent.labels().map { }` building two lists
where `LabelTag::parseLabel` would build one, the list concatenations on kinds 12473 and 38383) are
real but sit on low-volume kinds, so they are not worth the churn here.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I
      did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GznRZiv3zS7V9c2QQ9aMk9