### PR TITLE
Fix relay list updates to preserve public/private visibility

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip37Drafts/privateOutbox/PrivateOutboxRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip37Drafts/privateOutbox/PrivateOutboxRelayListEvent.kt
@@ -35,7 +35,9 @@ import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip51Lists.encryption.signNip51List
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.privateRelays
+import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +71,14 @@ class PrivateOutboxRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): PrivateOutboxRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.searchRelays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class SearchRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): SearchRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/RelayListSplit.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/RelayListSplit.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip51Lists
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+/** The new relay set of a NIP-51 list, split by where each relay must be written. */
+class RelayListSplit(
+    val publicRelays: List<NormalizedRelayUrl>,
+    val privateRelays: List<NormalizedRelayUrl>,
+)
+
+/**
+ * Splits the new relay set of a NIP-51 relay list into the relays that go into plain tags and
+ * the relays that go into the NIP-44 encrypted content, keeping each one where the earlier
+ * version already had it. Relays the earlier version didn't have follow its convention: public
+ * when it only had public relays, private otherwise.
+ *
+ * Rewriting every entry as a private tag instead empties the list out for clients that only
+ * read the plain tags, which is how removing a single relay used to wipe a list created
+ * elsewhere. See https://github.com/vitorpamplona/amethyst/issues/4075
+ */
+fun splitRelayListUpdate(
+    publicRelaysBefore: List<NormalizedRelayUrl>,
+    privateRelaysBefore: List<NormalizedRelayUrl>,
+    relays: List<NormalizedRelayUrl>,
+): RelayListSplit {
+    val wasPublic = publicRelaysBefore.toSet()
+    val wasPrivate = privateRelaysBefore.toSet()
+    val newOnesArePublic = wasPublic.isNotEmpty() && wasPrivate.isEmpty()
+
+    val publicRelays = ArrayList<NormalizedRelayUrl>(relays.size)
+    val privateRelays = ArrayList<NormalizedRelayUrl>(relays.size)
+
+    relays.forEach { relay ->
+        val isPublic =
+            when {
+                relay in wasPublic -> true
+                relay in wasPrivate -> false
+                else -> newOnesArePublic
+            }
+
+        if (isPublic) publicRelays.add(relay) else privateRelays.add(relay)
+    }
+
+    return RelayListSplit(publicRelays, privateRelays)
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/BlockedRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/BlockedRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.blockedRelays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class BlockedRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): BlockedRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/BroadcastRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/BroadcastRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.broadcastRelays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,10 +70,14 @@ class BroadcastRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): BroadcastRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/IndexerRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/IndexerRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.indexerRelays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class IndexerRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): IndexerRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/ProxyRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/ProxyRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.proxyRelays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class ProxyRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): ProxyRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayFeedsListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayFeedsListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relayFeeds
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class RelayFeedsListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): RelayFeedsListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/TrustedRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/TrustedRelayListEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.trustedRelays
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -69,11 +70,14 @@ class TrustedRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): TrustedRelayListEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.tags.relays(), privateTags.relays(), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relaySets/RelaySetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relaySets/RelaySetEvent.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip51Lists.encryption.signNip51List
 import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relaySet
 import com.vitorpamplona.quartz.nip51Lists.remove
+import com.vitorpamplona.quartz.nip51Lists.splitRelayListUpdate
 import com.vitorpamplona.quartz.nip51Lists.tags.DescriptionTag
 import com.vitorpamplona.quartz.nip51Lists.tags.ImageTag
 import com.vitorpamplona.quartz.nip51Lists.tags.RelayTag
