### PR TITLE
chore(release): bump to 1.15.2

### DIFF
--- a/.claude/skills/quartz-integration/SKILL.md
+++ b/.claude/skills/quartz-integration/SKILL.md
@@ -7,7 +7,7 @@ description: Integration guide for using the Quartz Nostr KMP library in externa
 
 Reference for integrating `com.vitorpamplona.quartz:quartz` into external Nostr KMP projects.
 
-**Published artifact**: `com.vitorpamplona.quartz:quartz:1.15.1` (Maven Central)
+**Published artifact**: `com.vitorpamplona.quartz:quartz:1.15.2` (Maven Central)
 **Targets**: JVM 21+, Android (minSdk 21+), iOS (XCFramework `quartz-kmpKit`)
 **License**: MIT
 
@@ -19,7 +19,7 @@ Reference for integrating `com.vitorpamplona.quartz:quartz` into external Nostr 
 
 ```toml
 [versions]
-quartz = "1.15.1"
+quartz = "1.15.2"
 
 [libraries]
 quartz = { module = "com.vitorpamplona.quartz:quartz", version.ref = "quartz" }
@@ -41,7 +41,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("com.vitorpamplona.quartz:quartz:1.15.1")
+    implementation("com.vitorpamplona.quartz:quartz:1.15.2")
 }
 ```
 

--- a/.claude/skills/quartz-integration/references/gradle-setup.md
+++ b/.claude/skills/quartz-integration/references/gradle-setup.md
@@ -3,7 +3,7 @@
 ## Current version
 
 ```
-com.vitorpamplona.quartz:quartz:1.15.1
+com.vitorpamplona.quartz:quartz:1.15.2
 ```
 
 Check latest: https://central.sonatype.com/artifact/com.vitorpamplona.quartz/quartz
@@ -16,7 +16,7 @@ Check latest: https://central.sonatype.com/artifact/com.vitorpamplona.quartz/qua
 
 ```toml
 [versions]
-quartz = "1.15.1"
+quartz = "1.15.2"
 
 [libraries]
 quartz = { module = "com.vitorpamplona.quartz:quartz", version.ref = "quartz" }
@@ -55,7 +55,7 @@ kotlin {
 ```kotlin
 // build.gradle.kts (app module)
 dependencies {
-    implementation("com.vitorpamplona.quartz:quartz:1.15.1")
+    implementation("com.vitorpamplona.quartz:quartz:1.15.2")
 }
 ```
 
@@ -70,7 +70,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.vitorpamplona.quartz:quartz:1.15.1")
+    implementation("com.vitorpamplona.quartz:quartz:1.15.2")
     // JNA needed for libsodium (NIP-44) on JVM
     implementation("net.java.dev.jna:jna:5.18.1")
 }

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -533,7 +533,7 @@ reads an optional per-release changelog from
 
 ## Bootstrap runbook (one-time)
 
-> **Status as of v1.15.1:** both Homebrew packages are now live upstream — the
+> **Status as of v1.15.2:** both Homebrew packages are now live upstream — the
 > `amethyst-nostr` cask (`Homebrew/homebrew-cask`, at 1.14.0) and the `amy`
 > formula (`Homebrew/homebrew-core`) both answer 200 on `formulae.brew.sh`, so
 > `bump-homebrew.yml` finally has something to bump. **Winget is still not
@@ -587,7 +587,7 @@ The token then lives only in that maintainer's shell:
 
 ```bash
 export HOMEBREW_GITHUB_API_TOKEN=ghp_...   # classic PAT, `repo` scope
-scripts/bump-homebrew-cask.sh v1.15.1
+scripts/bump-homebrew-cask.sh v1.15.2
 ```
 
 Create one at
@@ -603,7 +603,7 @@ Same split, and it needs **no token at all**. `scripts/bump-winget.sh` drives
 runs fine from macOS or Linux:
 
 ```bash
-scripts/bump-winget.sh v1.15.1
+scripts/bump-winget.sh v1.15.2
 ```
 
 CI (`bump-winget.yml`, `GITHUB_TOKEN` only) does the bookkeeping: downloads the

--- a/README.md
+++ b/README.md
@@ -328,16 +328,16 @@ repositories {
 Add the following line to your `commonMain` dependencies:
 
 ```gradle
-implementation('com.vitorpamplona.quartz:quartz:1.15.1')
+implementation('com.vitorpamplona.quartz:quartz:1.15.2')
 ```
 
 Variations to each platform are also available:
 
 ```gradle
