### PR TITLE
Add DeletionEvent and RequestToVanishEvent to CacheSearch filter

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/CacheSearch.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/CacheSearch.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
+import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
@@ -49,6 +50,7 @@ import com.vitorpamplona.quartz.nip50Search.EventSearchMatcher
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
+import com.vitorpamplona.quartz.nip62RequestToVanish.RequestToVanishEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.ClientTag
@@ -134,7 +136,9 @@ class CacheSearch(
                 note.event is FileHeaderEvent ||
                 note.event is MetadataEvent ||
                 note.event is ContactListEvent ||
-                note.event is AppSpecificDataEvent
+                note.event is AppSpecificDataEvent ||
+                note.event is DeletionEvent ||
+                note.event is RequestToVanishEvent
         )
 
     /**


### PR DESCRIPTION
## Summary

Extends the `CacheSearch.isNoteable()` filter to include `DeletionEvent` (NIP-09) and `RequestToVanishEvent` (NIP-62) as non-notable events. These event types should be filtered out from the main feed display, similar to how metadata, contact lists, and app-specific data are already excluded.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a straightforward filter extension. The change adds two event types to an existing exclusion list in `CacheSearch.isNoteable()`. Existing unit tests for cache search filtering should continue to pass.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This is a client-side filtering change that affects only how events are displayed in the UI cache, not protocol wire format or interoperability.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01LeT6g4wLvn2sJofnntvsZ1