@@ -79,11 +80,14 @@ class RelaySetEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): RelaySetEvent {
-            val newRelayList = relays.map { RelayTag.assemble(it) }
             val privateTags = earlierVersion.privateTags(signer) ?: throw SignerExceptions.UnauthorizedDecryptionException()
 
-            val publicTags = earlierVersion.tags.remove(RelayTag::match)
-            val newPrivateTags = privateTags.remove(RelayTag::match).plus(newRelayList)
+            // Keeps public relays public and private relays private: rewriting them all as
+            // private tags blanks the list out for clients that only read the plain tags.
+            val split = splitRelayListUpdate(earlierVersion.relays(), privateTags.mapNotNull(RelayTag.Companion::parse), relays)
+
+            val publicTags = earlierVersion.tags.remove(RelayTag::match).plus(split.publicRelays.map { RelayTag.assemble(it) })
+            val newPrivateTags = privateTags.remove(RelayTag::match).plus(split.privateRelays.map { RelayTag.assemble(it) })
 
             return signer.signNip51List(createdAt, KIND, publicTags, newPrivateTags)
         }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayFeedsListEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayFeedsListEventTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip51Lists.relayLists
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.utils.nsecToKeyPair
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RelayFeedsListEventTest {
+    private val signer = NostrSignerInternal("nsec10g0wheggqn9dawlc0yuv6adnat6n09anr7eyykevw2dm8xa5fffs0wsdsr".nsecToKeyPair())
+
+    private val damus = RelayUrlNormalizer.normalize("wss://relay.damus.io")
+    private val nosLol = RelayUrlNormalizer.normalize("wss://nos.lol")
+    private val primal = RelayUrlNormalizer.normalize("wss://relay.primal.net")
+
+    @Test
+    fun kindMatchesSpec() {
+        assertEquals(10012, RelayFeedsListEvent.KIND)
+    }
+
+    /**
+     * Reproduces https://github.com/vitorpamplona/amethyst/issues/4075: a 10012 written by
+     * another client (public `relay` tags) must not be emptied out when Amethyst removes one
+     * entry from it.
+     */
+    @Test
+    fun removingOneRelayKeepsTheOtherPublicEntriesPublic() =
+        runTest {
+            val fromAnotherClient =
+                signer.sign<RelayFeedsListEvent>(
+                    RelayFeedsListEvent.build(
+                        publicRelays = listOf(damus, nosLol),
+                        signer = signer,
+                        createdAt = 1740669816,
+                    ),
+                )
+
+            assertEquals(listOf(damus, nosLol), fromAnotherClient.publicRelays())
+
+            val afterRemoval =
+                RelayFeedsListEvent.updateRelayList(
+                    earlierVersion = fromAnotherClient,
+                    relays = listOf(damus),
+                    signer = signer,
+                    createdAt = 1740669817,
+                )
+
+            assertEquals(
+                listOf(damus),
+                afterRemoval.publicRelays(),
+                "the surviving relay must stay in the public tags so other clients still see it",
+            )
+            assertEquals(listOf(damus), afterRemoval.decryptRelays(signer))
+        }
+
+    @Test
+    fun privateRelaysStayPrivate() =
+        runTest {
+            val mixed =
+                signer.sign<RelayFeedsListEvent>(
+                    RelayFeedsListEvent.build(
+                        publicRelays = listOf(damus),
+                        privateRelays = listOf(nosLol, primal),
+                        signer = signer,
+                        createdAt = 1740669816,
+                    ),
+                )
+
+            val afterRemoval =
+                RelayFeedsListEvent.updateRelayList(
+                    earlierVersion = mixed,
+                    relays = listOf(damus, nosLol),
+                    signer = signer,
+                    createdAt = 1740669817,
+                )
+
+            assertEquals(listOf(damus), afterRemoval.publicRelays())
+            assertEquals(listOf(nosLol), afterRemoval.decryptPrivateRelays(signer))
+        }
+
+    @Test
+    fun newRelaysFollowTheConventionOfTheList() =
+        runTest {
+            val publicOnly =
+                signer.sign<RelayFeedsListEvent>(
+                    RelayFeedsListEvent.build(
+                        publicRelays = listOf(damus),
+                        signer = signer,
+                        createdAt = 1740669816,
+                    ),
+                )
+
+            val afterAdd =
+                RelayFeedsListEvent.updateRelayList(
+                    earlierVersion = publicOnly,
+                    relays = listOf(damus, nosLol),
+                    signer = signer,
+                    createdAt = 1740669817,
+                )
+
+            assertEquals(
+                listOf(damus, nosLol),
+                afterAdd.publicRelays(),
+                "a list another client keeps public should keep receiving public entries",
+            )
+
+            val privateOnly =
+                signer.sign<RelayFeedsListEvent>(
+                    RelayFeedsListEvent.build(
+                        privateRelays = listOf(damus),
+                        signer = signer,
+                        createdAt = 1740669816,
+                    ),
+                )
+
+            val afterPrivateAdd =
+                RelayFeedsListEvent.updateRelayList(
+                    earlierVersion = privateOnly,
+                    relays = listOf(damus, nosLol),
+                    signer = signer,
+                    createdAt = 1740669817,
+                )
+
+            assertTrue(afterPrivateAdd.publicRelays().isEmpty(), "a private list must stay private")
+            assertEquals(listOf(damus, nosLol), afterPrivateAdd.decryptPrivateRelays(signer))
+        }
+
+    @Test
+    fun keepsUnrelatedTags() =
+        runTest {
+            val withTitle =
+                signer.sign<RelayFeedsListEvent>(
+                    RelayFeedsListEvent.build(
+                        publicRelays = listOf(damus, nosLol),
+                        signer = signer,
+                        createdAt = 1740669816,
+                    ) {
+                        add(arrayOf("title", "My Feeds"))
+                    },
+                )
+
+            val afterRemoval =
+                RelayFeedsListEvent.updateRelayList(
+                    earlierVersion = withTitle,
+                    relays = listOf(nosLol),
+                    signer = signer,
+                    createdAt = 1740669817,
+                )
+
+            assertTrue(
+                afterRemoval.tags.any { it.size >= 2 && it[0] == "title" && it[1] == "My Feeds" },
+                "tags this client doesn't understand must survive the update",
+            )
+        }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayListPublicEntriesTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip51Lists/relayLists/RelayListPublicEntriesTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip51Lists.relayLists
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip37Drafts.privateOutbox.PrivateOutboxRelayListEvent
+import com.vitorpamplona.quartz.nip50Search.SearchRelayListEvent
+import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.RelayTag
+import com.vitorpamplona.quartz.nip51Lists.relayLists.tags.relays
+import com.vitorpamplona.quartz.nip51Lists.relaySets.RelaySetEvent
+import com.vitorpamplona.quartz.utils.nsecToKeyPair
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import com.vitorpamplona.quartz.nip51Lists.tags.RelayTag as RelaySetRelayTag
+
+/**
+ * Every NIP-51 relay list shares the same update path, so every one of them used to move the
+ * relays another client had left in plain tags into the encrypted content -- blanking the list
+ * out for that client. See https://github.com/vitorpamplona/amethyst/issues/4075
+ */
+class RelayListPublicEntriesTest {
+    private val signer = NostrSignerInternal("nsec10g0wheggqn9dawlc0yuv6adnat6n09anr7eyykevw2dm8xa5fffs0wsdsr".nsecToKeyPair())
+
+    private val damus = RelayUrlNormalizer.normalize("wss://relay.damus.io")
+    private val nosLol = RelayUrlNormalizer.normalize("wss://nos.lol")
+
+    private suspend inline fun <reified T : Event> publicListFromAnotherClient(
+        kind: Int,
+        tagName: String = RelayTag.TAG_NAME,
+    ): T =
+        signer.sign(
+            EventTemplate<T>(
+                createdAt = 1740669816,
+                kind = kind,
+                tags = arrayOf(arrayOf(tagName, damus.url), arrayOf(tagName, nosLol.url)),
+                content = "",
+            ),
+        )
+
+    @Test
+    fun relayFeedsListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<RelayFeedsListEvent>(RelayFeedsListEvent.KIND)
+            val after = RelayFeedsListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun blockedRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<BlockedRelayListEvent>(BlockedRelayListEvent.KIND)
+            val after = BlockedRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun trustedRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<TrustedRelayListEvent>(TrustedRelayListEvent.KIND)
+            val after = TrustedRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun broadcastRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<BroadcastRelayListEvent>(BroadcastRelayListEvent.KIND)
+            val after = BroadcastRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun indexerRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<IndexerRelayListEvent>(IndexerRelayListEvent.KIND)
+            val after = IndexerRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun proxyRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<ProxyRelayListEvent>(ProxyRelayListEvent.KIND)
+            val after = ProxyRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun searchRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<SearchRelayListEvent>(SearchRelayListEvent.KIND)
+            val after = SearchRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun privateOutboxRelayListKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<PrivateOutboxRelayListEvent>(PrivateOutboxRelayListEvent.KIND)
+            val after = PrivateOutboxRelayListEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.tags.relays())
+        }
+
+    @Test
+    fun relaySetKeepsTheSurvivorPublic() =
+        runTest {
+            val before = publicListFromAnotherClient<RelaySetEvent>(RelaySetEvent.KIND, RelaySetRelayTag.TAG_NAME)
+            val after = RelaySetEvent.updateRelayList(before, listOf(damus), signer, 1740669817)
+            assertEquals(listOf(damus), after.relays())
+        }
+}