-implementation('com.vitorpamplona.quartz:quartz-android:1.15.1')
-implementation('com.vitorpamplona.quartz:quartz-jvm:1.15.1')
-implementation('com.vitorpamplona.quartz:quartz-iosarm64:1.15.1')
-implementation('com.vitorpamplona.quartz:quartz-iossimulatorarm64:1.15.1')
+implementation('com.vitorpamplona.quartz:quartz-android:1.15.2')
+implementation('com.vitorpamplona.quartz:quartz-jvm:1.15.2')
+implementation('com.vitorpamplona.quartz:quartz-iosarm64:1.15.2')
+implementation('com.vitorpamplona.quartz:quartz-iossimulatorarm64:1.15.2')
 ```
 
 Check versions on [MavenCentral](https://central.sonatype.com/search?q=com.vitorpamplona.quartz)

--- a/RELEASE_OPS.md
+++ b/RELEASE_OPS.md
@@ -240,9 +240,9 @@ readable by anyone with push access here), so a maintainer runs the last step:
 ```bash
 # after merging the sync PRs
 export HOMEBREW_GITHUB_API_TOKEN=ghp_...     # classic PAT, `repo` scope
-scripts/bump-homebrew-cask.sh v1.15.1
+scripts/bump-homebrew-cask.sh v1.15.2
 
-scripts/bump-winget.sh v1.15.1               # no token — uses your `gh` auth
+scripts/bump-winget.sh v1.15.2               # no token — uses your `gh` auth
 ```
 
 Both scripts re-verify the published artifact's sha256 before submitting, and

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,7 @@
 
 Release notes for Amethyst, one file per version. Files are named with zero-padded version numbers so they sort correctly in any file browser. Use [`TEMPLATE.md`](TEMPLATE.md) as the starting point for the next release.
 
+- [v1.15.2 — Media Previews, Nested Replies, and Health Connect](v1.15.02.md)
 - [v1.15.1 — Release Build Fix](v1.15.01.md)
 - [v1.15.0 — Marmot Updates, a Advanced Search Box, and Books, DVM Updates](v1.15.00.md)
 - [v1.14.0 — Highlights, Relay Login, and a Much Faster Start](v1.14.00.md)

--- a/docs/changelog/v1.15.02.md
+++ b/docs/changelog/v1.15.02.md
@@ -1,0 +1,45 @@
+# v1.15.2: Media Previews, Nested Replies, and Health Connect
+
+## Improvements and Bug fixes
+
+- Plays the track a media player page is *about*, instead of trying to play the
+  page. A link to `e.nostr.build/a_<id>_mp3` rendered a permanently-buffering
+  player: that URL answers `text/html` — it is the HTML player page, and the
+  file it is about is named in its `og:audio`. Two separate defects produced it,
+  and both are fixed. File-extension matching now requires a real dot, so a path
+  ending in the *letters* of an extension (`_mp3`, or a prose slug like
+  `/my-thoughts-on-mp3`) is no longer handed to the video player; and the
+  preview pipeline reads `og:audio` / `og:video` and plays that file, with the
+  page's `og:image` as poster.
+
+  Reading a declaration is not trusting it: YouTube declares an `og:video` whose
+  type is `text/html` — an embed page, not a video — so it is refused and keeps
+  its link card.
+
+- Loads nested NIP-22 replies in the feed, not only after a thread is opened.
+  NIP-22 puts the direct parent in lowercase `e`/`a` and the conversation root in
+  uppercase `E`/`A`, and a comment two or more levels deep carries only the root.
+  The engagement subscriptions asked for the lowercase tags alone, so everything
+  below the first level was invisible until `ThreadScreen` opened a subscription
+  of its own. Each relay now gets a second, root-scoped filter.
+
+  Kind 1619 (NIP-34 PR updates) moves with it: the spec gives it only
+  `["E", <pull-request-id>]` and no lowercase `e` at all, so it had been sitting
+  in a filter it could never match.
+
+## Health Connect
+
+- Adds a rationale screen explaining what Amethyst reads from Health Connect and
+  why — the data types, their purposes, the seven-day and composer-only limits,
+  and what it never does (no writes, no route or location). It opens from the
+  workout composer, from Health Connect's own permission screen, and stands alone
+  without an account, which is what Google Play requires of it.
+- Stops blocking the UI thread on Health Connect reads, and memoizes source app
+  names rather than asking `PackageManager` again for each record.
+- Replaces the whole form when a second workout suggestion is picked, so the
+  distance and calories of the first no longer leak into the second.
+- Documents the integration for Play Console review, and in `PRIVACY.md`.
+
+## Build
+
+- Bumps `appCode` to 460.

--- a/geode/README.md
+++ b/geode/README.md
@@ -32,7 +32,7 @@ docker run -d --name geode -p 7447:7447 \
 ```
 
 with `in_memory = false` and `file = "/var/lib/geode/events.db"` in your
