### PR TITLE
Split NIP-22 root-scope replies into separate engagement filters

### DIFF
--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/Nip34NotificationCoverageTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/Nip34NotificationCoverageTest.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal
 
 import com.vitorpamplona.amethyst.commons.relayClient.account.nip01Notifications.NotificationsPerKeyKinds2
 import com.vitorpamplona.amethyst.commons.relayClient.event.watchers.RepliesAndReactionsKinds2
+import com.vitorpamplona.amethyst.commons.relayClient.event.watchers.RootScopedRepliesKinds
 import com.vitorpamplona.amethyst.service.notifications.NotificationDispatcher
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
@@ -32,6 +33,7 @@ import com.vitorpamplona.quartz.nip34Git.status.GitStatusAppliedEvent
 import com.vitorpamplona.quartz.nip34Git.status.GitStatusClosedEvent
 import com.vitorpamplona.quartz.nip34Git.status.GitStatusDraftEvent
 import com.vitorpamplona.quartz.nip34Git.status.GitStatusOpenEvent
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -116,25 +118,30 @@ class Nip34NotificationCoverageTest {
 
     /**
      * A status/update event's discovery path when a repo or PR is on screen: the
-     * [`e`=<targetId>][RepliesAndReactionsKinds2] engagement subscription. Without
-     * this the closed/merged pill on a repo listing can never populate — the
-     * status event's only other route to the device is the `#p`=me subscription,
-     * which only fires for accounts that were pre-tagged as participants.
-     * Patches/issues/PRs are self-anchored (they ARE the target, not events
-     * about the target), so they are intentionally NOT expected here.
+     * engagement subscription. Without this the closed/merged pill on a repo
+     * listing can never populate — the status event's only other route to the
+     * device is the `#p`=me subscription, which only fires for accounts that were
+     * pre-tagged as participants. Patches/issues/PRs are self-anchored (they ARE
+     * the target, not events about the target), so they are intentionally NOT
+     * expected here.
+     *
+     * Which of the two engagement filters carries a kind depends on how that kind
+     * anchors itself, so the two halves are asserted separately below: statuses
+     * and replies use a `root`-marked lowercase `e`, PR revisions use NIP-22's
+     * uppercase `E`. Asserting the wrong half passes the kind list while matching
+     * nothing on the wire.
      */
     @Test
-    fun `status and PR-update kinds are pulled by the engagement subscription`() {
-        val threadedActivityKinds =
+    fun `status kinds are pulled by the lowercase-e engagement subscription`() {
+        val eAnchoredActivityKinds =
             setOf(
-                GitPullRequestUpdateEvent.KIND,
                 GitReplyEvent.KIND,
                 GitStatusOpenEvent.KIND,
                 GitStatusAppliedEvent.KIND,
                 GitStatusClosedEvent.KIND,
                 GitStatusDraftEvent.KIND,
             )
-        val missing = threadedActivityKinds - RepliesAndReactionsKinds2.toSet()
+        val missing = eAnchoredActivityKinds - RepliesAndReactionsKinds2.toSet()
         assertTrue(
             "Kinds $missing are missing from RepliesAndReactionsKinds2. When a repo/PR row is " +
                 "on screen the app fetches replies + reactions targeting the visible events — " +
@@ -142,6 +149,28 @@ class Nip34NotificationCoverageTest {
                 "merged pill on a repo listing never populates for anyone who isn't a p-tagged " +
                 "participant of the PR.",
             missing.isEmpty(),
+        )
+    }
+
+    /**
+     * Kind 1619 has no lowercase `e` tag at all — NIP-34's PR Update example carries
+     * only `["E", <pull-request-event-id>]` — so it can only ever arrive through the
+     * uppercase root-scope filter. It sat in [RepliesAndReactionsKinds2] for a while
+     * and matched nothing there.
+     */
+    @Test
+    fun `PR-update kind is pulled by the uppercase-E engagement subscription`() {
+        assertTrue(
+            "GitPullRequestUpdateEvent (1619) is missing from RootScopedRepliesKinds. It anchors " +
+                "at the PR it revises with NIP-22's uppercase `E` and carries no lowercase `e`, " +
+                "so the `#e` engagement filter can never surface a PR's revision chain.",
+            GitPullRequestUpdateEvent.KIND in RootScopedRepliesKinds,
+        )
+        assertFalse(
+            "GitPullRequestUpdateEvent (1619) is back in RepliesAndReactionsKinds2, the `#e` " +
+                "filter's kind list. 1619 has no lowercase `e` tag, so the entry matches nothing " +
+                "and only makes the filter look like it covers PR updates.",
+            GitPullRequestUpdateEvent.KIND in RepliesAndReactionsKinds2,
         )
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToAddresses.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToAddresses.kt
@@ -63,6 +63,18 @@ val PostsAndChatMessagesToAddresses =
         LiveActivitiesChatMessageEvent.KIND,
     )
 
+/**
+ * NIP-22 keeps the conversation root in the **uppercase** `A` tag and only the direct
+ * parent in lowercase `a`. A comment on a comment of an article therefore never carries
+ * `a`=<address>, so an `a`-only engagement filter sees only the first level of that
+ * 1111 thread — the rest used to appear only once ThreadScreen opened its own `A`
+ * subscription.
+ */
+val RootScopedRepliesToAddressesKinds =
+    listOf(
+        CommentEvent.KIND,
+    )
+
 val DeletionKindList =
     listOf(
         DeletionEvent.KIND,
@@ -139,6 +151,22 @@ fun filterRepliesAndReactionsToAddresses(
                         kinds = TextNoteKindList,
                         tags = mapOf("q" to sortedList),
                         since = since,
+                        limit = 1000,
+                    ),
+            ),
+            // Its own filter on purpose: tag names inside one filter are ANDed, so folding
+            // "A" into the "a" filter above would only match comments carrying both.
+            RelayBasedFilter(
+                relay = relay,
+                filter =
+                    ExplainedFilter(
+                        purpose = SubPurpose.ENGAGEMENT,
+                        accountPubKeys = listOfNotNull(accountPubKey),
+                        kinds = RootScopedRepliesToAddressesKinds,
+                        tags = mapOf("A" to sortedList),
+                        since = since,
+                        // Matches the ceiling of the direct-reply filter above: this is the
+                        // rest of the same thread, not a second conversation.
                         limit = 1000,
                     ),
             ),

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
@@ -71,6 +71,20 @@ val RepliesAndReactionsKinds =
         AttestationEvent.KIND,
     )
 
+/**
+ * NIP-22 keeps the conversation root in the **uppercase** `E` tag and only the direct
+ * parent in lowercase `e`. A comment two or more levels deep therefore never carries
+ * `e`=<rootId>, so an `e`-only engagement filter sees only the first level of a
+ * 1111 thread — the rest used to appear only once ThreadScreen opened its own `E`
+ * subscription. These kinds are the ones that anchor themselves with `E`.
+ */
+val RootScopedRepliesKinds =
+    listOf(
+        CommentEvent.KIND,
+        // NIP-34 PR revisions point at the PR they revise through `E`.
+        GitPullRequestUpdateEvent.KIND,
+    )
+
 val RepliesAndReactionsKinds2 =
     listOf(
         DeletionEvent.KIND,
@@ -145,6 +159,22 @@ fun filterRepliesAndReactionsToNotes(
                             tags = mapOf("e" to sortedList),
                             since = since,
                             limit = 100,
+                        ),
+                ),
+                // Its own filter on purpose: tag names inside one filter are ANDed, so folding
+                // "E" into the "e" filter above would only match comments carrying both.
+                RelayBasedFilter(
+                    relay = relay,
+                    filter =
+                        ExplainedFilter(
+                            purpose = SubPurpose.ENGAGEMENT,
+                            accountPubKeys = listOfNotNull(accountPubKey),
+                            kinds = RootScopedRepliesKinds,
+                            tags = mapOf("E" to sortedList),
+                            since = since,
+                            // Matches the ceiling of the direct-reply filter above: this is the
+                            // rest of the same thread, not a second conversation.
+                            limit = 1000,
                         ),
                 ),
                 RelayBasedFilter(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
@@ -81,7 +81,9 @@ val RepliesAndReactionsKinds =
 val RootScopedRepliesKinds =
     listOf(
         CommentEvent.KIND,
-        // NIP-34 PR revisions point at the PR they revise through `E`.
+        // NIP-34 kind 1619 carries the PR it revises in `E` and has no lowercase
+        // `e` at all (see the spec's PR Update example), so this filter is the
+        // only engagement route to a PR's revision chain.
         GitPullRequestUpdateEvent.KIND,
     )
 
@@ -92,12 +94,12 @@ val RepliesAndReactionsKinds2 =
         NIP90StatusEvent.KIND,
         TorrentCommentEvent.KIND,
         GitReplyEvent.KIND,
-        // NIP-34 PR revision (1619) and status events (1630/1631/1632/1633).
-        // Rooted at the target patch/PR/issue via a `root`-marked `e` tag, so
-        // an `e=<targetId>` engagement fetch surfaces the PR's revision chain
-        // and every open/applied/closed/draft transition — the signal
-        // GitStatusIndex needs to answer isClosedOrResolved() for repo rows.
-        GitPullRequestUpdateEvent.KIND,
+        // NIP-34 status events (1630/1631/1632/1633). Rooted at the target
+        // patch/PR/issue via a `root`-marked `e` tag, so an `e=<targetId>`
+        // engagement fetch surfaces every open/applied/closed/draft transition —
+        // the signal GitStatusIndex needs to answer isClosedOrResolved() for
+        // repo rows. PR revisions (1619) anchor with `E` instead and are pulled
+        // by [RootScopedRepliesKinds]; listing them here matched nothing.
         GitStatusOpenEvent.KIND,
         GitStatusAppliedEvent.KIND,
         GitStatusClosedEvent.KIND,

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotesTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotesTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.event.watchers
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FilterRepliesAndReactionsToNotesTest {
+    private val relay = RelayUrlNormalizer.normalizeOrNull("wss://one.example")!!
+    private val rootId = "a".repeat(64)
+    private val author = "b".repeat(64)
+
+    private fun note(id: String) = Note(id).apply { addRelaySync(relay) }
+
+    private fun addressable(address: Address) = AddressableNote(address).apply { addRelaySync(relay) }
+
+    @Test
+    fun asksForNip22RootScopeSoNestedCommentsLoadOutsideTheThreadScreen() {
+        val filters = filterRepliesAndReactionsToNotes(listOf(note(rootId)), null)!!
+
+        val rootScope = filters.filter { it.filter.tags?.containsKey("E") == true }
+
+        assertEquals(1, rootScope.size)
+        assertEquals(
+            listOf(rootId),
+            rootScope
+                .single()
+                .filter.tags
+                ?.get("E"),
+        )
+        assertTrue(
+            rootScope
+                .single()
+                .filter.kinds!!
+                .contains(CommentEvent.KIND),
+        )
+        // The uppercase scope must be its own REQ: tag names inside one filter are ANDed,
+        // so merging `e` and `E` would only match comments carrying both.
+        assertTrue(filters.none { it.filter.tags?.containsKey("e") == true && it.filter.tags?.containsKey("E") == true })
+    }
+
+    @Test
+    fun asksForNip22RootAddressScopeOnAddressables() {
+        val address = Address(30023, author, "article")
+        val filters = filterRepliesAndReactionsToAddresses(listOf(addressable(address)), null)!!
+
+        val rootScope = filters.filter { it.filter.tags?.containsKey("A") == true }
+
+        assertEquals(1, rootScope.size)
+        assertEquals(
+            listOf(address.toValue()),
+            rootScope
+                .single()
+                .filter.tags
+                ?.get("A"),
+        )
+        assertTrue(
+            rootScope
+                .single()
+                .filter.kinds!!
+                .contains(CommentEvent.KIND),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

NIP-22 distinguishes between the direct parent (lowercase `e`/`a` tags) and the conversation root (uppercase `E`/`A` tags). Comments two or more levels deep carry only the root in `E`/`A`, never the direct parent in `e`/`a`. The existing engagement filters only queried lowercase tags, so nested threads beyond the first level were invisible until ThreadScreen opened its own subscription.

This change splits engagement subscriptions into two filters per relay:
1. **Direct replies** — lowercase `e`/`a` tags (existing behavior)
2. **Root-scoped replies** — uppercase `E`/`A` tags (new, for nested threads)

Kind 1619 (GitPullRequestUpdateEvent) is moved from `RepliesAndReactionsKinds2` to the new `RootScopedRepliesKinds` list because NIP-34's PR Update spec carries only `["E", <pull-request-id>]` and has no lowercase `e` tag at all — it was matching nothing in the old filter.

## Changes

- **FilterRepliesAndReactionsToNotes.kt**: Added `RootScopedRepliesKinds` list; split engagement filter into two (lowercase `e` and uppercase `E`). Moved kind 1619 from `RepliesAndReactionsKinds2` to `RootScopedRepliesKinds`.
- **FilterRepliesAndReactionsToAddresses.kt**: Added `RootScopedRepliesToAddressesKinds` list; split engagement filter into two (lowercase `a` and uppercase `A`).
- **Nip34NotificationCoverageTest.kt**: Split the monolithic test into two focused assertions — one for `e`-anchored kinds (replies, statuses) and one for `E`-anchored kinds (PR updates). Added explicit assertions that kind 1619 is in the correct filter and not in the wrong one.
- **FilterRepliesAndReactionsToNotesTest.kt**: New unit test verifying that NIP-22 root-scope filters are generated correctly for both notes and addressables.

## Test plan

- [x] Ran `./gradlew test` — new unit tests pass; existing notification coverage tests now correctly distinguish between `e`- and `E`-anchored kinds
- [x] Ran `./gradlew spotlessApply` — repo is formatted

The new `FilterRepliesAndReactionsToNotesTest` verifies that:
- Root-scope filters are created as separate subscriptions (not merged with direct-reply filters)
- The correct tag names (`E` for notes, `A` for addressables) are used
- CommentEvent.KIND is included in root-scope filters

The refactored `Nip34NotificationCoverageTest` now explicitly asserts that GitPullRequestUpdateEvent (1619) appears only in `RootScopedRepliesKinds` and not in `RepliesAndReactionsKinds2`, preventing regressions if the kind is accidentally moved back to the wrong filter.

## Interop suites

- [x] N/A — change affects relay subscription filters only; no wire format changes to events themselves

https://claude.ai/code/session_01ARAmQQWbT2gGVo9tysdAgM