### PR DESCRIPTION
## Summary

Fixes a regression where updating a NIP-51 relay list (e.g., removing a single relay) would move all relays into encrypted content, effectively blanking the list for other clients that only read plain tags. This affected all relay list types: RelayFeedsListEvent, BlockedRelayListEvent, TrustedRelayListEvent, BroadcastRelayListEvent, IndexerRelayListEvent, ProxyRelayListEvent, SearchRelayListEvent, PrivateOutboxRelayListEvent, and RelaySetEvent.

The fix introduces `splitRelayListUpdate()` which preserves the visibility convention of each relay: relays that were public stay public, relays that were private stay private, and new relays follow the list's existing convention (public if the list only had public relays, private otherwise).

Resolves https://github.com/vitorpamplona/amethyst/issues/4075

## Changes

- **New:** `RelayListSplit.kt` — data class and `splitRelayListUpdate()` function that intelligently splits relay updates into public and private sets based on their prior visibility
- **Updated:** All relay list event classes now use `splitRelayListUpdate()` in their `updateRelayList()` methods instead of moving all relays to encrypted content
- **Tests:** Added comprehensive test coverage:
  - `RelayFeedsListEventTest.kt` — tests for public/private preservation, new relay convention, and unrelated tag preservation
  - `RelayListPublicEntriesTest.kt` — parametric tests verifying all relay list types maintain public visibility

## Test plan

- [x] Ran `./gradlew test` — all new tests pass, existing relay list tests pass
- [x] Verified the fix with `RelayFeedsListEventTest.removingOneRelayKeepsTheOtherPublicEntriesPublic()` — confirms surviving relays remain in public tags
- [x] Verified `RelayListPublicEntriesTest` — all 9 relay list types preserve public visibility across update

## Interop suites

- [x] N/A — change affects only local relay list event construction, not wire bytes or protocol behavior

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01HKnV2t1sQDTRjYNptjpXAd