### PR TITLE
test(nwc): fix the flaky NwcInfoCache coalescing tests

### DIFF
--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcInfoCacheTest.kt
@@ -185,9 +185,16 @@ class NwcInfoCacheTest {
 
             val results =
                 coroutineScope {
-                    val first = async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) }
+                    // Unconfined, not IO: an unconfined coroutine runs its body inline until the
+                    // first real suspension, so by the time `async` returns, the caller has already
+                    // executed `inFlight.putIfAbsent` and parked on the winner's deferred. On IO it
+                    // had only been *scheduled*, and the gate below could open before it arrived --
+                    // the winner then removed the in-flight entry, the late caller found none, and
+                    // started a second fetch. That is the whole race, and it made this test fail
+                    // about one run in four under full-suite load while passing alone every time.
+                    val first = async(Dispatchers.Unconfined) { cache.getFresh(uri("wallet1")) }
                     fetcher.started.await()
-                    val rest = (1..4).map { async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) } }
+                    val rest = (1..4).map { async(Dispatchers.Unconfined) { cache.getFresh(uri("wallet1")) } }
                     fetcher.release.complete(Unit)
                     (listOf(first) + rest).awaitAll()
                 }
@@ -207,7 +214,10 @@ class NwcInfoCacheTest {
 
             val joined =
                 coroutineScope {
-                    val caller = async(Dispatchers.IO) { cache.getFresh(uri("wallet1")) }
+                    // Unconfined for the same reason as the concurrent-callers test above: the
+                    // joiner has to reach `inFlight.putIfAbsent` before the gate opens, and on IO
+                    // it is merely scheduled. Same latent race, not yet observed failing.
+                    val caller = async(Dispatchers.Unconfined) { cache.getFresh(uri("wallet1")) }
                     fetcher.release.complete(Unit)
                     caller.await()
                 }


### PR DESCRIPTION
`NwcInfoCacheTest.concurrentGetFreshCallersShareOneFetch` failed roughly one run in four under full-suite load with `expected:<1> but was:<2>`, and passed every time when run alone — so it read as a cache bug that isn't one.

## What was wrong

The followers joined on `Dispatchers.IO`, which only *schedules* them, and the test opened the gate immediately afterwards. That let the winning fetch finish first: its `finally { inFlight.remove(key, ours) }` cleared the slot, a follower arriving after that found nothing to join, and started a second fetch. On those runs the coalescing the test exists to prove was never exercised.

## The fix

`Dispatchers.Unconfined` runs a coroutine's body inline until its first real suspension, so `async` now returns only once the caller has executed `inFlight.putIfAbsent` and parked on the winner's deferred. The interleaving `GatedFetch`'s KDoc already promises — *"caller one is provably inside the fetch before the others arrive"* — is now ordered by construction rather than by timing.

`getFreshJoinsFetchAlreadyStartedByRefreshIfStale` carried the identical race and is fixed the same way; it had not been observed failing. The three other `Dispatchers.IO` callers in the file are deliberately left alone — there the caller *is* the fetch winner, so it has nothing to join late.

Test-only; no production code touched.

## Evidence

- the full fdroid unit suite (1464 tests), where the failure originally surfaced, green twice over
- the class green 6/6 in isolation

The isolated runs prove little by themselves — the unfixed test also passed 5/5 that way — so the loaded runs plus the structural argument are what carry this.

Found while testing the dependency-bump branch (`claude/quirky-pascal-5kj5sz`); kept separate from it deliberately, since the flake predates that branch and has nothing to do with the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)