### PR TITLE
feat(media): play YouTube links in the app, on YouTube's own IFrame player

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
@@ -65,6 +65,12 @@ data class UiSettings(
     // be bank or Venmo handles carrying legal names, and this puts them one tap
     // from every note in the feed.
     val showPayToZapChip: Boolean = true,
+    // Whether a YouTube link plays inside Amethyst -- in the sandboxed in-app browser, on
+    // YouTube's IFrame player page -- instead of being handed to the external YouTube app.
+    // Defaults to NEVER: the handoff is the behavior every existing user already has, the
+    // external app plays better (their account, quality, downloads), and an in-app YouTube
+    // page is YouTube's scripts running on a page we opened. Opt-in, not opt-out.
+    val playYouTubeInApp: BooleanType = BooleanType.NEVER,
 )
 
 enum class ThemeType(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
@@ -67,10 +67,12 @@ data class UiSettings(
     val showPayToZapChip: Boolean = true,
     // Whether a YouTube link plays inside Amethyst -- in the sandboxed in-app browser, on
     // YouTube's IFrame player page -- instead of being handed to the external YouTube app.
-    // Defaults to NEVER: the handoff is the behavior every existing user already has, the
-    // external app plays better (their account, quality, downloads), and an in-app YouTube
-    // page is YouTube's scripts running on a page we opened. Opt-in, not opt-out.
-    val playYouTubeInApp: BooleanType = BooleanType.NEVER,
+    // Defaults to ALWAYS: staying in the app is the point of the feature, and a link that
+    // bounces the reader out to another app loses them mid-feed. The page still runs in the
+    // `:napplet` process behind the account's Tor choice, so playing it in-app costs the
+    // reader nothing they were not already spending by opening it at all. Anyone who prefers
+    // the external app (their account, quality, downloads) turns this off in Settings > Media.
+    val playYouTubeInApp: BooleanType = BooleanType.ALWAYS,
 )
 
 enum class ThemeType(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
@@ -57,6 +57,7 @@ class UiSettingsFlow(
     val composeSignature: MutableStateFlow<String> = MutableStateFlow(""),
     val showOnchainWallet: MutableStateFlow<Boolean> = MutableStateFlow(true),
     val showPayToZapChip: MutableStateFlow<Boolean> = MutableStateFlow(true),
+    val playYouTubeInApp: MutableStateFlow<BooleanType> = MutableStateFlow(BooleanType.NEVER),
 ) {
     val listOfFlows: List<Flow<Any?>> =
         listOf<Flow<Any?>>(
@@ -90,6 +91,7 @@ class UiSettingsFlow(
             composeSignature,
             showOnchainWallet,
             showPayToZapChip,
+            playYouTubeInApp,
         )
 
     // emits at every change in any of the propertyes.
@@ -127,6 +129,7 @@ class UiSettingsFlow(
                 flows[27] as String,
                 flows[28] as Boolean,
                 flows[29] as Boolean,
+                flows[30] as BooleanType,
             )
         }
 
@@ -162,6 +165,7 @@ class UiSettingsFlow(
             composeSignature.value,
             showOnchainWallet.value,
             showPayToZapChip.value,
+            playYouTubeInApp.value,
         )
 
     fun update(torSettings: UiSettings): Boolean {
@@ -287,6 +291,10 @@ class UiSettingsFlow(
             showPayToZapChip.tryEmit(torSettings.showPayToZapChip)
             any = true
         }
+        if (playYouTubeInApp.value != torSettings.playYouTubeInApp) {
+            playYouTubeInApp.tryEmit(torSettings.playYouTubeInApp)
+            any = true
+        }
 
         return any
     }
@@ -342,6 +350,7 @@ class UiSettingsFlow(
                 MutableStateFlow(uiSettings.composeSignature),
                 MutableStateFlow(uiSettings.showOnchainWallet),
                 MutableStateFlow(uiSettings.showPayToZapChip),
+                MutableStateFlow(uiSettings.playYouTubeInApp),
             )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
@@ -57,7 +57,7 @@ class UiSettingsFlow(
     val composeSignature: MutableStateFlow<String> = MutableStateFlow(""),
     val showOnchainWallet: MutableStateFlow<Boolean> = MutableStateFlow(true),
     val showPayToZapChip: MutableStateFlow<Boolean> = MutableStateFlow(true),
-    val playYouTubeInApp: MutableStateFlow<BooleanType> = MutableStateFlow(BooleanType.NEVER),
+    val playYouTubeInApp: MutableStateFlow<BooleanType> = MutableStateFlow(BooleanType.ALWAYS),
 ) {
     val listOfFlows: List<Flow<Any?>> =
         listOf<Flow<Any?>>(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
@@ -199,6 +199,7 @@ class UiSharedPreferences(
         val UI_GALLERY_SET = stringPreferencesKey("ui.gallery_set")
         val UI_PROPOSE_AI_IMPROVEMENTS = stringPreferencesKey("ui.propose_ai_improvements")
         val UI_USE_TRACKED_BROADCASTS = stringPreferencesKey("ui.use_tracked_broadcasts")
+        val UI_PLAY_YOUTUBE_IN_APP = stringPreferencesKey("ui.play_youtube_in_app")
         val UI_AUTOMATICALLY_CREATE_DRAFTS = stringPreferencesKey("ui.automatically_create_drafts")
         val UI_SHOW_HOME_NEW_THREADS_TAB = booleanPreferencesKey("ui.show_home_new_threads_tab")
         val UI_SHOW_HOME_CONVERSATIONS_TAB = booleanPreferencesKey("ui.show_home_conversations_tab")
@@ -229,6 +230,7 @@ class UiSharedPreferences(
                     automaticallyShowImages = preferences[UI_SHOW_IMAGES]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyStartPlayback = preferences[UI_START_PLAYBACK]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyPlayVideos = preferences[UI_PLAY_VIDEOS]?.let { BooleanType.valueOf(it) } ?: BooleanType.ALWAYS,
+                    playYouTubeInApp = preferences[UI_PLAY_YOUTUBE_IN_APP]?.let { BooleanType.valueOf(it) } ?: BooleanType.NEVER,
                     automaticallyShowUrlPreview = preferences[UI_SHOW_URL_PREVIEW]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyHideNavigationBars = preferences[UI_HIDE_NAVIGATION_BARS]?.let { BooleanType.valueOf(it) } ?: BooleanType.ALWAYS,
                     automaticallyShowProfilePictures = preferences[UI_SHOW_PROFILE_PICTURES]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
@@ -286,6 +288,7 @@ class UiSharedPreferences(
                     preferences[UI_SHOW_IMAGES] = sharedSettings.automaticallyShowImages.name
                     preferences[UI_START_PLAYBACK] = sharedSettings.automaticallyStartPlayback.name
                     preferences[UI_PLAY_VIDEOS] = sharedSettings.automaticallyPlayVideos.name
+                    preferences[UI_PLAY_YOUTUBE_IN_APP] = sharedSettings.playYouTubeInApp.name
                     preferences[UI_SHOW_URL_PREVIEW] = sharedSettings.automaticallyShowUrlPreview.name
                     preferences[UI_HIDE_NAVIGATION_BARS] = sharedSettings.automaticallyHideNavigationBars.name
                     preferences[UI_SHOW_PROFILE_PICTURES] = sharedSettings.automaticallyShowProfilePictures.name

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
@@ -230,7 +230,7 @@ class UiSharedPreferences(
                     automaticallyShowImages = preferences[UI_SHOW_IMAGES]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyStartPlayback = preferences[UI_START_PLAYBACK]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyPlayVideos = preferences[UI_PLAY_VIDEOS]?.let { BooleanType.valueOf(it) } ?: BooleanType.ALWAYS,
-                    playYouTubeInApp = preferences[UI_PLAY_YOUTUBE_IN_APP]?.let { BooleanType.valueOf(it) } ?: BooleanType.NEVER,
+                    playYouTubeInApp = preferences[UI_PLAY_YOUTUBE_IN_APP]?.let { BooleanType.valueOf(it) } ?: BooleanType.ALWAYS,
                     automaticallyShowUrlPreview = preferences[UI_SHOW_URL_PREVIEW]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,
                     automaticallyHideNavigationBars = preferences[UI_HIDE_NAVIGATION_BARS]?.let { BooleanType.valueOf(it) } ?: BooleanType.ALWAYS,
                     automaticallyShowProfilePictures = preferences[UI_SHOW_PROFILE_PICTURES]?.let { ConnectivityType.valueOf(it) } ?: ConnectivityType.ALWAYS,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.AsyncImage
@@ -66,6 +67,7 @@ fun UrlPreviewCard(
     onCardClick: (() -> Unit)? = null,
 ) {
     val uri = LocalUriHandler.current
+    val context = LocalContext.current
     val popupExpanded =
         remember {
             mutableStateOf(false)
@@ -108,7 +110,9 @@ fun UrlPreviewCard(
                     onClick = {
                         if (onCardClick != null) {
                             onCardClick()
-                        } else {
+                        } else if (!YouTubeInApp.open(context, url)) {
+                            // Not a YouTube video, or in-app playback is off: open it the way this
+                            // card always has.
                             runCatching { uri.openUri(url) }
                         }
                     },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/YouTubeInApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/YouTubeInApp.kt
@@ -35,8 +35,9 @@ import com.vitorpamplona.amethyst.favorites.FavoriteAppLauncher
  * runs in the `:napplet` process, honours the site's Tor choice, and keeps a per-account storage
  * partition. YouTube's scripts therefore never share a process with the account or `LocalCache`.
  *
- * Off by default. [open] returns false whenever it declines -- setting off, or not a video link --
- * and the caller then opens the URL exactly as it did before, in the external app.
+ * On by default, and switchable in Settings > Media. [open] returns false whenever it declines --
+ * setting off, or not a video link -- and the caller then opens the URL exactly as it did before,
+ * in the external app.
  */
 object YouTubeInApp {
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/YouTubeInApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/YouTubeInApp.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import android.content.Context
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.richtext.YouTubeLink
+import com.vitorpamplona.amethyst.favorites.FavoriteAppLauncher
+
+/**
+ * Plays a YouTube link inside Amethyst, when the viewer has asked for that.
+ *
+ * YouTube publishes no media file, so there is nothing for ExoPlayer to open -- see [YouTubeLink].
+ * The one supported way to play a video outside youtube.com is its IFrame player page, which needs
+ * a browser. Rather than embed a WebView of our own, this reuses the one the app already has:
+ * [FavoriteAppLauncher.launchUrl] opens the page full-screen in `NappletBrowserActivity`, which
+ * runs in the `:napplet` process, honours the site's Tor choice, and keeps a per-account storage
+ * partition. YouTube's scripts therefore never share a process with the account or `LocalCache`.
+ *
+ * Off by default. [open] returns false whenever it declines -- setting off, or not a video link --
+ * and the caller then opens the URL exactly as it did before, in the external app.
+ */
+object YouTubeInApp {
+    /**
+     * Opens [url]'s player page in the in-app browser, returning whether it did.
+     *
+     * A false return is the normal, expected path and is never an error: it means "not mine", and
+     * the caller must fall back to its usual handling.
+     */
+    fun open(
+        context: Context,
+        url: String,
+    ): Boolean {
+        if (!isEnabled()) return false
+        val playerUrl = YouTubeLink.embedUrlFor(url) ?: return false
+
+        FavoriteAppLauncher.launchUrl(context, playerUrl)
+        return true
+    }
+
+    /**
+     * Whether a [url] would be taken in-app, for callers that need to decide before the tap (an
+     * icon, say). Same answer [open] would give.
+     */
+    fun handles(url: String): Boolean = isEnabled() && YouTubeLink.parse(url) != null
+
+    // Read from the app-wide settings rather than threaded through every call site: the two
+    // callers (the link-preview card and the NIP-71 video card) sit at different depths and only
+    // one of them has an AccountViewModel in scope. Main-process only -- `:napplet` never loads
+    // this class, and could not reach `Amethyst.instance` if it did.
+    private fun isEnabled(): Boolean = Amethyst.instance.uiState.playYouTubeInApp()
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Video.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Video.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -52,6 +53,7 @@ import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.ui.components.MyAsyncImage
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
+import com.vitorpamplona.amethyst.ui.components.YouTubeInApp
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.elements.DefaultImageHeader
@@ -133,8 +135,17 @@ fun VideoDisplay(
         ) {
             if (isYouTube) {
                 val uri = LocalUriHandler.current
+                val context = LocalContext.current
                 Row(
-                    modifier = Modifier.clickable { runCatching { uri.openUri(imeta.url) } },
+                    // In-app playback opens YouTube's player page in the sandboxed browser; when
+                    // it is off (the default) or the link names no video, this stays the handoff
+                    // to the external app that it has always been.
+                    modifier =
+                        Modifier.clickable {
+                            if (!YouTubeInApp.open(context, imeta.url)) {
+                                runCatching { uri.openUri(imeta.url) }
+                            }
+                        },
                 ) {
                     image?.let {
                         MyAsyncImage(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
@@ -147,6 +147,9 @@ class UiSettingsState(
 
     fun autoPlayVideos() = uiSettingsFlow.automaticallyPlayVideos.value == BooleanType.ALWAYS
 
+    /** Whether a YouTube link opens in the in-app sandboxed browser instead of the external app. */
+    fun playYouTubeInApp() = uiSettingsFlow.playYouTubeInApp.value == BooleanType.ALWAYS
+
     val autoPlayVideosFlow: StateFlow<Boolean> =
         uiSettingsFlow.automaticallyPlayVideos
             .map { it == BooleanType.ALWAYS }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -170,6 +170,8 @@ fun SettingsScreen(
             SettingsDivider()
             AutoplayVideosTile(sharedPrefs)
             SettingsDivider()
+            PlayYouTubeInAppTile(sharedPrefs)
+            SettingsDivider()
             UrlPreviewTile(sharedPrefs)
             SettingsDivider()
             ProfilePictureTile(sharedPrefs)
@@ -407,6 +409,16 @@ private fun AutoplayVideosTile(sharedPrefs: UiSettingsFlow) {
         icon = MaterialSymbols.PlayCircle,
         title = R.string.autoplay_videos,
         description = R.string.autoplay_videos_description,
+    )
+}
+
+@Composable
+private fun PlayYouTubeInAppTile(sharedPrefs: UiSettingsFlow) {
+    BooleanSwitchTile(
+        flow = sharedPrefs.playYouTubeInApp,
+        icon = MaterialSymbols.SmartDisplay,
+        title = R.string.play_youtube_in_app,
+        description = R.string.play_youtube_in_app_description,
     )
 }
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1442,6 +1442,7 @@
     <string name="automatically_load_images_gifs">Image Preview</string>
     <string name="automatically_play_videos">Video Playback</string>
     <string name="autoplay_videos">Autoplay Videos</string>
+    <string name="play_youtube_in_app">Play YouTube in Amethyst</string>
     <string name="automatically_show_url_preview">URL Preview</string>
     <string name="automatically_hide_nav_bars">Immersive Scrolling</string>
     <string name="automatically_hide_nav_bars_description">Hide Nav Bars when Scrolling</string>
@@ -1659,6 +1660,7 @@
     <string name="automatically_load_images_gifs_description">Automatically load images and GIFs</string>
     <string name="automatically_play_videos_description">Automatically load videos and GIFs</string>
     <string name="autoplay_videos_description">Automatically play videos when visible on screen</string>
+    <string name="play_youtube_in_app_description">Open YouTube links in the in-app browser instead of the YouTube app</string>
     <string name="automatically_show_url_preview_description">Show URL previews</string>
 
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/YouTubeLink.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/YouTubeLink.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import androidx.compose.runtime.Immutable
+
+/** A YouTube video a link resolves to, plus the offset the link asked to start at. */
+@Immutable
+data class YouTubeVideo(
+    val id: String,
+    val startSeconds: Int? = null,
+)
+
+/**
+ * Recognises the YouTube link spellings that show up in notes and turns them into the one URL a
+ * WebView can actually play: the IFrame player page.
+ *
+ * This exists because YouTube publishes no media file. A `watch?v=` page is an application, and the
+ * `og:video` it advertises is `youtube.com/embed/<id>` typed `text/html` -- markup, which is why
+ * [UrlInfoItem][com.vitorpamplona.amethyst.commons.preview.UrlInfoItem] refuses to hand it to
+ * ExoPlayer. The embed page below is the officially supported way to play a video outside
+ * youtube.com, and the only one that does not depend on scraping a stream URL.
+ *
+ * Kept free of UI and of `java.net.URI` so it stays CLI-safe and multiplatform; the parsing is a
+ * hand-rolled split, which is cheap and total (a malformed URL returns null rather than throwing).
+ */
+object YouTubeLink {
+    /**
+     * YouTube ids have been exactly 11 characters of this alphabet for the platform's whole life,
+     * and requiring that is what keeps `youtube.com/feed/subscriptions` or a channel page from
+     * being mistaken for a video. If the format ever widens, the failure is safe: [parse] returns
+     * null and the link opens the way it does today, in the external app.
+     */
+    private const val ID_LENGTH = 11
+
+    private val WATCH_HOSTS =
+        setOf(
+            "youtube.com",
+            "www.youtube.com",
+            "m.youtube.com",
+            "music.youtube.com",
+            "youtube-nocookie.com",
+            "www.youtube-nocookie.com",
+        )
+
+    private val SHORT_HOSTS = setOf("youtu.be", "www.youtu.be")
+
+    /** Path prefixes that carry the id as the next segment: /embed/ID, /shorts/ID, /live/ID, /v/ID. */
+    private val ID_IN_PATH = setOf("embed", "shorts", "live", "v")
+
+    /**
+     * The privacy-enhanced embed host. YouTube sets no tracking cookie here until playback actually
+     * starts, which is the right default for a client that ships a Tor toggle.
+     */
+    private const val EMBED_HOST = "https://www.youtube-nocookie.com/embed/"
+
+    fun isYouTube(url: String): Boolean = parse(url) != null
+
+    /** The video [url] points at, or null when it is not a recognisable YouTube video link. */
+    fun parse(url: String): YouTubeVideo? {
+        val afterScheme = url.substringAfter("://", url)
+        val hostEnd = afterScheme.indexOfFirst { it == '/' || it == '?' || it == '#' }
+        val host = (if (hostEnd < 0) afterScheme else afterScheme.substring(0, hostEnd)).lowercase()
+        val rest = if (hostEnd < 0) "" else afterScheme.substring(hostEnd)
+
+        val path = rest.substringBefore('?').substringBefore('#').trim('/')
+        val query = if ('?' in rest) rest.substringAfter('?').substringBefore('#') else ""
+
+        val id =
+            when (host) {
+                in SHORT_HOSTS -> path.substringBefore('/')
+                in WATCH_HOSTS -> {
+                    val segments = path.split('/')
+                    when {
+                        segments.size >= 2 && segments[0] in ID_IN_PATH -> segments[1]
+                        segments.firstOrNull() == "watch" -> param(query, "v")
+                        else -> null
+                    }
+                }
+                else -> null
+            }
+
+        if (id == null || !isVideoId(id)) return null
+
+        // `t` on watch/youtu.be links, `start` on embed links; both mean the same thing.
+        val start = param(query, "t") ?: param(query, "start")
+
+        return YouTubeVideo(id, start?.let { parseSeconds(it) })
+    }
+
+    /**
+     * The player page for [video], to be opened as a top-level URL in a WebView.
+     *
+     * `autoplay=1` is deliberate but will usually be ignored: the in-app browser keeps
+     * `mediaPlaybackRequiresUserGesture = true`, so the viewer taps play once inside the player.
+     * That setting is shared with every other site in that browser and must not be relaxed just to
+     * save a tap -- it is what stops any page from playing sound on open.
+     *
+     * `playsinline=1` keeps the video in the page instead of demanding fullscreen, and `rel=0`
+     * limits the end-of-video suggestions to the same channel.
+     */
+    fun embedUrl(video: YouTubeVideo): String {
+        val start = video.startSeconds?.takeIf { it > 0 }?.let { "&start=$it" } ?: ""
+        return "$EMBED_HOST${video.id}?autoplay=1&playsinline=1&rel=0$start"
+    }
+
+    /** Convenience for the common call: the player URL for [url], or null if it is not a video link. */
+    fun embedUrlFor(url: String): String? = parse(url)?.let { embedUrl(it) }
+
+    private fun isVideoId(id: String): Boolean =
+        id.length == ID_LENGTH &&
+            id.all { it in 'a'..'z' || it in 'A'..'Z' || it in '0'..'9' || it == '_' || it == '-' }
+
+    private fun param(
+        query: String,
+        name: String,
+    ): String? {
+        if (query.isEmpty()) return null
+        for (pair in query.split('&')) {
+            val eq = pair.indexOf('=')
+            if (eq == name.length && pair.startsWith(name)) {
+                return pair.substring(eq + 1).ifEmpty { null }
+            }
+        }
+        return null
+    }
+
+    /**
+     * YouTube writes offsets as bare seconds (`t=90`), seconds with a unit (`t=90s`), or a
+     * duration (`t=1h2m3s`, `t=2m30s`). Anything else yields null and the video starts at 0.
+     */
+    private fun parseSeconds(raw: String): Int? {
+        raw.toIntOrNull()?.let { return if (it >= 0) it else null }
+
+        var total = 0
+        var digits = 0
+        var seen = false
+        for (c in raw) {
+            when {
+                c.isDigit() -> {
+                    digits = digits * 10 + (c - '0')
+                    seen = true
+                }
+                c == 'h' || c == 'H' -> {
+                    total += digits * 3600
+                    digits = 0
+                }
+                c == 'm' || c == 'M' -> {
+                    total += digits * 60
+                    digits = 0
+                }
+                c == 's' || c == 'S' -> {
+                    total += digits
+                    digits = 0
+                }
+                else -> return null
+            }
+        }
+        // A trailing number with no unit (`1m30`) is seconds.
+        total += digits
+        return if (seen) total else null
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/YouTubeLinkTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/YouTubeLinkTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class YouTubeLinkTest {
+    private fun id(url: String) = YouTubeLink.parse(url)?.id
+
+    @Test
+    fun readsTheSpellingsThatShowUpInNotes() {
+        val expected = "dQw4w9WgXcQ"
+
+        assertEquals(expected, id("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://m.youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://music.youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://youtu.be/dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://www.youtube.com/shorts/dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://www.youtube.com/embed/dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://www.youtube.com/live/dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://www.youtube.com/v/dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"))
+        assertEquals(expected, id("http://youtube.com/watch?v=dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun survivesTheUsualUrlNoise() {
+        val expected = "dQw4w9WgXcQ"
+
+        assertEquals(expected, id("https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL1234&index=2"))
+        assertEquals(expected, id("https://www.youtube.com/watch?app=desktop&v=dQw4w9WgXcQ"))
+        assertEquals(expected, id("https://youtu.be/dQw4w9WgXcQ?si=abcdef"))
+        assertEquals(expected, id("https://www.youtube.com/embed/dQw4w9WgXcQ/"))
+        assertEquals(expected, id("https://www.youtube.com/watch?v=dQw4w9WgXcQ#fragment"))
+        // The parser never sees a scheme-less URL from the detector today, but it costs nothing.
+        assertEquals(expected, id("youtu.be/dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun aPageThatIsNotAVideoIsNotAVideo() {
+        // The 11-character id rule is what keeps these out: without it every youtube.com path
+        // would look like a video and open a player showing nothing.
+        assertNull(YouTubeLink.parse("https://www.youtube.com/feed/subscriptions"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/@SomeChannel"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v="))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v=tooshort"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v=waaaaaaaaaaytoolong"))
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v=has+bad+chars"))
+    }
+
+    @Test
+    fun otherHostsAreNotYouTube() {
+        assertNull(YouTubeLink.parse("https://vimeo.com/148751763"))
+        assertNull(YouTubeLink.parse("https://e.nostr.build/v_ETvKzX2OdOGmFEp1avRlm5_mp4"))
+        assertNull(YouTubeLink.parse("https://notyoutube.com/watch?v=dQw4w9WgXcQ"))
+        assertNull(YouTubeLink.parse("https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ"))
+        assertNull(YouTubeLink.parse(""))
+    }
+
+    @Test
+    fun readsTheStartOffsetInEverySpellingYouTubeUses() {
+        assertEquals(90, YouTubeLink.parse("https://youtu.be/dQw4w9WgXcQ?t=90")?.startSeconds)
+        assertEquals(90, YouTubeLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=90s")?.startSeconds)
+        assertEquals(3723, YouTubeLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1h2m3s")?.startSeconds)
+        assertEquals(150, YouTubeLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=2m30s")?.startSeconds)
+        assertEquals(90, YouTubeLink.parse("https://www.youtube.com/embed/dQw4w9WgXcQ?start=90")?.startSeconds)
+
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ")?.startSeconds)
+        assertNull(YouTubeLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=soon")?.startSeconds)
+    }
+
+    @Test
+    fun buildsThePrivacyEnhancedPlayerUrl() {
+        assertEquals(
+            "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&playsinline=1&rel=0",
+            YouTubeLink.embedUrlFor("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+        )
+        assertEquals(
+            "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&playsinline=1&rel=0&start=90",
+            YouTubeLink.embedUrlFor("https://youtu.be/dQw4w9WgXcQ?t=90"),
+        )
+        assertNull(YouTubeLink.embedUrlFor("https://vimeo.com/148751763"))
+    }
+
+    @Test
+    fun aZeroOffsetIsNotWorthAParameter() {
+        assertEquals(
+            "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&playsinline=1&rel=0",
+            YouTubeLink.embedUrlFor("https://youtu.be/dQw4w9WgXcQ?t=0"),
+        )
+    }
+}

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -26,6 +26,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -55,6 +56,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.scale
 import androidx.core.net.toUri
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ProxyConfig
 import androidx.webkit.ProxyController
@@ -157,7 +160,10 @@ class NappletBrowserActivity : ComponentActivity() {
     private val backCallback =
         object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
-                if (this@NappletBrowserActivity::webView.isInitialized && webView.canGoBack()) {
+                if (isFullscreen) {
+                    // Back leaves the video, it does not leave the page behind it.
+                    exitFullscreen()
+                } else if (this@NappletBrowserActivity::webView.isInitialized && webView.canGoBack()) {
                     webView.goBack()
                 } else {
                     isEnabled = false
@@ -167,7 +173,90 @@ class NappletBrowserActivity : ComponentActivity() {
         }
 
     private fun syncBackState() {
-        if (this::webView.isInitialized) backCallback.isEnabled = webView.canGoBack()
+        // Fullscreen has its own back behaviour (leave the video), so the callback stays enabled
+        // for it even on a page with no history.
+        if (isFullscreen) {
+            backCallback.isEnabled = true
+        } else if (this::webView.isInitialized) {
+            backCallback.isEnabled = webView.canGoBack()
+        }
+    }
+
+    // --- HTML5 fullscreen ---------------------------------------------------------------------
+
+    /**
+     * The black backdrop holding a page's fullscreen video, or null when not in fullscreen.
+     *
+     * Without the [WebChromeClient.onShowCustomView] pair below, `Element.requestFullscreen()` has
+     * no effect at all: the base implementation does nothing, so the fullscreen button on every
+     * embedded player -- YouTube's included -- is a dead tap. The view WebView hands us is the
+     * video surface detached from the page; it has to be parented somewhere, and returned when the
+     * page (or the viewer) asks to come back.
+     */
+    private var fullscreenContainer: FrameLayout? = null
+
+    /** WebView's "I have taken your view back" callback. Must be answered exactly once. */
+    private var fullscreenCallback: WebChromeClient.CustomViewCallback? = null
+
+    private val isFullscreen get() = fullscreenContainer != null
+
+    private fun enterFullscreen(
+        view: View,
+        callback: WebChromeClient.CustomViewCallback,
+    ) {
+        if (fullscreenContainer != null) {
+            // A second request without an intervening hide: refuse it, but answer the callback --
+            // an unanswered one wedges the page's player in a half-fullscreen state forever.
+            runCatching { callback.onCustomViewHidden() }
+            return
+        }
+
+        fullscreenCallback = callback
+        fullscreenContainer =
+            FrameLayout(this)
+                .apply {
+                    setBackgroundColor(Color.BLACK)
+                    addView(
+                        view,
+                        FrameLayout.LayoutParams(
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                            Gravity.CENTER,
+                        ),
+                    )
+                }.also {
+                    // A sibling of the padded content root, so the video really does reach the
+                    // screen edges instead of inheriting the host's system-bar insets.
+                    addContentView(
+                        it,
+                        FrameLayout.LayoutParams(
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                        ),
+                    )
+                }
+
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            hide(WindowInsetsCompat.Type.systemBars())
+        }
+        syncBackState()
+    }
+
+    private fun exitFullscreen() {
+        val container = fullscreenContainer ?: return
+
+        (container.parent as? ViewGroup)?.removeView(container)
+        container.removeAllViews()
+        fullscreenContainer = null
+
+        // Hands the video surface back to the page. Skipping this leaves the player believing it
+        // is still fullscreen, and the next tap on its button does nothing.
+        runCatching { fullscreenCallback?.onCustomViewHidden() }
+        fullscreenCallback = null
+
+        WindowInsetsControllerCompat(window, window.decorView).show(WindowInsetsCompat.Type.systemBars())
+        syncBackState()
     }
 
     private val brokerConnection =
@@ -298,6 +387,10 @@ class NappletBrowserActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        // Give the video surface back before the WebView is torn down: it belongs to the page, and
+        // destroying the WebView while we still hold one of its views is the corruption described
+        // below in miniature.
+        exitFullscreen()
         // Tell the broker to drop every reference to our reply Messenger BEFORE unbinding — a retained
         // Messenger is a binder, and it would pin this Activity (and its WebView) in `:napplet` for the
         // life of the process. `unbindService` alone does not release it. See [replyMessenger].
@@ -391,6 +484,13 @@ class NappletBrowserActivity : ComponentActivity() {
             filePathCallback: ValueCallback<Array<Uri>>,
             fileChooserParams: FileChooserParams,
         ): Boolean = showFileChooser(filePathCallback, fileChooserParams)
+
+        override fun onShowCustomView(
+            view: View,
+            callback: CustomViewCallback,
+        ) = enterFullscreen(view, callback)
+
+        override fun onHideCustomView() = exitFullscreen()
 
         override fun onProgressChanged(
             view: WebView,


### PR DESCRIPTION
> **Stacked on #4092.** Base is `fix/og-media-playback`, so the diff here is only the YouTube work. GitHub will retarget this to `main` when #4092 merges. Please review #4092 first.

> **Draft:** nothing here has been run on a device — see *Not verified* below. That gap matters much more for this PR than for #4092, because the whole feature is a WebView interaction.

## Summary

YouTube publishes no media file, so ExoPlayer has nothing to open — #4092 deliberately refuses its `og:video`, which is an `/embed/` page typed `text/html`. The one supported way to play a video outside youtube.com is its IFrame player page, which needs a browser. Rather than embed a second WebView stack, this uses the one Amethyst already ships.

Tapping a YouTube link calls `FavoriteAppLauncher.launchUrl` on the player page, which opens `NappletBrowserActivity`: the `:napplet` process, the site's remembered Tor choice, and a per-account storage partition. **YouTube's scripts never share a process with the account or `LocalCache`.** The page is loaded from `youtube-nocookie.com`, which sets no tracking cookie until playback starts.

This is also the only ToS-compliant path — the IFrame embed keeps YouTube's controls and branding, and there is no background playback. Stream extraction (NewPipeExtractor) was considered and rejected: I checked its LICENSE, and it is **GPLv3 with no linking or classpath exception**, which under CLAUDE.md § Dependency Licensing is a stop for an MIT-licensed APK — the same reason TarsosDSP was removed.

Wired at the two places a YouTube link renders: the link-preview card, and `Video.kt`'s existing NIP-71 YouTube branch (which previously showed a thumbnail and handed off externally). Plain text links are left alone — they go through the shared `SharedClickableUrl`, and desktop has no in-app browser to route them to.

**`playYouTubeInApp` defaults to on.** `YouTubeInApp.open` returns false when it declines — setting off, or not a video link — and the caller then opens the URL exactly as before. Existing installs have no stored value, so **they get in-app playback on upgrade** and turn it off in Settings → Media.

Also adds **HTML5 fullscreen to the sandboxed browser**, which was broken for every site, not just YouTube: `BrowserChromeClient` had no `onShowCustomView`, so `requestFullscreen()` did nothing and the fullscreen button on any embedded player was a dead tap. Back now leaves the video rather than the page, and the surface is handed back on teardown — holding one of the WebView's views across `destroy()` is the renderer corruption that file already documents at length.

`autoplay=1` is passed but will usually be ignored: the browser keeps `mediaPlaybackRequiresUserGesture = true`, so the viewer taps play once inside the player. That setting is shared with every other site there and is not worth relaxing to save a tap — it is what stops any page from playing sound on open.

## Test plan

### Feature test plan

Verified with `curl` against the live hosts:

- `https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ` → `200`, `text/html`, ~142 KB, `<title>YouTube</title>` — a real standalone player page, which is what makes loading it as a top-level URL work.
- YouTube `watch?v=…` declares `og:video:type: text/html`, which is why #4092 refuses it and this PR exists.

`YouTubeLinkTest` (7 tests) pins the parser against those spellings: watch, `youtu.be`, shorts, embed, live, `/v/`, `m.`, `music.`, `youtube-nocookie`; noise (`&list=`, `?si=`, `#fragment`, trailing slash); start offsets in all three formats YouTube writes (`t=90`, `t=90s`, `t=1h2m3s`, `start=`); and rejection of channel pages, `/feed/subscriptions`, bad ids and look-alike hosts (`youtube.com.evil.example`). The 11-character id rule is what keeps a channel page from opening a player showing nothing.

```
./gradlew :commons:jvmTest :amethyst:testFdroidDebugUnitTest :amethyst:compileFdroidDebugKotlin
BUILD SUCCESSFUL in 2m 52s
```

### Regression test plan

Touch points, failure mode, verification:

- **Every link-preview card** — `UrlPreviewCard`'s tap now tries `YouTubeInApp.open` first; if that mis-claimed a URL, no link would open in a browser again. Verified: `open` returns false unless the setting is on *and* `YouTubeLink.parse` returns a video, and the parser's rejection cases are tested above.
- **NIP-71 YouTube notes** — `Video.kt`'s existing branch changed from `openUri` to the same try-then-fall-back. Verified by inspection; the fallback is the original call, unchanged.
- **The in-app browser, all sites** — `onShowCustomView` is new shared behaviour in `NappletBrowserActivity`. Failure mode: a page requesting fullscreen leaves a black overlay you cannot dismiss, or the WebView is corrupted on teardown. Mitigated by exiting fullscreen in `onDestroy` before the existing WebView detach, refusing a second request while answering its callback, and routing back through `exitFullscreen`. **Not verified at runtime** — see below.
- **Settings persistence** — a new `BooleanType` was threaded through `UiSettings`, `UiSettingsFlow` (constructor, `listOfFlows`, the positional `propertyWatchFlow` mapping, `toSettings`, `update`, the `build` factory), and `UISharedPreferences`. Failure mode: a wrong index silently swaps two settings for everyone. Verified: the field was appended last everywhere, so every existing index is unchanged, and it reads `flows[30]`; amethyst's 1471 unit tests pass.
- **Rotation during playback** — `NappletBrowserActivity` already declares `configChanges="orientation|screenSize|…"`, so fullscreen will not recreate the activity.
- **Icon font** — `SmartDisplay` was already referenced in `MaterialSymbols.kt`, so no subset regeneration is required (CLAUDE.md § Icons).
- **Strings** — added only to `values/strings.xml`, leaving Crowdin to handle translations.

### Not verified, and why

**Nobody has watched a video play.** No emulator image and no device in this environment. Specifically unverified:

1. That the IFrame player renders and plays in that WebView, with Safe Browsing on, `MIXED_CONTENT_COMPATIBILITY_MODE`, and the per-account storage partition.
2. The whole fullscreen cycle — enter, rotate, back, exit, hand back. View-lifecycle code is exactly what only misbehaves at runtime.
3. Whether a feed video playing in the main process yields audio focus when the browser activity takes over.

That is why this is a **draft**. I would not merge it without someone installing `installFdroidDebug`, tapping a YouTube link, and exercising fullscreen.

Both flavours were built on the base branch (#4092); this PR adds no Google-proprietary touch points, but `installPlayDebug` / `installFdroidDebug` were not run because installing needs a device.

## Known gaps

Listed rather than hidden — none are blockers for review, all are follow-ups:

- **Two taps to start**, per `mediaPlaybackRequiresUserGesture` above.
- **Links with previews turned off don't route in-app** — they render through commons' `SharedClickableUrl`, shared with desktop. Needs a deliberate decision, not a quiet change.
- **The Video / Shorts / Longs feeds still blocklist `youtube.com`**, so YouTube NIP-71 events never appear there. That predates this work and made sense when YouTube couldn't play; worth revisiting now that it can, but it is a product call.
- **Nothing signals a card will play in-app** — a YouTube preview card looks like any other link card. `YouTubeInApp.handles()` exists to back such an affordance and currently has no caller; it should either get one or be deleted before merge.
- `YouTubeInApp` reads `Amethyst.instance.uiState` directly, which puts it out of reach of unit tests. Taking the flag as a parameter would make the routing decision testable.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

No events published, no kinds or tags, no MLS/DM/QUIC path. The audio it affects is decoded by YouTube's player in a WebView, not by us.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Written with Claude Code. The code-review pass required by CONTRIBUTING-WITH-AI was run against the base commits and its six findings are fixed in #4092; this PR's own diff has **not** had an independent review pass yet, and given the *Not verified* section above I would rather that happen alongside on-device QA than before it.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

No new dependencies. NewPipeExtractor (GPLv3, no linking exception) was explicitly rejected — see Summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8uqrrzDpqUYxV9R7CJgxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8uqrrzDpqUYxV9R7CJgxW)_