### PR TITLE
ci(crowdin): convert Android escaping to Compose escaping during the sync

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -50,6 +50,35 @@ jobs:
       - name: Fix ownership after Crowdin Docker action
         run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
 
+      # Both files in crowdin.yml are declared `type: android`, so Crowdin's Android
+      # serializer escapes apostrophes on the way down: `l'URL` comes back as `l\'URL`.
+      # That is correct for amethyst/src/main/res/, which aapt un-escapes at build time,
+      # and WRONG for commons/.../composeResources/, where Compose resolves only \uXXXX,
+      # \n and \t and leaves \' \" \? \@ alone -- so the backslash reaches the screen.
+      #
+      # Without this step every sync reopens the same regression and CI's
+      # compose_escaping_check.py fails on the bot's own PR. It happened three times
+      # (f9baab0e, 1685d7c0, e223d505 -- 2,888 occurrences across 40 locales the last
+      # time) before this step existed. Convert on the way in, so the PR is born clean.
+      #
+      # Only the Compose catalog is passed in; the Android res tree keeps its escaping.
+      # --no-unwrap-quotes is mandatory here: escape conversion is idempotent but
+      # quote-unwrapping is not, and a second unwrap would strip the real display quotes
+      # from values like import_follows_tips.
+      - name: Convert Android escaping to Compose escaping in the shared catalog
+        run: |
+          python3 tools/strings-migrate/fix_escapes.py --no-unwrap-quotes \
+              commons/src/commonMain/composeResources
+
+      # Assert the conversion actually satisfied the check that guards main, so a case
+      # the converter cannot repair fails the sync loudly here instead of opening a red
+      # PR. Known gap if this ever trips: fix_escapes.py only rewrites text inside
+      # <string>/<item> elements, while the check scans the whole file -- an escape in an
+      # XML comment (comments do propagate into the locale files) has to be fixed at the
+      # source string in commons/.../composeResources/values/strings.xml by hand.
+      - name: Verify the shared catalog is free of Android-only escaping
+        run: .claude/hooks/compose_escaping_check.py
+
       # Keep docs/changelog/translators.json seeded with everyone who has translated
       # recently, so the per-release `## Translations` credits (scripts/translators.sh)
       # can resolve them to npubs. Only adds rows when a genuinely new contributor


### PR DESCRIPTION
## Summary

Stops the Compose-escaping regression at its source instead of repairing it after the fact. Both entries in `crowdin.yml` are declared `type: android`, so Crowdin's Android serializer escapes apostrophes on the way down: `l'URL` comes back as `l\'URL`. That is right for `amethyst/src/main/res/`, which aapt un-escapes at build time, and wrong for `commons/.../composeResources/`, where Compose resolves only `\uXXXX`, `\n` and `\t` and leaves `\'` `\"` `\?` `\@` alone — so the backslash reaches the screen.

Nothing prevented this, so every sync reopened the same regression: three times so far (`f9baab0e`, `1685d7c0`, `e223d505`), most recently 2,888 occurrences across 40 locale files, each repaired by hand afterwards. This converts on the way in, so the PR is born clean.

## Details

Two steps, after the ownership fix (the Crowdin container writes as root, so the tree is not writable before it) and before the PR is opened:

- **Convert** — runs the documented repair over the Compose catalog only, so the Android res tree keeps the escaping it needs. `--no-unwrap-quotes` is mandatory: escape conversion is idempotent, quote-unwrapping is not, and a second unwrap would strip the real display quotes from values like `import_follows_tips`.
- **Verify** — re-runs `compose_escaping_check.py`, the same check that guards `main`, so a case the converter cannot repair fails the sync loudly here instead of opening a red PR.

### Why the gate has to live in this workflow

Worth flagging, because it explains why the check alone never stopped this: **the Crowdin PRs never run CI.** PR #4055 has zero check runs, and so does #4047, the sync that introduced the previous round. `build.yml` does run `on: pull_request`, but PRs opened with the default `GITHUB_TOKEN` do not trigger workflows — GitHub's recursion guard. The escaping check therefore only fires *after* merge, on `push: main`, by which point `main` is already broken and the failure surfaces on the next contributor's PR. A gate inside the Crowdin workflow is the only layer that actually executes for this content.

## Test plan

Replayed both steps against the **real** Crowdin output on `l10n_crowdin_translations` (`df930817`) in a scratch worktree, rather than a synthetic case:

- [x] Reproduced the failure first — `compose_escaping_check.py` reports 2,888 occurrences across 40 files on the bot's tree
- [x] Convert step fixes 1,996 entries across 40 files
- [x] Verify step then exits 0
- [x] `amethyst/src/main/res/` left untouched (`git status` clean for that path)
- [x] Resulting catalog is **byte-identical to `main`** — so with this in place that sync would have carried no string changes at all
- [x] Idempotent: re-running the converter on a clean tree reports `fixed 0 entries across 0 files`, no files modified
- [x] Round-trip safe for `upload_translations`: the source file already ships 105 bare apostrophes through `upload_sources` and Crowdin has accepted it for months, so uploading converted translations does not drift the stored strings
- [x] Converter handles `<plurals>` and `<string-array>` `<item>` bodies, not just `<string>` (tested directly; both exist in the catalog)
- [x] Workflow YAML parses; step order is checkout → crowdin → chown → convert → verify → seed → PR; the `run:` block's line continuation parses under `bash -n`
- [ ] `./gradlew spotlessApply` — N/A, no Kotlin changed

## Known gaps

Found while auditing; all latent, none live today, and none regress current behaviour:

1. **Escapes in XML comments.** `fix_escapes.py` only rewrites text inside `<string>`/`<item>` elements, while the check scans the whole file — so an escape in a comment would fail the gate with no automatic repair. Comments *do* propagate into locale files; none currently carry a backslash. Documented inline on the verify step, with the fix (correct it at the source string by hand).
2. **Converter walks every `*.xml` under the catalog, but `add-paths` only commits `strings.xml`.** No other XML files exist there today, and `crowdin.yml`'s translation pattern only ever writes `strings.xml`.
3. **The check scans all modules; the converter only fixes `commons`.** These coincide today — `commons` has the only `composeResources` catalog. If another module gains one, this workflow could fail on a catalog it does not manage.

## Interop suites

- [x] N/A — CI workflow only; cannot affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

---

**Note on #4055:** it should not be merged as-is — it is the exact inverse of `e223d505` (2002/2002 across the same 40 files) and would reinstate all 2,888 escapes, with no CI on it to catch that. Suggested order: merge this first, then close #4055 and let the next sync regenerate a clean PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVrW3p8NGWHgLbN673Fet2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVrW3p8NGWHgLbN673Fet2)_