### PR TITLE
fix(ui): tint the un-boosted repost icon like the rest of the action row

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -1002,7 +1002,7 @@ fun BoostReaction(
             if (hasBoosted) {
                 RepostedIcon(iconSizeModifier)
             } else {
-                RepostIcon(iconSizeModifier)
+                RepostIcon(iconSizeModifier, grayTint)
             }
         }
 


### PR DESCRIPTION
## What

One line in `ReactionsRow.BoostReaction`:

```kotlin
- RepostIcon(iconSizeModifier)
+ RepostIcon(iconSizeModifier, grayTint)
```

## Why

`RepostIcon` defaults to `tint = Color.Unspecified` (`ui/note/Icons.kt`), so the
idle boost button drew its glyph in whatever the ambient content colour happened
to be, while every other un-actioned icon in the row — reply, like, zap — is
drawn in the `grayTint` the row is already handed as a parameter. The boost icon
was the odd one out.

Passing it explicitly puts the un-boosted state back in line. The boosted state
is untouched: that branch renders `RepostedIcon`, which keeps its own
`RepostedColor` default.

Follow-up to a31364b999, which fixed the liked and reposted colours.

## Verification

- `:amethyst:compilePlayDebugKotlin` green on this base (`main` @ 1b4acc15b5).
- Pre-commit static analysis and pre-push tests passed.

No behaviour change beyond the tint, and no API change — the two-argument
overload already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwk8tDEaEvsNoGbtrjZavz