### PR TITLE
fix: don't dock the sidebar on portrait tablets (#4024)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/WindowUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/WindowUtils.kt
@@ -45,9 +45,6 @@ private tailrec fun Context.getActivityWindow(): Window? =
         else -> null
     }
 
-@Composable
-fun getActivity(): Activity = LocalContext.current.getActivity()
-
 tailrec fun Context.getActivity(): ComponentActivity =
     when (this) {
         is ComponentActivity -> this

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.ui.components.getActivity
 
@@ -94,6 +96,63 @@ val NotificationPanelWidth = 360.dp
  * (Messages' two-pane split, the embedded browser surfaces) opt out at registration.
  */
 val FeedContentMaxWidth = 600.dp
+
+/**
+ * Minimum window height for the docked drawer. Higher than Material's 480dp Compact/Medium
+ * height boundary on purpose: the permanent drawer's own header — banner, avatar, status
+ * editor, follower counts — fills most of a ~540dp column before the first navigation row, so
+ * below this the rail shows more of the menu than the dock does.
+ */
+private const val DOCK_MIN_WINDOW_HEIGHT_DP = 600
+
+/**
+ * The navigation tier for a window of this shape.
+ *
+ * The dock is not a width decision. A tablet is past the Expanded breakpoint in both
+ * orientations, so keying on width alone pins 300dp of menu open in portrait with no closed
+ * state to fall back on (issue #4024). It docks only when the window is wide, landscape, and
+ * tall enough for the drawer's own content to be usable; everything else that is not Compact
+ * falls through to the rail, which pairs with the existing swipe-in modal drawer.
+ *
+ * Takes plain dp rather than a [WindowWidthSizeClass] so a caller cannot pass a size class
+ * that contradicts the size, and so the whole table is unit-testable without a composition.
+ */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+internal fun decideNavigationStyle(
+    windowWidthDp: Int,
+    windowHeightDp: Int,
+): NavigationStyle {
+    val widthSizeClass =
+        WindowSizeClass
+            .calculateFromSize(DpSize(windowWidthDp.dp, windowHeightDp.dp))
+            .widthSizeClass
+
+    return when {
+        widthSizeClass == WindowWidthSizeClass.Expanded &&
+            windowWidthDp >= windowHeightDp &&
+            windowHeightDp >= DOCK_MIN_WINDOW_HEIGHT_DP -> NavigationStyle.PERMANENT_DRAWER
+        widthSizeClass != WindowWidthSizeClass.Compact -> NavigationStyle.NAV_RAIL
+        else -> NavigationStyle.BOTTOM_BAR
+    }
+}
+
+/**
+ * Whether the window is wide enough to dock the notification feed beside the content.
+ *
+ * Deliberately not keyed on [NavigationStyle.PERMANENT_DRAWER]: a wide portrait window now
+ * gets the rail, and gating on the dock would strip a panel it has today. Named
+ * `decideNotificationPanel` rather than `showsNotificationPanel` so it does not shadow
+ * [ScreenLayoutSpec.showsNotificationPanel] at the construction site.
+ *
+ * The [NavigationStyle.BOTTOM_BAR] term is not load-bearing — Compact is under 600dp, so a
+ * bottom-bar window cannot reach 1200dp — but it makes that an invariant the code enforces.
+ */
+internal fun decideNotificationPanel(
+    style: NavigationStyle,
+    windowWidthDp: Int,
+): Boolean =
+    style != NavigationStyle.BOTTOM_BAR &&
+        windowWidthDp >= NOTIFICATION_PANEL_MIN_WINDOW_DP
 
 /**
  * Centers a destination's content at [FeedContentMaxWidth]. The outer box paints the theme

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.compositionLocalOf
@@ -38,7 +37,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import com.vitorpamplona.amethyst.ui.components.getActivity
 
 /** How the app shell presents its top-level navigation for the current window size. */
 enum class NavigationStyle {
@@ -46,12 +44,13 @@ enum class NavigationStyle {
     BOTTOM_BAR,
 
     /**
-     * Medium windows (portrait tablets, unfolded foldables): a left navigation rail
-     * replaces the bottom bar; the drawer stays modal behind the rail's avatar button.
+     * Every non-Compact window that does not dock — portrait tablets and unfolded foldables at
+     * any width, plus short landscape windows: a left navigation rail replaces the bottom bar
+     * and the drawer stays modal behind the rail's avatar button.
      */
     NAV_RAIL,
 
-    /** Expanded windows (landscape tablets, desktop windows): the drawer docks permanently on the left. */
+    /** Wide, landscape, tall windows (landscape tablets, desktop): the drawer docks permanently on the left. */
     PERMANENT_DRAWER,
 }
 
@@ -62,7 +61,7 @@ enum class NavigationStyle {
 @Immutable
 data class ScreenLayoutSpec(
     val navigationStyle: NavigationStyle,
-    val showsNotificationPanel: Boolean,
+    val hasRoomForNotificationPanel: Boolean,
 ) {
     /**
      * True on the rail and permanent-drawer tiers. Large screens hide the bottom bar and pin
@@ -71,16 +70,18 @@ data class ScreenLayoutSpec(
     val isLargeScreen: Boolean get() = navigationStyle != NavigationStyle.BOTTOM_BAR
 
     companion object {
-        val Phone = ScreenLayoutSpec(NavigationStyle.BOTTOM_BAR, showsNotificationPanel = false)
+        val Phone = ScreenLayoutSpec(NavigationStyle.BOTTOM_BAR, hasRoomForNotificationPanel = false)
     }
 }
 
 val LocalScreenLayout = compositionLocalOf { ScreenLayoutSpec.Phone }
 
 /**
- * Minimum window width for the docked notification panel: the permanent drawer
- * ([PermanentDrawerWidth]) + a readable center pane + the panel ([NotificationPanelWidth])
- * only coexist comfortably from a landscape-tablet-sized window up.
+ * Minimum window width for the docked notification panel: a leading navigation pane, a
+ * readable center pane and the panel ([NotificationPanelWidth]) only coexist comfortably from
+ * a landscape-tablet-sized window up. Sized against the widest leading pane, the permanent
+ * drawer ([PermanentDrawerWidth]); the rail is narrower, so a railed window that clears this
+ * gets a roomier center pane rather than a tighter one.
  */
 private const val NOTIFICATION_PANEL_MIN_WINDOW_DP = 1200
 
@@ -114,8 +115,8 @@ private const val DOCK_MIN_WINDOW_HEIGHT_DP = 600
  * tall enough for the drawer's own content to be usable; everything else that is not Compact
  * falls through to the rail, which pairs with the existing swipe-in modal drawer.
  *
- * Takes plain dp rather than a [WindowWidthSizeClass] so a caller cannot pass a size class
- * that contradicts the size, and so the whole table is unit-testable without a composition.
+ * A square window counts as landscape and docks; `Configuration.ORIENTATION_LANDSCAPE`
+ * breaks that tie the other way, so the two disagree at exactly width == height.
  */
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 internal fun decideNavigationStyle(
@@ -139,20 +140,10 @@ internal fun decideNavigationStyle(
 /**
  * Whether the window is wide enough to dock the notification feed beside the content.
  *
- * Deliberately not keyed on [NavigationStyle.PERMANENT_DRAWER]: a wide portrait window now
- * gets the rail, and gating on the dock would strip a panel it has today. Named
- * `decideNotificationPanel` rather than `showsNotificationPanel` so it does not shadow
- * [ScreenLayoutSpec.showsNotificationPanel] at the construction site.
- *
- * The [NavigationStyle.BOTTOM_BAR] term is not load-bearing — Compact is under 600dp, so a
- * bottom-bar window cannot reach 1200dp — but it makes that an invariant the code enforces.
+ * Deliberately not keyed on [NavigationStyle]: a wide portrait window now gets the rail, and
+ * gating on the dock would strip a panel it has today.
  */
-internal fun decideNotificationPanel(
-    style: NavigationStyle,
-    windowWidthDp: Int,
-): Boolean =
-    style != NavigationStyle.BOTTOM_BAR &&
-        windowWidthDp >= NOTIFICATION_PANEL_MIN_WINDOW_DP
+internal fun hasRoomForNotificationPanel(windowWidthDp: Int): Boolean = windowWidthDp >= NOTIFICATION_PANEL_MIN_WINDOW_DP
 
 /**
  * Centers a destination's content at [FeedContentMaxWidth]. The outer box paints the theme
@@ -178,23 +169,15 @@ fun CappedScreenContent(content: @Composable () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun rememberScreenLayoutSpec(): ScreenLayoutSpec {
-    val widthSizeClass = calculateWindowSizeClass(getActivity()).widthSizeClass
-    val windowWidthDp = LocalConfiguration.current.screenWidthDp
-    return remember(widthSizeClass, windowWidthDp) {
-        val style =
-            when (widthSizeClass) {
-                WindowWidthSizeClass.Expanded -> NavigationStyle.PERMANENT_DRAWER
-                WindowWidthSizeClass.Medium -> NavigationStyle.NAV_RAIL
-                else -> NavigationStyle.BOTTOM_BAR
-            }
+    val configuration = LocalConfiguration.current
+    val windowWidthDp = configuration.screenWidthDp
+    val windowHeightDp = configuration.screenHeightDp
+    return remember(windowWidthDp, windowHeightDp) {
         ScreenLayoutSpec(
-            navigationStyle = style,
-            showsNotificationPanel =
-                style == NavigationStyle.PERMANENT_DRAWER &&
-                    windowWidthDp >= NOTIFICATION_PANEL_MIN_WINDOW_DP,
+            navigationStyle = decideNavigationStyle(windowWidthDp, windowHeightDp),
+            hasRoomForNotificationPanel = hasRoomForNotificationPanel(windowWidthDp),
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
@@ -138,8 +138,10 @@ fun AccountSwitcherAndLeftDrawerLayout(
 }
 
 /**
- * Compact and Medium windows: the drawer slides in as a modal sheet. On Medium an
- * [AppNavigationRail] sits at the left edge in place of the phone bottom bar.
+ * Every window that does not dock the drawer: the drawer slides in as a modal sheet. On the
+ * rail tier an [AppNavigationRail] sits at the left edge in place of the phone bottom bar and
+ * the shell becomes multi-pane — a wide portrait window rails and is still wide enough for
+ * the notification panel.
  */
 @Composable
 private fun ModalDrawerShell(
@@ -183,11 +185,12 @@ private fun ModalDrawerShell(
         },
         content = {
             if (showRail) {
-                Row(Modifier.fillMaxSize()) {
-                    AppNavigationRail(nav, accountViewModel)
-                    VerticalDivider(thickness = DividerThickness)
-                    CenterPane(Modifier.weight(1f), content)
-                }
+                MultiPaneShell(
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                    leading = { AppNavigationRail(nav, accountViewModel) },
+                    content = content,
+                )
             } else {
                 content()
             }
@@ -196,8 +199,62 @@ private fun ModalDrawerShell(
 }
 
 /**
- * Expanded windows: the drawer is permanently docked on the left, the bottom bar disappears,
- * and — when the window is wide enough — the notification feed docks on the right.
+ * The wide-window arrangement both shells render: a [leading] navigation pane, the centre
+ * content, and the notification feed when the window has room. Shared because a wide portrait
+ * window now rails rather than docks and is still wide enough for the panel — the two shells
+ * differ only in which navigation pane leads.
+ */
+@Composable
+private fun MultiPaneShell(
+    accountViewModel: AccountViewModel,
+    nav: Nav,
+    leading: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Row(Modifier.fillMaxSize()) {
+        leading()
+
+        VerticalDivider(thickness = DividerThickness)
+
+        CenterPane(Modifier.weight(1f), content)
+
+        NotificationSidePanelSlot(accountViewModel, nav)
+    }
+}
+
+/**
+ * The docked notification feed, when there is room for it. The panel duplicates the
+ * Notifications screen, so it steps aside while the user is there.
+ *
+ * The back-stack entry is collected here rather than in the shells so windows too narrow for
+ * the panel never observe it, and so navigation churn recomposes this slot instead of the
+ * whole shell. The trade is that a rail-tier window wide enough for the panel ends up with a
+ * second collector beside [ModalDrawerShell]'s own — one extra subscriber on a shared flow,
+ * against a shell restart per navigation on every window that cannot show the panel.
+ *
+ * [Route] matching goes through `remember` because `hasRoute` resolves a serializer
+ * reflectively on every call.
+ */
+@Composable
+private fun NotificationSidePanelSlot(
+    accountViewModel: AccountViewModel,
+    nav: Nav,
+) {
+    if (!LocalScreenLayout.current.hasRoomForNotificationPanel) return
+
+    val navBackStackEntry by nav.controller.currentBackStackEntryAsState()
+    val destination = navBackStackEntry?.destination
+    val onNotifications = remember(destination) { destination?.hasRoute<Route.Notification>() == true }
+
+    if (!onNotifications) {
+        VerticalDivider(thickness = DividerThickness)
+        NotificationSidePanel(accountViewModel, nav)
+    }
+}
+
+/**
+ * Wide, landscape, tall windows: the drawer is permanently docked on the left, the bottom bar
+ * disappears, and — when the window is wide enough — the notification feed docks on the right.
  */
 @Composable
 private fun PermanentDrawerShell(
@@ -206,24 +263,12 @@ private fun PermanentDrawerShell(
     openSheet: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val navBackStackEntry by nav.controller.currentBackStackEntryAsState()
-    // The panel duplicates the Notifications screen, so it steps aside while the user is there.
-    val showPanel =
-        LocalScreenLayout.current.showsNotificationPanel &&
-            navBackStackEntry?.destination?.hasRoute<Route.Notification>() != true
-
-    Row(Modifier.fillMaxSize()) {
-        PermanentDrawerContent(nav, openSheet, accountViewModel)
-
-        VerticalDivider(thickness = DividerThickness)
-
-        CenterPane(Modifier.weight(1f), content)
-
-        if (showPanel) {
-            VerticalDivider(thickness = DividerThickness)
-            NotificationSidePanel(accountViewModel, nav)
-        }
-    }
+    MultiPaneShell(
+        accountViewModel = accountViewModel,
+        nav = nav,
+        leading = { PermanentDrawerContent(nav, openSheet, accountViewModel) },
+        content = content,
+    )
 }
 
 /**

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayoutSpecTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayoutSpecTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.layouts
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The tier rule from amethyst/plans/2026-08-31-portrait-sidebar-tier-rule.md:
+ *
+ *     dock  <=>  widthClass == Expanded  &&  width >= height  &&  height >= 600dp
+ *
+ * Sizes are window dp, width first. Every row of the spec's Behaviour table appears here.
+ */
+class ScreenLayoutSpecTest {
+    private fun assertStyle(
+        expected: NavigationStyle,
+        widthDp: Int,
+        heightDp: Int,
+    ) = assertEquals("${widthDp}x${heightDp}dp", expected, decideNavigationStyle(widthDp, heightDp))
+
+    // ---- Behaviour table ----
+
+    @Test
+    fun phonePortraitKeepsTheBottomBar() = assertStyle(NavigationStyle.BOTTOM_BAR, 411, 923)
+
+    @Test
+    fun phoneLandscapeNoLongerDocks() = assertStyle(NavigationStyle.NAV_RAIL, 923, 411)
+
+    @Test
+    fun reporterTabletPortraitNoLongerDocks() = assertStyle(NavigationStyle.NAV_RAIL, 889, 1422)
+
+    @Test
+    fun wideTabletPortraitNoLongerDocks() = assertStyle(NavigationStyle.NAV_RAIL, 1201, 1920)
+
+    @Test
+    fun mediumTabletPortraitStillRails() = assertStyle(NavigationStyle.NAV_RAIL, 800, 1280)
+
+    @Test
+    fun tabletLandscapeStillDocks() = assertStyle(NavigationStyle.PERMANENT_DRAWER, 1422, 889)
+
+    @Test
+    fun mediumTabletLandscapeStillDocks() = assertStyle(NavigationStyle.PERMANENT_DRAWER, 1280, 800)
+
+    @Test
+    fun wideButShortLandscapeNoLongerDocks() = assertStyle(NavigationStyle.NAV_RAIL, 1200, 540)
+
+    // ---- Boundaries ----
+
+    @Test
+    fun squareWindowAtTheWidthBreakpointDocks() = assertStyle(NavigationStyle.PERMANENT_DRAWER, 840, 840)
+
+    @Test
+    fun portraitByOneDpDoesNotDock() = assertStyle(NavigationStyle.NAV_RAIL, 840, 841)
+
+    @Test
+    fun exactlyAtTheHeightFloorDocks() = assertStyle(NavigationStyle.PERMANENT_DRAWER, 840, 600)
+
+    @Test
+    fun oneDpBelowTheHeightFloorDoesNotDock() = assertStyle(NavigationStyle.NAV_RAIL, 840, 599)
+
+    @Test
+    fun oneDpBelowTheWidthBreakpointRails() = assertStyle(NavigationStyle.NAV_RAIL, 839, 600)
+
+    @Test
+    fun compactWidthKeepsTheBottomBar() = assertStyle(NavigationStyle.BOTTOM_BAR, 599, 900)
+
+    // ---- Notification panel ----
+
+    @Test
+    fun panelHiddenJustBelowTheThreshold() = assertEquals(false, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1199))
+
+    @Test
+    fun panelShownExactlyAtTheThreshold() = assertEquals(true, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1200))
+
+    @Test
+    fun panelShownAboveTheThreshold() = assertEquals(true, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1201))
+
+    @Test
+    fun panelSurvivesTheCollapseToTheRail() = assertEquals(true, decideNotificationPanel(NavigationStyle.NAV_RAIL, 1200))
+
+    @Test
+    fun panelNeverAppearsOnTheBottomBar() = assertEquals(false, decideNotificationPanel(NavigationStyle.BOTTOM_BAR, 1200))
+
+    /**
+     * A landscape-short window: wide enough for the panel, too short for the dock. Rail plus
+     * panel is a combination that has never shipped, so assert both halves together.
+     */
+    @Test
+    fun shortLandscapeYieldsRailPlusPanel() {
+        val style = decideNavigationStyle(1200, 599)
+        assertEquals(NavigationStyle.NAV_RAIL, style)
+        assertEquals(true, decideNotificationPanel(style, 1200))
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayoutTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayoutTest.kt
@@ -21,6 +21,8 @@
 package com.vitorpamplona.amethyst.ui.layouts
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -30,7 +32,7 @@ import org.junit.Test
  *
  * Sizes are window dp, width first. Every row of the spec's Behaviour table appears here.
  */
-class ScreenLayoutSpecTest {
+class ScreenLayoutTest {
     private fun assertStyle(
         expected: NavigationStyle,
         widthDp: Int,
@@ -86,19 +88,10 @@ class ScreenLayoutSpecTest {
     // ---- Notification panel ----
 
     @Test
-    fun panelHiddenJustBelowTheThreshold() = assertEquals(false, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1199))
+    fun panelHiddenJustBelowTheThreshold() = assertFalse(hasRoomForNotificationPanel(1199))
 
     @Test
-    fun panelShownExactlyAtTheThreshold() = assertEquals(true, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1200))
-
-    @Test
-    fun panelShownAboveTheThreshold() = assertEquals(true, decideNotificationPanel(NavigationStyle.PERMANENT_DRAWER, 1201))
-
-    @Test
-    fun panelSurvivesTheCollapseToTheRail() = assertEquals(true, decideNotificationPanel(NavigationStyle.NAV_RAIL, 1200))
-
-    @Test
-    fun panelNeverAppearsOnTheBottomBar() = assertEquals(false, decideNotificationPanel(NavigationStyle.BOTTOM_BAR, 1200))
+    fun panelShownExactlyAtTheThreshold() = assertTrue(hasRoomForNotificationPanel(1200))
 
     /**
      * A landscape-short window: wide enough for the panel, too short for the dock. Rail plus
@@ -106,8 +99,7 @@ class ScreenLayoutSpecTest {
      */
     @Test
     fun shortLandscapeYieldsRailPlusPanel() {
-        val style = decideNavigationStyle(1200, 599)
-        assertEquals(NavigationStyle.NAV_RAIL, style)
-        assertEquals(true, decideNotificationPanel(style, 1200))
+        assertStyle(NavigationStyle.NAV_RAIL, 1200, 599)
+        assertTrue(hasRoomForNotificationPanel(1200))
     }
 }


### PR DESCRIPTION
Fixes #4024.

Before:
<img width="300" alt="Screenshot 2026-09-01 at 22 06 24" src="https://github.com/user-attachments/assets/8e7db364-ce1a-497e-b604-9e6538137a2a" />

After:
<img width="300" alt="Screenshot 2026-09-01 at 21 20 27" src="https://github.com/user-attachments/assets/ca4213ec-b03c-43c6-9fc8-a40294356825" /> <img width="300" alt="Screenshot 2026-09-01 at 21 20 34" src="https://github.com/user-attachments/assets/efe6fbcb-192b-4ab0-a4ae-a8a9fdfbb53c" />

## The problem

On a tablet in portrait the side menu is pinned open at 300dp and cannot be closed. There is no collapse control, no swipe, and no setting. The reporter (OnePlus Pad 3, 13.2", Android 16) asked for either a way to hide it or a swipe to dismiss it.

The cause is that the shell picked its navigation style from **window width alone**:

```kotlin
when (widthSizeClass) {
    WindowWidthSizeClass.Expanded -> NavigationStyle.PERMANENT_DRAWER
    WindowWidthSizeClass.Medium   -> NavigationStyle.NAV_RAIL
    else                          -> NavigationStyle.BOTTOM_BAR
}
```

Nothing consulted orientation or height. A phone teaches you "portrait hides the menu, landscape docks it" — but only by accident, because a phone's portrait width happens to be Compact. A tablet is past 840dp in *both* orientations, so that intuition breaks.

And the docked tier has no closed state to fall back on. `PermanentDrawerShell` is a plain `Row` whose first child is a fixed 300dp column: no `ModalNavigationDrawer`, no scrim, no swipe handler, no back handler. The menu isn't "a drawer that happens to be open" — on that path the drawer concept doesn't exist.

The clearest way to see it: on the same emulator, in the same orientation, 89dp apart —

| Portrait width | Tier | Layout |
| --- | --- | --- |
| 800dp (Medium Tablet @ 320dpi) | `NAV_RAIL` | 80dp rail, menu hidden |
| 889dp (same device @ 288dpi ≈ the reporter's Pad 3) | `PERMANENT_DRAWER` | 300dp dock, forced open |

A user who changes Android's display-size setting can flip between those two layouts on one device and never learn why.

A landscape phone hit the same path: a Pixel 9a is 923dp wide in landscape, so it docked a 300dp column into a 411dp-tall window.

## The fix

Decide the dock from the **shape** of the window, not just its width:

```
dock  ⟺  widthClass == Expanded  ∧  width ≥ height  ∧  height ≥ 600dp
```

Anything not dockable and not Compact falls through to `NAV_RAIL`, which already ships and is already what an 800dp portrait tablet gets today. This isn't a new layout — the rail plus the swipe-in modal drawer is an existing, shipping combination; the change just extends it past a threshold that should never have been width-only.

**The reporter also gets the gesture they asked for.** `zonedDrawerSwipeIfModal` short-circuits to a no-op while `isDrawerDocked`, so at 889dp the swipe zone was never attached. Undocking arms it: right-swipe opens the drawer (from anywhere on a pager's first page; from the right half on later pages, since the left half is reserved for paging), and `drawerGesturesEnabled`'s `isOpen` term keeps `ModalNavigationDrawer`'s close gesture live. So "swipe left on the sidebar to hide" is answered literally, by machinery that already existed and simply wasn't reachable on their device.

### Why the height floor is 600dp, not Material's 480dp

The dock's cost is horizontal, but its *usability* is vertical: `PermanentDrawerContent` renders a profile banner, avatar, status editor and follower counts before the first navigation row. In a ~540dp-tall window that header eats most of the column and the menu becomes a scrolling sliver — worse than the rail, which shows every pinned destination at once. Affected band: landscape windows ≥840dp wide and 480–599dp tall, i.e. large phones and small foldables in landscape.

### Notification panel

`showsNotificationPanel` was gated on `style == PERMANENT_DRAWER && width >= 1200`. Left alone, this fix would have **removed** the panel from a ≥1200dp portrait window that has it today — a regression introduced by the fix itself. It's now keyed on width alone, and the rail shell renders it too, so `NAV_RAIL` + panel works. That combination has never shipped before, so it's explicitly verified below.

## Behaviour

| Window | Before | After |
| --- | --- | --- |
| Phone portrait 411×923dp | bottom bar | bottom bar |
| Phone landscape 923×411dp | **dock** | rail + swipe drawer |
| Tablet portrait 889×1422dp — *the issue* | **dock** | rail + swipe drawer |
| Tablet portrait 1201×1920dp | **dock + panel** | rail + panel |
| Tablet portrait 800×1280dp | rail | rail |
| Tablet landscape 1422×889dp | dock | dock |
| Tablet landscape 1280×800dp | dock + panel | dock + panel |
| Landscape 1200×540dp | **dock + panel** | rail + panel |

Landscape docking is deliberately unchanged. This fixes portrait; it does not make the sidebar collapsible everywhere.

## A second visible change worth flagging

`MessagesScreen` sizes itself from the pane it occupies, not the window. Dropping the dock widens that pane past the Compact breakpoint, so **Messages flips from single-pane to two-pane** on the affected windows:

| Window | Pane before | Pane after | Messages |
| --- | --- | --- | --- |
| 889dp portrait | 589dp (Compact) | 809dp (Medium) | single → two-pane, 323 + 485dp |
| 1201dp portrait | ~540dp (Compact) | ~760dp (Medium) | single → two-pane |

Arguably an improvement — a 13" tablet showing list-and-thread instead of one column — but it isn't what the issue asked for, so it's called out rather than buried. Verified on device.

## Verification

`decideNavigationStyle` and `hasRoomForNotificationPanel` are pure functions taking dp, so the whole behaviour table is unit-tested without a composition or an Activity. The boundary cases are mutation-load-bearing: 840×840 fails if `width >= height` is tightened to `>`, 840×600 fails if the height floor is tightened, and 839×600 pins the Expanded edge independently.

Full suite green (1420 tests / 187 classes, 0 failures). The shells have no automated coverage — this module has no Compose UI test harness — so they were verified on device:

| Check | Result |
| --- | --- |
| 889dp portrait (Medium Tablet @ 288dpi) | rail measured 79.5dp, no dock, no panel |
| 1201dp portrait (@ 213dpi) | rail 80dp + content + panel 362dp |
| 800dp portrait (@ 320dpi) | rail, unchanged |
| Landscape 1280×800dp | dock 300dp + panel 360dp, unchanged |
| Landscape 1024×640dp (@ 400dpi) | dock, no panel — pins both the 1200dp panel threshold and the 600dp height floor |
| Messages @ 889dp portrait | two-pane, 323 + 485dp |
| Physical Pixel 9a, landscape 923dp | rail + working swipe drawer |

A measurement question was settled empirically before wiring: `Configuration.screenWidthDp/screenHeightDp` historically excluded system decorations where the full window bounds include them, which would have mattered because the 600dp floor sits exactly where the two could disagree. Measured on a landscape tablet with 3-button navigation on `targetSdk 37`: `config=1280x800dp window=1280x800dp` — identical across two launches, so edge-to-edge enforcement has already removed the discrepancy and `LocalConfiguration` is safe as the single source.

## Not included

- **No setting.** An earlier draft added a synced `autoHideDock` boolean. Once the rule is fixed it would only serve someone on a *landscape* tablet who wants the dock hidden, which nobody has asked for, and a synced NIP-78 field is permanent surface area. Worth adding if that demand appears.
- **`FeedContentMaxWidth` unchanged.** At 889dp the reading column goes 589 → 600dp; the reclaimed 300dp becomes gutter, not text. The goal is removing undismissable chrome, not gaining reading width.

## Known, pre-existing, not fixed here

While testing this I found the Messages two-pane list column is too narrow at Medium pane widths — 248dp at a 620dp pane, with chat titles truncating to `A…` / `No…`. Confirmed **pre-existing** by building `main-upstream` and reproducing it pixel-identically without any of these commits.

It also has a discontinuity worth its own issue: the split is `1f/2.5f` below Expanded and `1f/3f` at or above it, so crossing 840dp makes the list column *shrink* — 839dp gives a 335.6dp list, 840dp gives 280dp. One extra dp of pane costs 56dp of list, and `1/3` doesn't catch back up until ~1007dp. Out of scope here.
