### PR TITLE
Fix single-flight guarantee for fast signers in BlossomReadAuthTokenProvider

### DIFF
--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProviderTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/BlossomReadAuthTokenProviderTest.kt
@@ -218,6 +218,35 @@ class BlossomReadAuthTokenProviderTest {
             )
         }
 
+    /**
+     * The same single-flight guarantee, but with a signature that returns almost
+     * immediately — an in-process [NostrSignerInternal], which is what the image
+     * path uses for a local key.
+     *
+     * A fast signature is the harder case: the leader can finish, cache its token
+     * and retire its in-flight entry while a straggler is still between its own
+     * cache miss and its look at the in-flight map. That straggler finds both
+     * empty, and must pick the just-minted token up instead of signing a second
+     * one. Run over many rounds because the window is only microseconds wide.
+     */
+    @Test
+    fun aFastSignerStillSharesOneSignature() =
+        runBlocking {
+            repeat(ROUNDS) { round ->
+                val instant = DelayingTestSigner(delayMs = 0)
+                val provider = BlossomReadAuthTokenProvider({ instant }, scope)
+
+                val results =
+                    (1..CONCURRENT_CALLERS)
+                        .map { async(Dispatchers.Default) { provider.header(host) } }
+                        .awaitAll()
+
+                assertEquals("round $round: one signature for $CONCURRENT_CALLERS callers", 1, instant.signatures)
+                assertEquals("round $round: every caller must get the same token", 1, results.toSet().size)
+                assertNotNull("round $round: token must be non-null", results.first())
+            }
+        }
+
     private companion object {
         // Matches OkHttpClientFactory's maxRequestsPerHost: the worst realistic
         // burst is one gated host filling every per-host dispatcher slot.
@@ -225,5 +254,9 @@ class BlossomReadAuthTokenProviderTest {
 
         // How long one signature takes in the concurrency test.
         const val SIGN_MS = 300L
+
+        // Rounds of the fast-signer burst. The leader-finished-early window is
+        // microseconds wide, so one round hits it only now and then.
+        const val ROUNDS = 200
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/http/BlossomReadAuthTokenProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/http/BlossomReadAuthTokenProvider.kt
@@ -103,7 +103,9 @@ class BlossomReadAuthTokenProvider(
 
     /**
      * Returns the in-flight signature for [host], starting one if this caller
-     * wins the race. Null when there is no signer to sign with.
+     * wins the race — or an already-completed one carrying the token a leader
+     * cached while this caller was on its way in. Null when there is no signer
+     * to sign with.
      *
      * Leader/follower over [ConcurrentHashMap.putIfAbsent] rather than
      * `computeIfAbsent`: the completion handler removes the map entry, and a job
@@ -112,6 +114,15 @@ class BlossomReadAuthTokenProvider(
      */
     private fun signOnce(host: String): CompletableDeferred<String?>? {
         inFlight[host]?.let { return it }
+
+        // Second look at the cache, because the caller's own miss happened before this
+        // read and a leader caches its token *before* retiring its [inFlight] entry — so
+        // an absent entry here means any token that leader minted is already visible.
+        // Without this look, a signature fast enough to finish inside that gap (a local
+        // key signs in microseconds) loses the single-flight guarantee: every straggler
+        // still between its cache miss and this read finds both empty and signs again,
+        // which is the N-signatures burst [inFlight] exists to collapse.
+        cachedHeader(host)?.let { return CompletableDeferred<String?>(it) }
 
         val signer = signerProvider() ?: return null
 


### PR DESCRIPTION
## Summary

`BlossomReadAuthTokenProvider` is meant to mint **one** BUD-11 read-auth token per gated host, however many images ask at once. With a fast signer it minted two, and `BlossomReadAuthFetcherTest > aBurstOf401sSharesOneSignature` failed intermittently because the 16 retries did not all carry the same token.

The provider decides across two separate map reads: `header()` reads the token cache, then `signOnce()` reads the in-flight map. A leader caches its token **before** retiring its in-flight entry, so a straggler sitting between those two reads sees an empty cache (its read came first) and an empty in-flight map (the leader already finished) — and signs a second token. The window is microseconds wide: invisible to a 300 ms test signer, routinely hit by an in-process `NostrSignerInternal`.

`signOnce()` now takes a second look at the cache once it finds no in-flight entry. Because the leader caches before removing its entry, an absent entry proves the minted token is already visible, so the straggler reuses it instead of starting another signature. Every ordering now lands on one of: follow the in-flight deferred, take the just-cached token, or legitimately become the leader. On a NIP-55 external signer that is the difference between one IPC round trip per host per burst and N.

## Test plan

### Feature test plan

New `aFastSignerStillSharesOneSignature` — 200 rounds of 16 concurrent `header()` callers against a zero-delay `DelayingTestSigner`, asserting one signature and one token per round. Written as a failing test first:

- Fix reverted, test present → **FAILED**: `round 99: one signature for 16 callers expected:<1> but was:<2>`
- Fix applied → passes, 0.265 s for all 200 rounds.

The existing `concurrentCallersShareOneSignature` (16 callers, 300 ms signer) cannot reach this window — its signature is still in flight when every caller arrives, which is why the race survived it. The 200 rounds are what make a microsecond-wide window land reliably.

### Regression test plan

What could plausibly break, and what covers it:

- **An expired token handed back by the new cache look** — it can't: the second look goes through `cachedHeader()`, which applies the TTL. `refreshesAfterExpiry` asserts the expired case still re-signs (signature count, not header equality) and passes.
- **A failed or timed-out signature no longer retried** — it still is: nothing is cached on failure, so the next caller finds both cache and in-flight empty and becomes the leader, as before.
- **`warm()`** shares `signOnce()` and is unchanged in behaviour; `warmPopulatesTheCacheWithoutTheCallerWaiting` passes.
- **The fetcher/interceptor layers** that consume the provider: `BlossomReadAuthFetcherTest` (6), `BlossomReadAuthInterceptorTest` (14), `BlossomReadAuthTokenProviderTest` (10) — 30 tests, 0 failures.

Ran:

- `./gradlew :amethyst:testPlayDebugUnitTest` — **1506 tests, 8 skipped, 0 failures**
- Pre-push gate, i.e. `:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test` — `All test passed.`
- `./gradlew spotlessApply` — no changes

Not run, and why: no device/emulator pass — the diff is provider logic plus a unit test, with no UI, manifest, dependency or Android-API surface. Flavour-irrelevant for the same reason (`commons/commonMain` + a test, no Play-only imports), so only the Play flavour's unit tests were run.

## Interop suites

- [x] N/A — no change to wire bytes, decoded audio, MLS state or DM envelopes. The minted token's shape is untouched (still `server`-scoped, no `x` tag, per BUD-11); only how many of them get signed changes.

## AI assistance

- [x] Drafted with AI assistance

Diff authored by Claude Code in the session linked below, verified by the runs listed above (failing-test-first reproduction included).

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Both touched files keep their existing MIT headers; no third-party code added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011APd48WJ5pZVK4Ltpj3YpL