### PR TITLE
Fix MediaSession artwork scaling crash on some OEM ROMs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
@@ -25,10 +25,12 @@ package com.vitorpamplona.amethyst.service.playback.playerPool
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.res.Resources
 import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.util.BitmapLoader
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSourceBitmapLoader
@@ -38,6 +40,7 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.vitorpamplona.amethyst.service.playback.composable.mediaitem.MediaItemCache
 import com.vitorpamplona.amethyst.ui.MainActivity
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -76,8 +79,7 @@ class MediaSessionPool(
 ) {
     private val exceptionHandler =
         CoroutineExceptionHandler { _, throwable ->
-            com.vitorpamplona.quartz.utils.Log
-                .e("MediaSessionPool", "Caught exception: ${throwable.message}", throwable)
+            Log.e("MediaSessionPool", "Caught exception: ${throwable.message}", throwable)
         }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
@@ -96,23 +98,41 @@ class MediaSessionPool(
     private val sharedBitmapLoader by lazy { buildSharedBitmapLoader() }
 
     @OptIn(UnstableApi::class)
-    private fun buildSharedBitmapLoader(): DataSourceBitmapLoader =
-        DataSourceBitmapLoader
-            .Builder(appContext)
-            .setExecutorService(DataSourceBitmapLoader.DEFAULT_EXECUTOR_SERVICE.get())
-            .setDataSourceFactory(dataSourceFactory)
-            // Cap decoded artwork to the platform's own metadata bitmap limit so the legacy
-            // MediaSession path never has to re-scale it. media3 would otherwise size-limit the
-            // bitmap using Resources.getSystem()'s config_mediaMetadataBitmapMaxSize, which on
-            // several OEM ROMs (e.g. LineageOS/peridot) is unresolvable and falls back to the full
-            // screen width. That over-sized bitmap then gets re-scaled by the framework inside
-            // android.media.session.MediaSession.setMetadata(), and some of those ROMs recycle the
-            // *source* bitmap during MediaMetadata.Builder.scaleBitmap(). media3's CacheBitmapLoader
-            // caches that now-recycled bitmap and hands it back on the next metadata update, which
-            // crashes with "cannot use a recycled source in createBitmap". Pre-sizing to the same
-            // limit the framework uses keeps build() from ever calling scaleBitmap().
-            .setMaximumOutputDimension(mediaMetadataBitmapMaxSize())
-            .build()
+    private fun buildSharedBitmapLoader(): BitmapLoader {
+        val decoder =
+            DataSourceBitmapLoader
+                .Builder(appContext)
+                .setExecutorService(DataSourceBitmapLoader.DEFAULT_EXECUTOR_SERVICE.get())
+                .setDataSourceFactory(dataSourceFactory)
+                // Subsampling only halves, so decoding straight to the ceiling can land at half the
+                // size the session would have accepted (a 1080px image under a 900px ceiling decodes
+                // to 540px). Decoding to just under 2x and letting MetadataArtworkBitmapLoader scale
+                // precisely is the same recipe media3 uses for its own default loader.
+                .setMaximumOutputDimension((mediaMetadataBitmapMaxSize() * 2 - 1).coerceAtLeast(1))
+                .build()
+
+        // Artwork comes from arbitrary nostr imeta URLs, so it routinely arrives far larger than the
+        // platform's metadata bitmap ceiling, and android.media.session.MediaSession.setMetadata()
+        // then re-scales it inside MediaMetadata.Builder.build(). media3 stores the *same* Bitmap
+        // instance under both METADATA_KEY_DISPLAY_ICON and METADATA_KEY_ALBUM_ART
+        // (LegacyConversions.convertToMediaMetadataCompat), so build() scales that one instance
+        // twice. AOSP leaves the source alone, but on ROMs that recycle it while scaling the second
+        // pass throws "cannot use a recycled source in createBitmap" on the main thread, inside a
+        // Guava callback the app cannot intercept.
+        //
+        // media3 does size-limit artwork (SizeLimitedBitmapLoader), but it reads the ceiling from
+        // Resources.getSystem() and falls back to the full display width when
+        // config_mediaMetadataBitmapMaxSize can't be resolved by name, while the framework itself
+        // reads it from the context that created the session. Capping it here, the same way the
+        // framework measures it, keeps build() from scaling at all.
+        return MetadataArtworkBitmapLoader(decoder, ::mediaMetadataBitmapMaxSize)
+    }
+
+    // getIdentifier() is a by-name lookup, so it is resolved once; the dimension itself is re-read
+    // per load because it is a dp value and the app survives display-size changes without a restart.
+    private val metadataBitmapMaxSizeResId by lazy {
+        appContext.resources.getIdentifier("config_mediaMetadataBitmapMaxSize", "dimen", "android")
+    }
 
     /**
      * Mirrors how android.media.session.MediaSession derives its metadata bitmap ceiling: the
@@ -122,8 +142,17 @@ class MediaSessionPool(
      */
     private fun mediaMetadataBitmapMaxSize(): Int {
         val resources = appContext.resources
-        val id = resources.getIdentifier("config_mediaMetadataBitmapMaxSize", "dimen", "android")
-        val resolved = if (id != 0) resources.getDimensionPixelSize(id) else 0
+        val resolved =
+            if (metadataBitmapMaxSizeResId != 0) {
+                try {
+                    resources.getDimensionPixelSize(metadataBitmapMaxSizeResId)
+                } catch (e: Resources.NotFoundException) {
+                    Log.w("MediaSessionPool", "config_mediaMetadataBitmapMaxSize could not be read", e)
+                    0
+                }
+            } else {
+                0
+            }
         return if (resolved > 0) resolved else (DEFAULT_METADATA_BITMAP_DP * resources.displayMetrics.density).toInt()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
@@ -215,7 +215,14 @@ class MediaSessionPool(
         try {
             val mediaSession =
                 MediaSession
-                    .Builder(context, player)
+                    // appContext, not the caller's: the platform MediaSession reads its metadata
+                    // bitmap ceiling off the resources of whatever context builds it, and
+                    // mediaMetadataBitmapMaxSize() below caps artwork using the app context's. A
+                    // context on a different configuration (a resized window, a secondary display)
+                    // would set a smaller ceiling than the cap, putting the framework back into
+                    // scaling artwork it was handed. It also keeps a pooled, long-lived session
+                    // from holding on to an Activity.
+                    .Builder(appContext, player)
                     .apply {
                         setBitmapLoader(sharedBitmapLoader)
                         setId(id)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkBitmapLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkBitmapLoader.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+@file:OptIn(UnstableApi::class)
+
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.core.graphics.scale
+import androidx.media3.common.util.BitmapLoader
+import androidx.media3.common.util.UnstableApi
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+
+/**
+ * Scales loaded artwork down to [maxDimensionPx] so the platform never has to scale it itself.
+ *
+ * android.media.session.MediaSession.setMetadata() re-builds the metadata through
+ * MediaMetadata.Builder.build(), which scales every bitmap-valued key larger than the platform's
+ * own config_mediaMetadataBitmapMaxSize. media3 stores the *same* Bitmap instance under both
+ * METADATA_KEY_DISPLAY_ICON and METADATA_KEY_ALBUM_ART (LegacyConversions), so that one instance is
+ * scaled twice inside a single build() call. AOSP leaves the source untouched, but on ROMs that
+ * recycle it while scaling the second pass throws
+ *
+ *     IllegalArgumentException: cannot use a recycled source in createBitmap
+ *
+ * on the main thread, inside a Guava callback the app cannot intercept. Handing the session artwork
+ * that already fits removes the scaling step, and with it the crash.
+ *
+ * [maxDimensionPx] is a lambda rather than a constant because the limit is a dp value: it changes
+ * with the display density, and the app survives density changes without restarting.
+ *
+ * loadBitmapFromMetadata is deliberately not overridden — [BitmapLoader]'s default implementation
+ * routes back through [decodeBitmap]/[loadBitmap] here, while delegating it would call the same two
+ * methods on the delegate and skip the cap.
+ */
+class MetadataArtworkBitmapLoader(
+    private val delegate: BitmapLoader,
+    private val maxDimensionPx: () -> Int,
+) : BitmapLoader {
+    override fun supportsMimeType(mimeType: String): Boolean = delegate.supportsMimeType(mimeType)
+
+    override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> = capped(delegate.decodeBitmap(data))
+
+    override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> = capped(delegate.loadBitmap(uri))
+
+    /**
+     * Runs on whichever thread completed the load (directExecutor), never on the main thread. A
+     * throw here fails the future, which media3 logs as a failed artwork load instead of crashing.
+     */
+    private fun capped(future: ListenableFuture<Bitmap>): ListenableFuture<Bitmap> =
+        Futures.transform(
+            future,
+            { bitmap -> bitmap.capTo(maxDimensionPx()) },
+            MoreExecutors.directExecutor(),
+        )
+}
+
+private fun Bitmap.capTo(maxDimension: Int): Bitmap {
+    val target = fitArtworkWithin(width, height, maxDimension) ?: return this
+    return scale(target.width, target.height)
+}
+
+/** The size a [width] x [height] bitmap is scaled to, or null when it already fits. */
+data class ArtworkSize(
+    val width: Int,
+    val height: Int,
+)
+
+/**
+ * Mirrors android.media.MediaMetadata.Builder.scaleBitmap(): one scale factor for both axes,
+ * truncated to whole pixels, so the result is exactly what the platform would have produced and
+ * never one pixel over the limit. Returns null when nothing needs to change — a bitmap that already
+ * fits, or a limit that couldn't be resolved.
+ */
+fun fitArtworkWithin(
+    width: Int,
+    height: Int,
+    maxDimension: Int,
+): ArtworkSize? {
+    if (maxDimension <= 0) return null
+    if (width <= maxDimension && height <= maxDimension) return null
+
+    val scale = minOf(maxDimension.toFloat() / width, maxDimension.toFloat() / height)
+    return ArtworkSize(
+        width = (width * scale).toInt().coerceIn(1, maxDimension),
+        height = (height * scale).toInt().coerceIn(1, maxDimension),
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkBitmapLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkBitmapLoader.kt
@@ -50,6 +50,10 @@ import com.google.common.util.concurrent.MoreExecutors
  * [maxDimensionPx] is a lambda rather than a constant because the limit is a dp value: it changes
  * with the display density, and the app survives density changes without restarting.
  *
+ * [delegate] must decode a fresh bitmap per request and keep no reference to it — caps free the
+ * pre-scale original. media3's own caching wrapper sits above this loader, not below it, so the
+ * bitmap handed out here is the only one that outlives the call.
+ *
  * loadBitmapFromMetadata is deliberately not overridden — [BitmapLoader]'s default implementation
  * routes back through [decodeBitmap]/[loadBitmap] here, while delegating it would call the same two
  * methods on the delegate and skip the cap.
@@ -78,7 +82,14 @@ class MetadataArtworkBitmapLoader(
 
 private fun Bitmap.capTo(maxDimension: Int): Bitmap {
     val target = fitArtworkWithin(width, height, maxDimension) ?: return this
-    return scale(target.width, target.height)
+    val scaled = scale(target.width, target.height)
+    // The pre-scale bitmap is ours alone (see the delegate contract above) and, because the decoder
+    // is allowed to overshoot the cap to keep the subsampling close to it, holds up to 4x the pixels
+    // of the copy. Freeing it here rather than waiting for the collector keeps that overshoot from
+    // stacking up on the decoder thread. Bitmap.scale hands back the source when nothing changed, so
+    // only a real copy makes the original garbage.
+    if (scaled !== this) recycle()
+    return scaled
 }
 
 /** The size a [width] x [height] bitmap is scaled to, or null when it already fits. */

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkFitTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/MetadataArtworkFitTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The platform scales session artwork inside MediaMetadata.Builder.build() whenever a bitmap is
+ * larger than config_mediaMetadataBitmapMaxSize, and media3 hands it the same Bitmap instance under
+ * two keys — so that one instance is scaled twice, which crashes on ROMs that recycle the source.
+ * These cases pin the sizes that keep build() from scaling at all.
+ */
+class MetadataArtworkFitTest {
+    @Test
+    fun bitmapsWithinTheLimitAreLeftAlone() {
+        assertNull(fitArtworkWithin(320, 240, 960))
+        // Exactly at the limit: the framework compares with >, so this must not be scaled either.
+        assertNull(fitArtworkWithin(960, 960, 960))
+        assertNull(fitArtworkWithin(960, 480, 960))
+    }
+
+    @Test
+    fun anUnresolvedLimitScalesNothing() {
+        assertNull(fitArtworkWithin(4000, 3000, 0))
+        assertNull(fitArtworkWithin(4000, 3000, -1))
+    }
+
+    @Test
+    fun squareArtworkIsCappedAtTheLimit() {
+        assertEquals(ArtworkSize(960, 960), fitArtworkWithin(4000, 4000, 960))
+    }
+
+    @Test
+    fun aspectRatioIsPreservedAndNeitherAxisExceedsTheLimit() {
+        val landscape = fitArtworkWithin(4000, 2000, 960)!!
+        assertEquals(ArtworkSize(960, 480), landscape)
+
+        val portrait = fitArtworkWithin(2000, 4000, 960)!!
+        assertEquals(ArtworkSize(480, 960), portrait)
+    }
+
+    @Test
+    fun onlyOneOversizedAxisStillScalesBothDown() {
+        // 1000x100 under a 960 cap: the framework scales by the smaller ratio, so the height goes
+        // down with the width.
+        assertEquals(ArtworkSize(960, 96), fitArtworkWithin(1000, 100, 960))
+    }
+
+    @Test
+    fun extremeAspectRatiosNeverCollapseToZeroPixels() {
+        // 10000x3 would truncate the height to 0 and Bitmap.createScaledBitmap would throw.
+        val strip = fitArtworkWithin(10000, 3, 960)!!
+        assertEquals(960, strip.width)
+        assertEquals(1, strip.height)
+    }
+
+    @Test
+    fun roundingNeverLandsOnePixelOverTheLimit() {
+        // Float scale factors truncate, so the long edge lands on the limit or just under it —
+        // never over, which is what would send the platform back into scaleBitmap().
+        for (width in 961..4000) {
+            val fitted = fitArtworkWithin(width, width - 1, 960)!!
+            assert(fitted.width in 1..960) { "width ${fitted.width} out of range for $width" }
+            assert(fitted.height in 1..960) { "height ${fitted.height} out of range for $width" }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a crash on some OEM ROMs (e.g., LineageOS) when updating media session metadata with large artwork. The platform's `MediaSession.setMetadata()` re-scales artwork inside `MediaMetadata.Builder.build()`, and media3 hands it the same `Bitmap` instance under two keys, causing that instance to be scaled twice. Some ROMs recycle the source bitmap during the first scale, crashing on the second with `IllegalArgumentException: cannot use a recycled source in createBitmap`.

The fix pre-scales artwork to the platform's metadata bitmap ceiling using a new `MetadataArtworkBitmapLoader` wrapper, preventing the framework from ever needing to scale it. Also corrects the bitmap loader context to use `appContext` instead of the caller's context, ensuring the ceiling is read from the same resources the session uses.

## Changes

- **New `MetadataArtworkBitmapLoader`**: Wraps the media3 bitmap decoder and caps artwork to `config_mediaMetadataBitmapMaxSize` before returning it. Includes detailed comments explaining the crash and the fix.
- **New `fitArtworkWithin()` function**: Mirrors the platform's `MediaMetadata.Builder.scaleBitmap()` logic to compute exact target dimensions, ensuring the result never exceeds the limit.
- **Updated `MediaSessionPool`**: 
  - Wraps `DataSourceBitmapLoader` with `MetadataArtworkBitmapLoader`
  - Increases decoder ceiling to `2x - 1` (subsampling only halves, so decoding to just under 2x lets the wrapper scale precisely)
  - Caches the resource ID lookup and adds error handling for `getDimensionPixelSize()`
  - Uses `appContext` when building `MediaSession` so the platform reads its ceiling from the same resources we cap to
- **Code cleanup**: Simplifies a long qualified name (`com.vitorpamplona.quartz.utils.Log` → `Log`)

## Test plan

- [x] Added comprehensive unit tests in `MetadataArtworkFitTest` covering:
  - Bitmaps within the limit (left unchanged)
  - Unresolved limits (no scaling)
  - Square and rectangular artwork (aspect ratio preserved)
  - Extreme aspect ratios (never collapse to zero pixels)
  - Rounding precision (never exceeds limit)
- [x] Ran `./gradlew test` — all tests pass
- [x] Manually verified the scaling logic matches the platform's `MediaMetadata.Builder.scaleBitmap()` behavior

## Interop suites

- [x] N/A — change is Android-only, affects media session metadata display, not wire bytes or audio codec paths

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01M2qse1pZsCAsQ5XASgeqSK