-`geode.toml`. Pin a version (`:1.15.1`) instead of `:latest` for reproducible
+`geode.toml`. Pin a version (`:1.15.2`) instead of `:latest` for reproducible
 deploys. To build the image yourself, from the repo root:
 
 ```bash
@@ -47,7 +47,7 @@ it — a minimal JRE is bundled, so no system Java is required. It installs to
 `/opt/geode/` with the launcher at `/opt/geode/bin/geode`.
 
 ```bash
-sudo dpkg -i geode-1.15.1-linux-x64.deb    # or: sudo rpm -i geode-1.15.1-linux-x64.rpm
+sudo dpkg -i geode-1.15.2-linux-x64.deb    # or: sudo rpm -i geode-1.15.2-linux-x64.rpm
 ```
 
 To run it as a managed service, wire up the shipped systemd unit
@@ -69,7 +69,7 @@ formula: [`packaging/homebrew/geode-relay.rb`](packaging/homebrew/geode-relay.rb
 Download `geode-<version>-<os>-<arch>.tar.gz`, unpack, and run:
 
 ```bash
-tar xzf geode-1.15.1-linux-x64.tar.gz
+tar xzf geode-1.15.2-linux-x64.tar.gz
 ./geode/bin/geode --config geode/share/geode/config.example.toml
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Amethyst app version — single source of truth consumed by both Android (amethyst/)
 # and Desktop (desktopApp/). `appCode` is the Android versionCode: a monotonic
 # integer that must increment on every release, even when `app` is unchanged.
-app = "1.15.1"
-appCode = "459"
+app = "1.15.2"
+appCode = "460"
 accompanistAdaptive = "0.37.3"
 # Pinned: 0.3.0 turns CacheMap.entries/keys/values into DeprecationLevel.ERROR (and
 # throws UnsupportedOperationException at runtime), which breaks quartz's appleMain


### PR DESCRIPTION
`app` 1.15.1 → 1.15.2, `appCode` 459 → 460. That single edit drives Android's `versionName`/`versionCode`, Desktop and CLI `packageVersion`, quartz's Maven version and geode's `RelayInfo.VERSION`.

## What's in it

Three substantive PRs since v1.15.1, plus Crowdin translations and the packaging syncs the bump workflows opened after the last tag.

- **#4092 — media previews.** An extension match now requires a real dot, so a player page whose path merely ends in the *letters* `_mp3` stops being handed to the video player; and `og:audio` / `og:video` are read and played, with the page's `og:image` as poster. A declaration whose type is `text/html` — YouTube's — is refused and keeps its link card.
- **#4095 — nested NIP-22 replies.** Engagement subscriptions asked only for lowercase `e`/`a`, so a comment two or more levels deep was invisible until `ThreadScreen` opened a subscription of its own. Each relay now gets a second, root-scoped filter on `E`/`A`. Kind 1619 moves there too — NIP-34 gives PR updates only an uppercase `E`, so it had been sitting in a filter it could never match.
- **#4096 — Health Connect.** The rationale screen Play requires, reachable from the workout composer, from Health Connect's own permission screen, and standalone without an account; reads moved off the UI thread; source app names memoized instead of re-asking `PackageManager`; and the workout form is replaced rather than merged when a second suggestion is picked.

## Verified on device

Two of the three are only observable on a device, so both were exercised on a Pixel 9 emulator before cutting:

- the `og:audio` track plays in a thread with real transport controls (scrub bar at 00:30 / 05:00) where it used to buffer forever; YouTube still renders a link card;
- the Health Connect rationale opens from all three routes — including the one that matters for review, where Health Connect's own permission screen launches `ViewPermissionUsageActivity` through the `START_VIEW_PERMISSION_USAGE`-guarded filter.

## Notes

`RELEASE_NOTES_ID` deliberately stays on the v1.15.0 note — `RELEASE_OPS` has it repointed on `x.y.0` only.

Left alone deliberately: everything under `*/packaging/` and `translators.json`'s tag, which the bump workflows and the Crowdin job write *after* the tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgVDQQXAg4cmzsWHoJj61k