### PR TITLE
Unify payment target UI across profile and dialog

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
@@ -20,48 +20,24 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header
 
-import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.components.util.setText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.payment.ProfilePaymentMethod
-import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.BitcoinOrange
 import com.vitorpamplona.amethyst.ui.theme.Size16Modifier
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
 import com.vitorpamplona.quartz.nipBCOnchainZaps.taproot.SegwitAddress
-import kotlinx.coroutines.launch
 
 /** Lightning-family target types Amethyst can pay in-app through the Send Payment screen. */
 private val LIGHTNING_TARGET_TYPES = setOf("lightning", "ln", "lnurl")
@@ -111,72 +87,57 @@ fun PaymentTargetChip(
 ) {
     val style = remember(target.type) { paymentTargetStyleFor(target.type) }
     val uriHandler = LocalUriHandler.current
-    val context = LocalContext.current
-    val clipboard = LocalClipboard.current
-    val scope = rememberCoroutineScope()
-    val copyLabel = stringRes(R.string.copy_to_clipboard)
-    val copiedMessage = stringRes(R.string.copied_to_clipboard)
 
-    Surface(
-        shape = RoundedCornerShape(50),
-        color = style.color.copy(alpha = 0.10f),
-        border = BorderStroke(1.dp, style.color.copy(alpha = 0.35f)),
-        modifier =
-            Modifier.combinedClickable(
-                onClick = {
-                    // Targets one of the user's in-app wallets can pay (lightning,
-                    // bitcoin) go to the Send Payment screen, which collects the
-                    // amount and pays this exact target; everything else hands off
-                    // to an external wallet app via its payment URI.
-                    val inAppRoute = inAppPaymentRouteFor(baseUser.pubkeyHex, target)
-                    if (inAppRoute != null) {
-                        nav.nav(inAppRoute)
-                    } else {
-                        runCatching { uriHandler.openUri(style.uriFor(target.authority)) }
-                            .onFailure {
-                                accountViewModel.toastManager.toast(
-                                    R.string.error_dialog_payment_error,
-                                    R.string.no_payment_app_found_for_type,
-                                    style.label,
-                                )
-                            }
+    PaymentTargetPill(
+        target = target,
+        onClick = {
+            // Targets one of the user's in-app wallets can pay (lightning,
+            // bitcoin) go to the Send Payment screen, which collects the
+            // amount and pays this exact target; everything else hands off
+            // to an external wallet app via its payment URI.
+            val inAppRoute = inAppPaymentRouteFor(baseUser.pubkeyHex, target)
+            if (inAppRoute != null) {
+                nav.nav(inAppRoute)
+            } else {
+                runCatching { uriHandler.openUri(style.uriFor(target.authority)) }
+                    .onFailure {
+                        accountViewModel.toastManager.toast(
+                            R.string.error_dialog_payment_error,
+                            R.string.no_payment_app_found_for_type,
+                            style.label,
+                        )
                     }
-                },
-                onLongClick = {
-                    scope.launch {
-                        clipboard.setText(target.authority)
-                        Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
-                    }
-                },
-                onLongClickLabel = copyLabel,
-            ),
+            }
+        },
+    )
+}
+
+/**
+ * The pill for a single NIP-A3 payment target: the type's icon and tinted
+ * label followed by the shortened authority, with a long-press copy of the
+ * full authority. Shared by the profile's payment rail and the payment-target
+ * dialog so a target looks the same wherever it shows up.
+ */
+@Composable
+fun PaymentTargetPill(
+    target: PaymentTarget,
+    onClick: () -> Unit,
+) {
+    val style = remember(target.type) { paymentTargetStyleFor(target.type) }
+
+    ProfilePaymentChip(
+        color = style.color,
+        label = style.label,
+        detail = remember(target.authority) { shortAddress(target.authority) },
+        copyValue = target.authority,
+        onClick = onClick,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-        ) {
-            Icon(
-                symbol = style.symbol,
-                contentDescription = style.label,
-                tint = style.color,
-                modifier = Size16Modifier,
-            )
-            Text(
-                text = style.label,
-                color = style.color,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = shortAddress(target.authority),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.widthIn(max = 180.dp),
-            )
-        }
+        Icon(
+            symbol = style.symbol,
+            contentDescription = null,
+            tint = style.color,
+            modifier = Size16Modifier,
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
@@ -74,6 +74,15 @@ fun inAppPaymentRouteFor(
 }
 
 /**
+ * The URI an external wallet app should receive for [target]: the type's own
+ * scheme (`bitcoin:`, `lightning:`, `https://cash.app/…`) and RFC 8905
+ * `payto://` for types Amethyst has no dedicated scheme for. Shared with the
+ * payment-target dialog so the same pill hands off to the same app wherever
+ * it is tapped.
+ */
+fun paymentTargetUri(target: PaymentTarget): String = paymentTargetStyleFor(target.type).uriFor(target.authority)
+
+/**
  * Chip for a NIP-A3 payment target. Rendered inside [DisplayPaymentRailChips]'s
  * FlowRow alongside the wallet-rail chips so all payment chips share one
  * wrapping row and spacing.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,10 +47,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.core.net.toUri
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
@@ -72,7 +71,6 @@ import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
 import com.vitorpamplona.amethyst.ui.theme.ZeroPadding
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 @Composable
@@ -153,6 +151,7 @@ fun PaymentTargetsDialog(
     payInApp: ((PaymentTarget) -> Boolean)? = null,
 ) {
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -188,15 +187,13 @@ fun PaymentTargetsDialog(
                         },
                         onPay = {
                             if (payInApp?.invoke(target) != true) {
-                                try {
-                                    val intent = Intent(Intent.ACTION_VIEW, "payto://${target.type}/${target.authority}".toUri())
-                                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                                    context.startActivity(intent)
-                                    onDismiss()
-                                } catch (e: Exception) {
-                                    if (e is CancellationException) throw e
-                                    errorMessage = stringRes(context, R.string.no_payment_app_found)
-                                }
+                                // Same handoff the profile chip does: the type's own
+                                // scheme when it has one (payto:// only as the
+                                // fallback), and no task flags — CLEAR_TASK used to
+                                // wipe whatever the wallet app already had open.
+                                runCatching { uriHandler.openUri(paymentTargetUri(target)) }
+                                    .onSuccess { onDismiss() }
+                                    .onFailure { errorMessage = stringRes(context, R.string.no_payment_app_found) }
                             }
                         },
                     )
@@ -233,8 +230,10 @@ private fun PaymentTargetRow(
                 .padding(horizontal = 16.dp, vertical = 10.dp),
     ) {
         // Same pill the profile page renders for this target: type icon,
-        // tinted type label and the shortened authority, instead of the
-        // raw wallet id spelled out over two lines.
+        // tinted type label and the shortened authority, instead of the raw
+        // wallet id spelled out over two lines. Tapping it pays and long-press
+        // copies, exactly like on the profile, so the row carries no separate
+        // pay button — three icon buttons left the address 0dp of width.
         Box(modifier = Modifier.weight(1f)) {
             PaymentTargetPill(target = target, onClick = onPay)
         }
@@ -251,14 +250,6 @@ private fun PaymentTargetRow(
             Icon(
                 symbol = MaterialSymbols.ContentCopy,
                 contentDescription = stringRes(R.string.copy_to_clipboard),
-                modifier = Size20Modifier,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        IconButton(onClick = onPay) {
-            Icon(
-                symbol = MaterialSymbols.Bolt,
-                contentDescription = stringRes(R.string.payment_targets),
                 modifier = Size20Modifier,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -48,7 +49,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
@@ -232,19 +232,11 @@ private fun PaymentTargetRow(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 10.dp),
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = target.type.replaceFirstChar(Char::titlecase),
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = target.authority,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
+        // Same pill the profile page renders for this target: type icon,
+        // tinted type label and the shortened authority, instead of the
+        // raw wallet id spelled out over two lines.
+        Box(modifier = Modifier.weight(1f)) {
+            PaymentTargetPill(target = target, onClick = onPay)
         }
         Spacer(modifier = Modifier.width(8.dp))
         IconButton(onClick = onShowQr) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/ProfilePaymentRailChips.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/ProfilePaymentRailChips.kt
@@ -290,6 +290,10 @@ fun ProfilePaymentChip(
                 color = color,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.SemiBold,
+                // Narrow hosts (the payment-target dialog's row) would otherwise
+                // wrap a long type label into a two-line pill.
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             if (detail != null) {
                 Text(


### PR DESCRIPTION
## Summary

The payment-targets dialog listed each target as a titlecased type over the full wallet id on a second line. It now renders the same pill the profile page uses — type icon, tinted type label, shortened authority, tap to pay, long-press to copy — with the pill extracted as `PaymentTargetPill` so the profile rail and the dialog share one implementation instead of two copies of the same `Surface`/`Row`. `ReactionsRow`'s use of the same dialog picks up the new look for free.

Auditing that change turned up three more defects in those rows, fixed in the second commit.

## Changes

- **`DisplayPaymentTargets.kt`** — extracted `PaymentTargetPill`; rebuilt `PaymentTargetChip` on top of the existing `ProfilePaymentChip`; added `paymentTargetUri()` so both call sites resolve a target to the same URI.
- **`PaymentButton.kt`** — dialog rows render the pill; handoff goes through `paymentTargetUri()` and `LocalUriHandler` instead of a hand-built `Intent`.
- **`ProfilePaymentRailChips.kt`** — the chip's type label is capped at one line.

Defects fixed:

1. **The address rendered at 0dp.** The pill plus three 48dp icon buttons left the pill 112dp on a 320dp dialog — exactly icon + type label — so the shortened authority was measured at zero width and never drawn. The pill already pays on tap and copies on long-press, so the redundant bolt button is gone and the address gets its width back:

   | dialog width | icon buttons | pill box | address |
   |---|---|---|---|
   | 320dp | 3 (before) | 112dp | **0dp** |
   | 320dp | 2 (after) | 160dp | 45dp |
   | 372dp | 2 (after) | 212dp | 97dp |

2. **A long type label wrapped the pill to two lines** (`BITCOINCASH` measured 28dp tall vs 14dp) — hence `maxLines = 1` on the label. No effect on the profile rail, where the FlowRow gives chips full width.

3. **The same pill reached different apps depending on where it was tapped.** The dialog hard-coded `payto://<type>/<authority>` for every type while the profile chip used the type's own scheme, and almost no Android wallet registers `payto`; a bitcoin target that paid from the profile failed from the dialog. Both now go through `paymentTargetUri()`, which keeps `payto://` as the unknown-type fallback.

4. **`FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK` on that handoff** wiped whatever the wallet app already had open. The dialog runs from an activity context that needs neither flag.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran the pre-push suite — `:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test`, all green
- [ ] **Manually exercised the change — not done.** This was written in a headless environment with no device or emulator, so there are no screenshots and nobody has looked at the rendered pill. That check is still open.

Notes:

The layout numbers above are measured, not estimated. `:amethyst` has no Robolectric, so the dialog row was replicated in a throwaway Compose UI test on the desktop module (`createComposeRule`, `getUnclippedBoundsInRoot`) at 320dp and 372dp dialog widths with 48dp icon buttons, which is what reproduced the 0dp address and the two-line label. The probe was deleted afterwards and is not part of this diff.

The Compose compiler report for the three files was also checked: every composable in the payment path is `restartable skippable`. `PaymentTarget` is reported unstable (a plain class from `quartz`, which isn't compiled with the Compose plugin), but strong skipping compares it by instance and the instances come from a remembered `paymentTargets()`, so skipping holds.

## Interop suites

- [x] N/A — UI-only; no wire bytes, decoded audio, MLS state or DM envelopes are touched

## AI assistance

- [x] Drafted with AI assistance (Claude Code). Reviewed against the code and the measurements above; see the Test plan for exactly what was and was not run.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01We35qZJEhp8bSbPUHo6Koc