### PR TITLE
fix(theme): pin the launch splash colour and drop the no-op night-mode writes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
@@ -21,8 +21,6 @@
 package com.vitorpamplona.amethyst.ui.theme
 
 import android.app.Activity
-import android.app.UiModeManager
-import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -49,7 +47,6 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.SpanStyle
@@ -712,24 +709,15 @@ fun AmethystTheme(
     fontSize: FontSizeType = FontSizeType.NORMAL,
     content: @Composable () -> Unit,
 ) {
-    val context = LocalContext.current
+    // Deliberately no UiModeManager.nightMode write: changing the device night mode needs
+    // MODIFY_DAY_NIGHT_MODE, which this app does not declare, so the call silently no-ops — and it
+    // ran on every recomposition of the theme, writing device state from inside composition. The
+    // in-app choice is applied through the colour scheme below, which is what actually took effect.
     val darkTheme =
         when (prefTheme) {
-            ThemeType.DARK -> {
-                val uiManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-                uiManager.nightMode = UiModeManager.MODE_NIGHT_YES
-                true
-            }
-
-            ThemeType.LIGHT -> {
-                val uiManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-                uiManager.nightMode = UiModeManager.MODE_NIGHT_NO
-                false
-            }
-
-            else -> {
-                isSystemInDarkTheme()
-            }
+            ThemeType.DARK -> true
+            ThemeType.LIGHT -> false
+            else -> isSystemInDarkTheme()
         }
     val colors =
         remember(darkTheme, accentColor) {

--- a/amethyst/src/main/res/values-night/themes.xml
+++ b/amethyst/src/main/res/values-night/themes.xml
@@ -2,6 +2,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.Amethyst" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
+        <!-- Pinned to the brand colour rather than left to inherit the theme background.
+             The system builds the launch splash from this theme before the process starts,
+             using the *system* light/dark config — but the in-app ThemeType may be pinned to
+             the opposite, so an inherited background flashes the wrong colour before the UI
+             appears (white before a dark UI, or black before a light one). A fixed brand
+             colour reads as an intentional splash in every combination. -->
+        <item name="android:windowSplashScreenBackground" tools:targetApi="31">@color/purple_700</item>
         <item name="android:windowBackground">@color/black</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
     </style>

--- a/amethyst/src/main/res/values/themes.xml
+++ b/amethyst/src/main/res/values/themes.xml
@@ -2,6 +2,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.Amethyst" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
+        <!-- Pinned to the brand colour rather than left to inherit the theme background.
+             The system builds the launch splash from this theme before the process starts,
+             using the *system* light/dark config — but the in-app ThemeType may be pinned to
+             the opposite, so an inherited background flashes the wrong colour before the UI
+             appears (white before a dark UI, or black before a light one). A fixed brand
+             colour reads as an intentional splash in every combination. -->
+        <item name="android:windowSplashScreenBackground" tools:targetApi="31">@color/purple_700</item>
         <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
     </style>
     <style name="noAnimTheme" parent="Theme.AppCompat.DayNight.NoActionBar">


### PR DESCRIPTION
Two small, independent fixes found while profiling feed rendering. Neither is a performance change — they're correctness/hygiene.

## 1. The launch splash can flash the wrong colour

The system builds the launch splash from the manifest theme **before the process starts**, resolving it against the *system* light/dark configuration. But the in-app `ThemeType` can be pinned to the opposite:

| system | in-app theme | splash | UI | |
|---|---|---|---|---|
| dark | SYSTEM / DARK | black | dark | ok |
| light | SYSTEM / LIGHT | white | light | ok |
| light | **DARK pinned** | white | dark | ⚠️ white flash |
| dark | **LIGHT pinned** | black | light | ⚠️ dark flash |

No app-side code can fix that first frame — it's painted before `onCreate` runs, so `setDefaultNightMode` and friends are too late.

Pinning `windowSplashScreenBackground` to the brand colour already used for the status bar makes the splash read as intentional in every combination.

**Deliberately narrow:** only the API 31+ splash attribute is set. `windowBackground` is left alone, because
- clearing it makes the window **non-opaque**, which costs SurfaceFlinger the chance to skip the layers beneath — measured **~17% worse at frame P90** on an SM-T220; and
- pre-31 devices keep their current behaviour rather than getting a new colour.

**Verified on device** by recording a cold start and sampling frames: launcher → purple splash `(63,12,181)` ≈ `#3700B3` → dark UI, with no white frame at 30 fps.

*(Colour is a taste call — it's one line if you'd prefer a different one.)*

## 2. The night-mode writes are dead code

`AmethystTheme` set `UiModeManager.nightMode` to force the device night mode when a DARK/LIGHT theme is pinned. Changing it requires `MODIFY_DAY_NIGHT_MODE`, which **the manifest does not declare**, so the call silently no-ops for a normal app — while performing a device-state write *from inside composition*, on every recomposition of the theme.

The pinned choice already takes effect through the colour scheme selected immediately below, which is what was actually doing the work. Removing the writes changes no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1CzYQvWyHfipSW7x3j4Yo