### PR TITLE
Remove 3-relay cap from invite links; support up to 255

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteBundle.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteBundle.kt
@@ -144,7 +144,7 @@ object ConcordInviteBundle {
      * [InviteBundleStatus] under CORD-05 §2 replaceable semantics. The newest event
      * wins: a `vsk=9` revocation tombstone marks the link [InviteBundleStatus.Revoked]
      * even when an older, still-openable bundle is also present (so a stale relay copy
-     * can't resurrect a retired link). Otherwise the first `vsk=6` bundle that opens +
+     * can't resurrect a retired link). Otherwise the **newest** `vsk=6` bundle that opens +
      * validates with [token] is [InviteBundleStatus.Live]; anything else present is
      * [InviteBundleStatus.Unreadable], and an empty set is [InviteBundleStatus.Absent].
      *
@@ -160,7 +160,14 @@ object ConcordInviteBundle {
     ): InviteBundleStatus {
         val newest = wraps.maxByOrNull { it.createdAt } ?: return InviteBundleStatus.Absent
         if (newest.tags.vsk() == ControlEntityKind.INVITE_REVOKED) return InviteBundleStatus.Revoked
-        val invite = wraps.firstNotNullOfOrNull { parse(it, token)?.takeIf { i -> validate(i) } }
+        // Newest-first, not fetch order. [wraps] arrives straight off `fetchAll`, i.e. in relay
+        // arrival order, so opening whichever copy decrypts first is a coin flip between editions.
+        // That matters because a Refounding re-mints every live link at its OWN coordinate with the
+        // new epoch's root: a relay still serving the pre-Refounding bundle would otherwise hand the
+        // joiner the root of the epoch the community just left, and they would join, see planes
+        // nobody reads, and get no error saying why. The revocation branch above already resolves
+        // newest-wins; the live branch has to agree with it.
+        val invite = wraps.sortedByDescending { it.createdAt }.firstNotNullOfOrNull { parse(it, token)?.takeIf { i -> validate(i) } }
         return when {
             invite == null -> InviteBundleStatus.Unreadable
             isExpired(invite, nowMs) -> InviteBundleStatus.Expired(invite)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteLink.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteLink.kt
@@ -53,15 +53,14 @@ class ParsedInviteLink(
  * `(33301, link_signer_pubkey, d="")`. The `#fragment` is **never sent to any
  * server**: it is base64url of `[version=4][flags][relays?][token:16]`, carrying
  * the 16-byte unlock token (→ [com.vitorpamplona.quartz.concord.crypto
- * .ConcordKeyDerivation.inviteBundleKey]) and, when flag `0x01` is unset, up to
- * three bootstrap relays encoded against [InviteRelayDictionary].
+ * .ConcordKeyDerivation.inviteBundleKey]) and, when flag `0x01` is unset, the
+ * bootstrap relays encoded against [InviteRelayDictionary].
  *
  * Pinned to the Concord v2 reference client for interop.
  */
 object ConcordInviteLink {
     const val VERSION = 4
     const val FLAG_STOCK_RELAYS = 0x01
-    const val MAX_RELAYS = 3
 
     private const val MARKER_WSS_HOST = 0
     private const val MARKER_FULL_URL = 255
@@ -70,8 +69,13 @@ object ConcordInviteLink {
 
     /**
      * Encodes the fragment for [token] and optional [relays]. Passing null or the
-     * exact stock set uses flag `0x01` and emits no relay bytes; otherwise up to
-     * [MAX_RELAYS] relays are encoded (dictionary id, `wss://` host, or full URL).
+     * exact stock set uses flag `0x01` and emits no relay bytes; otherwise every
+     * relay is encoded (dictionary id, `wss://` host, or full URL).
+     *
+     * The only ceiling is the format's own: the relay count is a single byte, so at
+     * most 255 relays fit. Each carries its own byte cost, so a long list makes a long
+     * link — pick relays that can actually serve the bundle rather than pasting a
+     * whole relay list in.
      */
     @OptIn(ExperimentalEncodingApi::class)
     fun encodeFragment(
@@ -86,7 +90,7 @@ object ConcordInviteLink {
         if (useStock) {
             out.add(FLAG_STOCK_RELAYS.toByte())
         } else {
-            require(relays.size <= MAX_RELAYS) { "at most $MAX_RELAYS relays, was ${relays.size}" }
+            require(relays.size <= 255) { "relay count must fit in one byte, was ${relays.size}" }
             out.add(0)
             out.add(relays.size.toByte())
             for (r in relays) {
@@ -157,7 +161,10 @@ object ConcordInviteLink {
         return InviteFragment(bytes.copyOfRange(pos, pos + TOKEN_LEN), relays, usedStock)
     }
 
-    /** Builds a full shareable invite URL under [base]. */
+    /**
+     * Builds a full shareable invite URL under [base], carrying every relay in [relays]
+     * as the bootstrap set (or the stock flag when null / exactly the stock set).
+     */
     fun buildUrl(
         base: String,
         linkSignerPubKey: String,

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteClassifyTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteClassifyTest.kt
@@ -97,6 +97,28 @@ class ConcordInviteClassifyTest {
         }
 
     @Test
+    fun remintAtTheSameCoordinateWinsOverAStaleCopy() =
+        runTest {
+            // The Refounding path (CORD-05 §1): every live link is re-minted at its own coordinate
+            // carrying the new epoch's root. A relay that still serves the pre-Refounding bundle
+            // must not be able to hand a joiner the epoch the community just left.
+            val community = ConcordCommunityFactory.create(owner, "Nostrichs", createdAt = 1L, relays = listOf("wss://relay.example"))
+            val before = inviteFor(community).copy(communityRoot = "aa".repeat(32), rootEpoch = 1L)
+            val minted = ConcordInviteBundle.mintLink("https://vector.chat", before, createdAt = 1000L)
+
+            val after = before.copy(communityRoot = "bb".repeat(32), rootEpoch = 2L)
+            val remint = ConcordInviteBundle.build(minted.linkSignerPrivKey, minted.token, after, createdAt = 2000L)
+
+            // Both fetch orders must resolve to the re-mint — `fetchAll` gives no ordering guarantee.
+            listOf(listOf(minted.bundleEvent, remint), listOf(remint, minted.bundleEvent)).forEach { wraps ->
+                val status = ConcordInviteBundle.classify(wraps, minted.token)
+                assertTrue(status is InviteBundleStatus.Live)
+                assertEquals("bb".repeat(32), status.invite.communityRoot)
+                assertEquals(2L, status.invite.rootEpoch)
+            }
+        }
+
+    @Test
     fun unknownSubKindIsUnreadable() =
         runTest {
             // A mis-posted registry (vsk=8) at the bundle coordinate — the exact shape of the

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteLinkTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord05Invites/ConcordInviteLinkTest.kt
@@ -67,6 +67,46 @@ class ConcordInviteLinkTest {
     }
 
     @Test
+    fun buildUrlCarriesEveryRelayOfAnOversizedList() {
+        // A community with five relays used to crash the mint ("at most 3 relays, was 5").
+        // There is no cap below the format's own, so all five make the round trip.
+        val relays =
+            listOf(
+                "wss://one.example",
+                "wss://two.example",
+                "wss://three.example",
+                "wss://four.example",
+                "wss://five.example",
+            )
+        val parsed = ConcordInviteLink.parseUrl(ConcordInviteLink.buildUrl("https://vector.chat", signer, token, relays))
+        assertNotNull(parsed)
+        assertEquals(relays, parsed.fragment.relays)
+        assertContentEquals(token, parsed.fragment.token)
+    }
+
+    @Test
+    fun buildUrlKeepsTheFourStockRelaysAsTheStockFlag() {
+        // The stock set still collapses to flag 0x01 and zero relay bytes rather than
+        // being spelled out as four dictionary ids.
+        val parsed = ConcordInviteLink.parseUrl(ConcordInviteLink.buildUrl("https://vector.chat", signer, token, InviteRelayDictionary.STOCK))
+        assertNotNull(parsed)
+        assertTrue(parsed.fragment.usedStockRelays)
+        assertEquals(InviteRelayDictionary.STOCK, parsed.fragment.relays)
+    }
+
+    @Test
+    fun encodesTheLargestRelayListTheCountByteCanHold() {
+        // 255 is the format ceiling, not a policy one: the relay count is a single byte.
+        val relays = List(255) { "wss://relay$it.example" }
+        val frag = ConcordInviteLink.decodeFragment(ConcordInviteLink.encodeFragment(token, relays))
+        assertEquals(relays, frag.relays)
+        assertContentEquals(token, frag.token)
+
+        // One more would silently wrap the count byte to 0 and strand every relay, so it throws.
+        assertFailsWith<IllegalArgumentException> { ConcordInviteLink.encodeFragment(token, relays + "wss://overflow.example") }
+    }
+
+    @Test
     @OptIn(ExperimentalEncodingApi::class)
     fun rejectsWrongVersion() {
         // craft a version-3 fragment: [3, 0x01, token...]


### PR DESCRIPTION
## Summary

Removes the artificial 3-relay limit from Concord invite links and replaces it with the format's actual ceiling: 255 relays (the size of a single byte used to encode relay count). Updates documentation to clarify that the only constraint is the format itself, not a policy decision. Fixes a bug where `classify()` was opening invite bundles in fetch order rather than newest-first, which could cause stale relay copies to hand joiners an outdated community root after a Refounding.

## Changes

**ConcordInviteLink.kt:**
- Removes `MAX_RELAYS = 3` constant
- Updates `encodeFragment()` to accept any number of relays up to 255 (the byte limit)
- Clarifies in docs that the only ceiling is the format's own (single-byte relay count)
- Updates error message to reflect the actual constraint

**ConcordInviteBundle.kt:**
- Fixes `classify()` to sort bundles by `createdAt` descending before opening, ensuring the newest bundle wins (matching the revocation branch's newest-wins semantics)
- Adds detailed comment explaining why this matters: a Refounding re-mints every live link at its own coordinate with the new epoch's root, so a stale relay serving the pre-Refounding bundle would otherwise hand the joiner an outdated root

**Tests:**
- `ConcordInviteLinkTest`: Adds three new tests:
  - `buildUrlCarriesEveryRelayOfAnOversizedList()` — verifies 5 relays round-trip (the original crash case)
  - `buildUrlKeepsTheFourStockRelaysAsTheStockFlag()` — confirms stock set still uses flag 0x01
  - `encodesTheLargestRelayListTheCountByteCanHold()` — tests the 255-relay ceiling and verifies 256 throws
- `ConcordInviteClassifyTest`: Adds `remintAtTheSameCoordinateWinsOverAStaleCopy()` — verifies that re-minted bundles are opened in newest-first order regardless of fetch order

## Test plan

- [x] Ran `./gradlew test` — all new tests pass, existing tests pass
- [x] Manually verified the three new relay-count tests exercise the round-trip paths
- [x] Verified the Refounding test confirms newest-wins semantics in both fetch orders

## Interop suites

- [x] N/A — change affects invite link encoding (wire bytes) but is backward-compatible; existing clients will still parse stock-relay flag and smaller lists correctly

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01WcaCNiqN8T9izve4AXcake