### PR TITLE
fix(nav): give the back gesture the slides it lost to navigation-compose 2.10

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -23,9 +23,6 @@ package com.vitorpamplona.amethyst.ui.navigation
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -448,8 +445,12 @@ fun BuildNavigation(
     NavHost(
         navController = nav.controller,
         startDestination = Route.Home,
-        enterTransition = { fadeIn(animationSpec = tween(200)) },
-        exitTransition = { fadeOut(animationSpec = tween(200)) },
+        enterTransition = { navShellFadeIn },
+        exitTransition = { navShellFadeOut },
+        // Without these two, a back *gesture* runs navigation-compose's own defaults
+        // (fadeIn opposite scaleOut(0.7f)) instead of the slides declared per route.
+        predictivePopEnterTransition = { predictivePopEnter() },
+        predictivePopExitTransition = { predictivePopExit() },
     ) {
         composableCapped<Route.Home> { HomeScreen(accountViewModel, nav) }
         composable<Route.Message> { MessagesScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
@@ -21,6 +21,9 @@
 package com.vitorpamplona.amethyst.ui.navigation
 
 import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -32,10 +35,14 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.vitorpamplona.amethyst.ui.layouts.CappedScreenContent
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
 
 // Per-entry hint stamped by Nav.navBottomBar marking that the entry was
 // reached via a bottom-nav tab. Used in two places:
@@ -97,6 +104,7 @@ inline fun <reified T : Any> NavGraphBuilder.composableFromEnd(
     capWidth: Boolean = true,
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
+    PopFamilies.register(T::class, PopFamily.END)
     composable<T>(
         enterTransition = { if (targetState.isBottomNavRoot()) null else enterFromEnd() },
         exitTransition = { if (targetState.isBottomNavRoot()) null else exitBehind() },
@@ -121,6 +129,7 @@ inline fun <reified T : Any> NavGraphBuilder.composableFromBottom(
     capWidth: Boolean = true,
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
+    PopFamilies.register(T::class, PopFamily.BOTTOM)
     composable<T>(
         enterTransition = { enterFromBottom() },
         exitTransition = { exitBehind() },
@@ -184,3 +193,63 @@ fun popExitToBottom() = if (NavTransitionTier.isLargeScreen) sharedAxisExitToBot
 fun exitBehind() = if (NavTransitionTier.isLargeScreen) fadeScaleOut else scaleOut
 
 fun popEnterFromBehind() = if (NavTransitionTier.isLargeScreen) fadeScaleIn else scaleIn
+
+/**
+ * The NavHost-level fade both directions of a tab switch fall back to. Shared with
+ * [BuildNavigation]'s own enter/exit so the gesture path and the button path cannot drift.
+ */
+val navShellFadeIn = fadeIn(animationSpec = tween(200))
+val navShellFadeOut = fadeOut(animationSpec = tween(200))
+
+/** Which builder a destination was declared with, for [predictivePopEnter] / [predictivePopExit]. */
+enum class PopFamily { END, BOTTOM, NONE }
+
+/**
+ * Records the family of every destination the builders below declare.
+ *
+ * navigation-compose 2.10.0 gave a predictive back *gesture* its own transition pair —
+ * `predictivePopEnterTransition` / `predictivePopExitTransition` — separate from popEnter/popExit,
+ * and its defaults are `fadeIn` opposite `scaleOut(targetScale = 0.7f)`. So a swipe-from-edge back
+ * stopped running the slides declared per route and started shrinking the outgoing screen toward
+ * its centre, while a back *button* press still slid, because only the gesture takes that branch
+ * (NavHost.kt: `if (inPredictiveBack) … else if (composeNavigator.isPop.value) …`).
+ *
+ * The per-destination overrides are `internal` in that release, so the only public lever is the
+ * NavHost-level pair — which is handed the entries but not the builder that declared them. This is
+ * how they find out. Registration happens as the graph is built and is idempotent, so recomposing
+ * the host re-registers the same values.
+ */
+object PopFamilies {
+    private val families = ConcurrentHashMap<KClass<*>, PopFamily>()
+
+    fun register(
+        route: KClass<*>,
+        family: PopFamily,
+    ) {
+        families[route] = family
+    }
+
+    fun of(destination: NavDestination): PopFamily = families.entries.firstOrNull { destination.hasRoute(it.key) }?.value ?: PopFamily.NONE
+}
+
+/**
+ * The gesture twin of the route-level `popEnterTransition`s, reproducing their rules: a tab root
+ * revealed behind a pop falls back to the shell fade, anything else grows in from behind.
+ */
+fun AnimatedContentTransitionScope<NavBackStackEntry>.predictivePopEnter(): EnterTransition =
+    when (PopFamilies.of(targetState.destination)) {
+        PopFamily.BOTTOM -> popEnterFromBehind()
+        PopFamily.END -> if (initialState.isBottomNavRoot()) navShellFadeIn else popEnterFromBehind()
+        PopFamily.NONE -> navShellFadeIn
+    }
+
+/**
+ * The gesture twin of the route-level `popExitTransition`s: a modal leaves downward, a drill-in
+ * leaves toward the end, and a tab entry fades — the same three answers a button back gives.
+ */
+fun AnimatedContentTransitionScope<NavBackStackEntry>.predictivePopExit(): ExitTransition =
+    when (PopFamilies.of(initialState.destination)) {
+        PopFamily.BOTTOM -> popExitToBottom()
+        PopFamily.END -> if (initialState.isBottomNavRoot()) navShellFadeOut else popExitToEnd()
+        PopFamily.NONE -> navShellFadeOut
+    }


### PR DESCRIPTION
A swipe-from-edge back stopped sliding and started shrinking the outgoing screen toward its centre. A back **button** press still slid, which is the tell: only the gesture takes the changed branch.

Not in any release — it arrived with the 2.9.8 → 2.10.1 bump in 86d96dda06, this cycle.

## Cause

navigation-compose 2.10.0 split the gesture off from the button. `NavHost` was:

```kotlin
if (composeNavigator.isPop.value || inPredictiveBack) { … popExitTransition.invoke(this) }
```

and is now:

```kotlin
if (inPredictiveBack) { … predictivePopExitTransition.invoke(this, swipeEdge) }
else if (composeNavigator.isPop.value) { … popExitTransition.invoke(this) }
```

with defaults, in `DefaultNavTransitions.android.kt`, of:

```kotlin
predictivePopEnterTransition = { fadeIn(spring(dampingRatio = 1.0f, stiffness = 1600.0f)) }
predictivePopExitTransition  = { scaleOut(targetScale = 0.7f) }
```

`BuildNavigation` passes no predictive pair, so every gesture back ran that 0.7 scale instead of the slides declared per route.

## Fix

The per-destination overrides are `internal` in 2.10.1, so the only public lever is the NavHost-level pair — and it is handed the entries but not the builder that declared them. `PopFamilies` records that as the graph is built, so `predictivePopEnter` / `predictivePopExit` can reproduce the existing rules exactly: a modal leaves downward, a drill-in leaves toward the end, a tab entry fades.

They call `popExitToEnd` / `popExitToBottom` / `popEnterFromBehind` rather than respell them, so the large-screen tier still applies and the gesture path cannot drift from the button path. `navShellFadeIn/Out` are now shared with the NavHost's own enter/exit instead of being spelled twice.

## Verification

On emulator-5554 (Pixel 9, API 36), gesture held at the same `x=540` with `input motionevent` and screencapped mid-drag:

| build | route | result |
|---|---|---|
| pre-fix | Profile | screen **scaled down**, Home visible around all four edges |
| this PR | Profile (`composableFromEnd`) | screen **translated right**, full size, Home revealed on the left |
| this PR | Edit Profile (`composableFromBottom`) | screen **translated down**, Profile revealed above |

The bottom-family case is the one that proves the lookup resolves per family rather than answering END for everything.

`spotlessCheck` and the pre-push suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgVDQQXAg4cmzsWHoJj61k