### PR TITLE
fix: clear every compiler, Gradle and mechanical lint warning, and two things the sweep turned up

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -399,9 +399,9 @@ dependencies {
     // Usage: runtime-enable, then capture a Perfetto trace with the `track_event` data source:
     //   adb shell am broadcast -a androidx.tracing.perfetto.action.ENABLE_TRACING \
     //     -n com.vitorpamplona.amethyst.debug/androidx.tracing.perfetto.TracingReceiver
-    debugImplementation("androidx.compose.runtime:runtime-tracing")
-    debugImplementation("androidx.tracing:tracing-perfetto:1.0.1")
-    debugImplementation("androidx.tracing:tracing-perfetto-binary:1.0.1")
+    debugImplementation(libs.androidx.compose.runtime.tracing)
+    debugImplementation(libs.androidx.tracing.perfetto)
+    debugImplementation(libs.androidx.tracing.perfetto.binary)
 
     implementation(project(":quartz"))
     implementation(project(":commons"))

--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/service/playback/composable/PlaybackErrorOverlayFitTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/service/playback/composable/PlaybackErrorOverlayFitTest.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -62,7 +62,8 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class PlaybackErrorOverlayFitTest {
-    @get:Rule val rule = createComposeRule()
+    @get:Rule
+    val rule = createComposeRule()
 
     private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.vitorpamplona.amethyst.service.playback.composable.audioSquare
@@ -50,7 +50,8 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class AudioPlayerBoxOverflowTest {
-    @get:Rule val rule = createComposeRule()
+    @get:Rule
+    val rule = createComposeRule()
 
     private class Bounds {
         var top = 0f

--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/insets/ComposeImeInsetWedgeTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/insets/ComposeImeInsetWedgeTest.kt
@@ -31,7 +31,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.core.graphics.Insets
 import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.WindowInsetsAnimationCompat
@@ -70,7 +70,8 @@ import org.junit.Test
  * fallback would silently start reading a dead value too.
  */
 class ComposeImeInsetWedgeTest {
-    @get:Rule val rule = createComposeRule()
+    @get:Rule
+    val rule = createComposeRule()
 
     private val keyboardHeight = 957
 

--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/note/DeferredAnimationTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/note/DeferredAnimationTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.vitorpamplona.amethyst.ui.actions.DeferredCrossfade

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.normalizedUrls
 import com.vitorpamplona.quartz.utils.Log
+import com.vitorpamplona.quartz.utils.LogLevel
 import com.vitorpamplona.quartz.utils.bytesUsedInMemory
 import com.vitorpamplona.quartz.utils.pointerSizeInBytes
 import kotlin.time.DurationUnit
@@ -92,6 +93,16 @@ fun collectMemorySnapshot(context: Context): MemorySnapshot {
 private const val STATE_DUMP_TAG = "STATE DUMP"
 
 fun debugState(context: Context) {
+    // Everything below is logged at DEBUG, and every argument is built eagerly (the
+    // eager Log.d overload, not the lambda one). Gate on the level that would drop
+    // those lines, because the arguments are the expensive part: nine materialising
+    // LargeCache.filter scans over notes/addressables/users/channels, plus three
+    // passes calling Event.countMemory() — which walks every tag of every cached
+    // event. MainActivity.onPause() calls this unconditionally, so without the gate
+    // a release build (minLevel WARN) did all of that on every backgrounding and
+    // threw the result away. Benchmark builds sit at INFO and paid it too.
+    if (Log.minLevel > LogLevel.DEBUG) return
+
     val totalMemoryMb = Runtime.getRuntime().totalMemory() / (1024 * 1024)
     val freeMemoryMb = Runtime.getRuntime().freeMemory() / (1024 * 1024)
     val maxMemoryMb = Runtime.getRuntime().maxMemory() / (1024 * 1024)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip62Vanish/VanishRequestsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip62Vanish/VanishRequestsState.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 @Stable
 data class VanishEventItem(
@@ -124,7 +125,10 @@ class VanishRequestsState(
                         }
                 )
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            // A cancelled check has no result. Reporting ERROR would show the relay as
+            // having answered badly when it was never asked.
+            if (e is CancellationException) throw e
             item.complianceResults.update {
                 it + (relay to ComplianceStatus.ERROR)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/NamecoinSharedPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/NamecoinSharedPreferences.kt
@@ -166,7 +166,8 @@ class NamecoinSharedPreferences(
             } else {
                 emptyList()
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             emptyList()
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/NappletResourceFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/NappletResourceFetcher.kt
@@ -60,6 +60,7 @@ import java.net.URLDecoder
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Fetches a resource URL on an applet's behalf — the applet has no direct network
@@ -162,7 +163,10 @@ class NappletResourceFetcher(
                 return failure(ERROR_BLOCKED, e.message)
             } catch (_: InterruptedIOException) {
                 return failure(ERROR_TIMEOUT)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                // Cancellation is not an upstream failure — do not report it to the
+                // napplet as one, and do not keep the request alive past it.
+                if (e is CancellationException) throw e
                 return failure(ERROR_NETWORK)
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -201,6 +201,9 @@ class EventNotificationConsumer(
             .onFailure { Log.d(TAG) { "Skipping non-decodable npub $npub: ${it.message}" } }
             .getOrNull()
 
+    // GitReplyEvent (kind 1622) is deprecated in favour of NIP-22 comments, but
+    // events already on relays still arrive and still have to be routed.
+    @Suppress("DEPRECATION")
     private suspend fun dispatchForAccount(
         event: Event,
         account: Account,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
@@ -112,6 +112,9 @@ class NotificationDispatcher(
         // recipient account.
         // `internal` (was `private`) so the notification-kinds contract test
         // can pin the push-side kind set against the in-app feed's kind set.
+        // GitReplyEvent (kind 1622) is deprecated in favour of NIP-22 comments, but
+        // events already on relays still arrive and still have to be routed.
+        @Suppress("DEPRECATION")
         internal val NOTIFICATION_KINDS: Set<Int> =
             setOf(
                 // Direct-arrival

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/renderers/CodeNotification.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/renderers/CodeNotification.kt
@@ -81,6 +81,9 @@ object CodeNotification {
         event: GitPullRequestUpdateEvent,
     ) = post(context, account, event.id, event.createdAt, event.pubKey, R.string.app_notification_code_channel_message_pr_update, event.content)
 
+    // GitReplyEvent (kind 1622) is deprecated in favour of NIP-22 comments, but
+    // events already on relays still arrive and still have to be rendered.
+    @Suppress("DEPRECATION")
     suspend fun notify(
         context: Context,
         account: Account,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -65,6 +65,7 @@ import org.webrtc.RtpSender
 import org.webrtc.VideoTrack
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "CallSession"
 private const val VIDEO_MAX_BITRATE_BPS_DEFAULT = 1_500_000
@@ -429,6 +430,7 @@ class CallSession(
             try {
                 withContext(Dispatchers.IO) { createWebRtcSession(peerPubKey) }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Log.e(TAG, "Failed to create PeerConnection for ${peerPubKey.take(8)}", e)
                 return
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LatexEquation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LatexEquation.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.sp
+import androidx.core.graphics.withTranslation
 import com.vitorpamplona.amethyst.commons.richtext.MathParser
 import ru.noties.jlatexmath.JLatexMathDrawable
 
@@ -130,12 +131,11 @@ fun LatexEquation(
         Canvas(modifier = equationModifier) {
             drawIntoCanvas { canvas ->
                 val native = canvas.nativeCanvas
-                val checkpoint = native.save()
                 // Position the icon's baseline on the text baseline within the padded box.
-                native.translate(0f, drawTopPx)
-                drawable.setBounds(0, 0, drawable.intrinsicWidth, drawable.intrinsicHeight)
-                drawable.draw(native)
-                native.restoreToCount(checkpoint)
+                native.withTranslation(y = drawTopPx) {
+                    drawable.setBounds(0, 0, drawable.intrinsicWidth, drawable.intrinsicHeight)
+                    drawable.draw(this)
+                }
             }
         }
         if (trailing.isNotEmpty()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/location/LocationPreviewMap.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/location/LocationPreviewMap.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.amethyst.ui.note.creators.location
 import android.graphics.ColorFilter
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
-import android.graphics.drawable.BitmapDrawable
 import android.view.MotionEvent
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.graphics.drawable.toDrawable
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -159,7 +159,7 @@ fun LocationPreviewMap(
         remember(pinColor, pinEmoji) {
             if (pinColor != null && pinEmoji != null) {
                 val bitmap = roadEventPinBitmap(pinEmoji, pinColor.toArgb(), context.resources.displayMetrics.density)
-                BitmapDrawable(context.resources, bitmap)
+                bitmap.toDrawable(context.resources)
             } else {
                 null
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
@@ -118,6 +118,5 @@ open class UserFeedViewModel(
     override fun onCleared() {
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
         bundler.cancel()
-        super.onCleared()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2647,7 +2647,6 @@ class AccountViewModel(
         com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity.NestBridge
             .clear()
         feedStates.destroy()
-        super.onCleared()
     }
 
     fun loadMentions(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentConsoleViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentConsoleViewModel.kt
@@ -310,7 +310,6 @@ class AgentConsoleViewModel : ViewModel() {
     override fun onCleared() {
         stopObserving()
         stopWatching()
-        super.onCleared()
     }
 
     /** One decrypted observer telemetry frame rendered on the Observer tab. */

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentWorkBoardViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentWorkBoardViewModel.kt
@@ -218,7 +218,6 @@ class AgentWorkBoardViewModel : ViewModel() {
 
     override fun onCleared() {
         stopWatching()
-        super.onCleared()
     }
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmListViewModel.kt
@@ -360,6 +360,5 @@ class BuzzDmListViewModel : ViewModel() {
     override fun onCleared() {
         liveJob?.cancel()
         liveJob = null
-        super.onCleared()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/JobBoardViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/JobBoardViewModel.kt
@@ -137,7 +137,6 @@ class JobBoardViewModel : ViewModel() {
 
     override fun onCleared() {
         stopWatching()
-        super.onCleared()
     }
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/WorkflowRunBoardViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/WorkflowRunBoardViewModel.kt
@@ -258,7 +258,6 @@ class WorkflowRunBoardViewModel : ViewModel() {
 
     override fun onCleared() {
         stopWatching()
-        super.onCleared()
     }
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/calendars/CalendarEventListCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/calendars/CalendarEventListCard.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -58,11 +59,15 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 // Thread-safe and hoisted: previously each CalendarDateBadge recompose allocated a new
 // SimpleDateFormat, which (a) is not thread-safe and (b) created 500 allocations while scrolling.
-private val MonthShortFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("MMM", Locale.getDefault())
+// Cached per locale rather than in a single val that captures the locale once: the month
+// names have to follow a language the user changes while the app is running.
+private val monthShortFormatters = ConcurrentHashMap<Locale, DateTimeFormatter>()
+
+private fun monthShortFormatter(locale: Locale): DateTimeFormatter = monthShortFormatters.getOrPut(locale) { DateTimeFormatter.ofPattern("MMM", locale) }
 
 @Composable
 fun CalendarEventListCard(
@@ -214,7 +219,10 @@ private fun CalendarDateBadge(startSeconds: Long?) {
             Instant.ofEpochSecond(startSeconds).atZone(ZoneId.systemDefault()).toLocalDate()
         }
     val day = localDate.dayOfMonth.toString()
-    val month = remember(localDate) { MonthShortFormatter.format(localDate).uppercase() }
+    // LocalLocale rather than Locale.getDefault(): the latter is not observable, so a
+    // locale change while the app runs would leave the month name in the old language.
+    val locale = LocalLocale.current.platformLocale
+    val month = remember(localDate, locale) { monthShortFormatter(locale).format(localDate).uppercase() }
 
     Column(
         modifier = Modifier.size(width = 52.dp, height = 60.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/calendars/create/NewCalendarCollectionViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/calendars/create/NewCalendarCollectionViewModel.kt
@@ -109,7 +109,6 @@ class NewCalendarCollectionViewModel : ViewModel() {
 
     override fun onCleared() {
         liveScanJob?.cancel()
-        super.onCleared()
     }
 
     fun toggle(address: Address) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/send/MarmotFileUploader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/send/MarmotFileUploader.kt
@@ -119,7 +119,6 @@ class MarmotFileUploader(
             // imprecisely.
             val canonicalMediaType = MarmotMediaType.canonicalize(mimeType) ?: GENERIC_MEDIA_TYPE
             val cipher = EncryptedMediaV2Cipher(exporterSecret, canonicalMediaType, filename)
-            val v2Cipher = cipher
 
             item.orchestrator.uploadEncrypted(
                 uri = media.uri,
@@ -142,21 +141,19 @@ class MarmotFileUploader(
                 // compression and metadata stripping — because that is what the
                 // key was derived from.
                 val reference =
-                    v2Cipher?.let {
-                        EncryptedMediaReferenceV2(
-                            locators =
-                                listOf(
-                                    MediaLocatorV2(EncryptedMediaPolicyV2.INITIAL_LOCATOR_KIND, serverResult.url),
-                                ),
-                            ciphertextSha256 = it.ciphertextSha256,
-                            plaintextSha256 = it.plaintextSha256,
-                            nonce = it.nonce,
-                            mediaType = it.mediaType,
-                            filename = filename,
-                            dim = serverResult.fileHeader.dim?.toString(),
-                            thumbhash = serverResult.fileHeader.thumbHash?.thumbhash,
-                        )
-                    }
+                    EncryptedMediaReferenceV2(
+                        locators =
+                            listOf(
+                                MediaLocatorV2(EncryptedMediaPolicyV2.INITIAL_LOCATOR_KIND, serverResult.url),
+                            ),
+                        ciphertextSha256 = cipher.ciphertextSha256,
+                        plaintextSha256 = cipher.plaintextSha256,
+                        nonce = cipher.nonce,
+                        mediaType = cipher.mediaType,
+                        filename = filename,
+                        dim = serverResult.fileHeader.dim?.toString(),
+                        thumbhash = serverResult.fileHeader.thumbHash?.thumbhash,
+                    )
                 results.add(
                     Mip04UploadResult(
                         url = serverResult.url,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
@@ -801,7 +801,6 @@ class ChatNewMessageViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
@@ -1027,7 +1027,6 @@ open class ChannelNewMessageViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessViewModelNew.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessViewModelNew.kt
@@ -132,7 +132,6 @@ class ChessViewModelNew(
     fun clearFocusedGame() = logic.clearFocusedGame()
 
     override fun onCleared() {
-        super.onCleared()
         logic.stopPolling()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
@@ -739,7 +739,6 @@ class LongFormPostViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
@@ -612,7 +612,6 @@ open class NewProductViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -1977,7 +1977,6 @@ open class ShortNotePostViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         writingAssistant?.close()
         writingAssistant = null
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/VoiceReplyViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/VoiceReplyViewModel.kt
@@ -320,7 +320,6 @@ class VoiceReplyViewModel : ViewModel() {
 
     override fun onCleared() {
         cancel()
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/music/AddToMusicPlaylistViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/music/AddToMusicPlaylistViewModel.kt
@@ -102,7 +102,6 @@ class AddToMusicPlaylistViewModel : ViewModel() {
 
     override fun onCleared() {
         liveScanJob?.cancel()
-        super.onCleared()
     }
 
     private suspend fun rescan() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestNewMessageViewModel.kt
@@ -597,7 +597,6 @@ open class NestNewMessageViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -139,6 +139,9 @@ class NotificationFeedFilter(
                 AttestationRequestEvent.KIND,
             )
 
+        // GitReplyEvent (kind 1622) is deprecated in favour of NIP-22 comments, but
+        // events already on relays still arrive and still have to be routed.
+        @Suppress("DEPRECATION")
         val NOTIFICATION_KINDS =
             // Kinds that RENDER as a row on the Notifications tab. This is a
             // display gate over whatever is already in LocalCache — it plays no
@@ -268,6 +271,9 @@ class NotificationFeedFilter(
 
         // Shared with EventNotificationConsumer so push notifications and the
         // in-app feed apply the same per-kind "is this event for me" rule.
+        // GitReplyEvent (kind 1622) is deprecated in favour of NIP-22 comments, but
+        // events already on relays still arrive and still have to be routed.
+        @Suppress("DEPRECATION")
         fun tagsAnEventByUser(
             note: Note,
             authorHex: HexKey,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
@@ -660,7 +660,6 @@ class NewPublicMessageViewModel :
     }
 
     override fun onCleared() {
-        super.onCleared()
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedViewModel.kt
@@ -196,6 +196,5 @@ class RelayFeedViewModel :
 
     override fun onCleared() {
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
-        super.onCleared()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -116,6 +116,5 @@ open class StringFeedViewModel(
     override fun onCleared() {
         Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
         bundler.cancel()
-        super.onCleared()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/NewHlsVideoViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/NewHlsVideoViewModel.kt
@@ -180,7 +180,6 @@ open class NewHlsVideoViewModel : ViewModel() {
     }
 
     override fun onCleared() {
-        super.onCleared()
         currentJob?.cancel()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/ReloadMintViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/ReloadMintViewModel.kt
@@ -459,7 +459,6 @@ class ReloadMintViewModel : ViewModel() {
         // The pipeline runs on the AccountViewModel scope, not this VM's, so it would
         // outlive the screen — cancel it when the screen goes away.
         job?.cancel()
-        super.onCleared()
     }
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TopUpMintViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/TopUpMintViewModel.kt
@@ -267,7 +267,6 @@ class TopUpMintViewModel : ViewModel() {
         // The pipeline runs on the AccountViewModel scope, not this VM's, so it would
         // outlive the screen — cancel it when the screen goes away.
         job?.cancel()
-        super.onCleared()
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/wizard/CashuWalletWizardViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/wizard/CashuWalletWizardViewModel.kt
@@ -293,7 +293,6 @@ class CashuWalletWizardViewModel : ViewModel() {
     }
 
     override fun onCleared() {
-        super.onCleared()
         discovery?.cancel()
     }
 }

--- a/amethyst/src/main/res/values/colors.xml
+++ b/amethyst/src/main/res/values/colors.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
-    <color name="transparent">#00FFFFFF</color>
 
     <!-- Launch splash / window background. Tracks MaterialTheme's background so the
          first composed frame does not step to a different colour. See values-night. -->

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LocalCacheSearchParityTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LocalCacheSearchParityTest.kt
@@ -47,6 +47,9 @@ import java.io.File
  */
 class LocalCacheSearchParityTest {
     companion object {
+        /** Hoisted out of [loadCorpus]: building a Json format is expensive enough that the compiler warns on it. */
+        private val json = Json { ignoreUnknownKeys = true }
+
         private lateinit var corpus: List<Event>
 
         @BeforeClass
@@ -57,7 +60,7 @@ class LocalCacheSearchParityTest {
                     .firstOrNull { it.isFile }
                     ?: error("tools/search-parity/fixture.json is missing; run tools/search-parity/fetch_fixtures.py")
 
-            val root = Json { ignoreUnknownKeys = true }.parseToJsonElement(file.readText()).jsonObject
+            val root = json.parseToJsonElement(file.readText()).jsonObject
             corpus =
                 root["cases"]!!
                     .jsonArray

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthPromptBusTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthPromptBusTest.kt
@@ -153,6 +153,7 @@ class RelayAuthPromptBusTest {
      * answer already sitting in the deferred, so the relay it belongs to goes unauthenticated for that
      * long despite the user having answered. Marking it shown is what makes the answer land now.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun anAnswerFannedOutToAQueuedPromptLandsWithoutWaitingOutTheQueueWindow() =
         runTest {

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthSessionGrantsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthSessionGrantsTest.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthPermissionStore
 import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthPolicy
 import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthVerdict
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -185,6 +186,7 @@ class RelayAuthSessionGrantsTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun promotingAGrantToAlwaysNeverOpensAGapThatRePrompts() =
         runTest {
@@ -205,6 +207,7 @@ class RelayAuthSessionGrantsTest {
             assertEquals(RelayAuthVerdict.ALLOW, ledger.decide(askable(relay)))
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun neverAllowStopsAuthenticatingBeforeItsWriteLands() =
         runTest {

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/Nip34NotificationCoverageTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/Nip34NotificationCoverageTest.kt
@@ -70,6 +70,7 @@ class Nip34NotificationCoverageTest {
      * A NIP-22 [com.vitorpamplona.quartz.nip22Comments.CommentEvent] handles
      * modern comments through its own separate wiring.
      */
+    @Suppress("DEPRECATION")
     private val nip34ParticipantKinds =
         setOf(
             GitPatchEvent.KIND,
@@ -131,6 +132,7 @@ class Nip34NotificationCoverageTest {
      * uppercase `E`. Asserting the wrong half passes the kind list while matching
      * nothing on the wire.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun `status kinds are pulled by the lowercase-e engagement subscription`() {
         val eAnchoredActivityKinds =

--- a/benchmark/src/androidTest/java/com/vitorpamplona/quartz/benchmark/HexBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/vitorpamplona/quartz/benchmark/HexBenchmark.kt
@@ -136,7 +136,7 @@ class HexBenchmark {
     /** The pre-existing two-pass way to safely decode an id, for comparison with [hexDecode64OrNull]. */
     @Test
     fun hexIsHex64ThenDecode() {
-        r.measureRepeated { if (Hex.isHex64(hex)) Hex.decode(hex) else null }
+        r.measureRepeated { if (Hex.isHex64(hex)) Hex.decode(hex) }
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,18 +9,18 @@ import java.util.Properties
 // compiles this buildscript {} section in an earlier stage that can't see the
 // file's imports (hence the qualified Properties) or share code with the body,
 // but it can publish values — the gate is computed once here and read below
-// via `by extra`.
+// via the project's extra properties.
 buildscript {
     val localProperties = File(rootDir, "local.properties")
-    val sonarProperties by extra(
+    val sonarProperties =
         java.util.Properties().apply {
             if (localProperties.exists()) localProperties.inputStream().use { load(it) }
-        },
-    )
-    val sonarEnabled by extra(
+        }
+    extra.set("sonarProperties", sonarProperties)
+    val sonarEnabled =
         sonarProperties.getProperty("sonar.host.url") != null &&
-            gradle.startParameter.taskNames.any { it.substringAfterLast(":") in setOf("sonar", "sonarqube") },
-    )
+            gradle.startParameter.taskNames.any { it.substringAfterLast(":") in setOf("sonar", "sonarqube") }
+    extra.set("sonarEnabled", sonarEnabled)
     if (sonarEnabled) {
         repositories {
             gradlePluginPortal()
@@ -110,9 +110,9 @@ subprojects {
 // `./gradlew sonar` behaves exactly like passing them via -Dsonar.xxx=... on the
 // command line. sonar.projectKey/projectName default to the root project name
 // ("Amethyst") and only need overriding in local.properties if desired.
-val sonarEnabled: Boolean by extra
+val sonarEnabled = extra["sonarEnabled"] as Boolean
 if (sonarEnabled) {
-    val sonarProperties: Properties by extra
+    val sonarProperties = extra["sonarProperties"] as Properties
     apply(plugin = "org.sonarqube")
 
     sonarProperties

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -110,7 +110,7 @@ application {
 // JVM decodes each one as ASCII (every byte > 0x7F → U+FFFD), and amy
 // then signs a kind:7 whose `content` is four replacement characters.
 // Whitenoise rejects it with "Invalid reaction content".
-val patchAmyLauncherCharset by tasks.registering {
+val patchAmyLauncherCharset = tasks.register("patchAmyLauncherCharset") {
     val appName = application.applicationName
     val startScriptsTask = tasks.named("startScripts")
     dependsOn(startScriptsTask)

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -278,7 +278,7 @@ tasks.withType<Test>().configureEach {
 // there. Commons gains this gate once FeedDefinitionSerializer.kt has been
 // migrated off Jackson; future commonMain code must not reintroduce JVM-only
 // JSON / HTTP deps.
-val verifyKmpPurity by tasks.registering {
+val verifyKmpPurity = tasks.register("verifyKmpPurity") {
     group = "verification"
     description = "Fails if iOS-targeted source sets import JVM-only deps."
     val checkedDirs =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotAgentStreamWatcher.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotAgentStreamWatcher.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * What a front end renders for one live agent text stream.
@@ -203,6 +204,9 @@ class MarmotAgentStreamWatcher(
                 try {
                     quic.subscribe(candidate, start.streamId.hexToByteArray(), startEvent.id.hexToByteArray())
                 } catch (e: Exception) {
+                    // Without this a cancelled watcher keeps dialling the remaining
+                    // candidates instead of stopping.
+                    if (e is CancellationException) throw e
                     Log.d("MarmotAgentStreamWatcher") { "candidate $candidate unusable: ${e.message}" }
                     continue
                 }
@@ -222,6 +226,7 @@ class MarmotAgentStreamWatcher(
                         )
                 }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Log.d("MarmotAgentStreamWatcher") { "stream from $candidate ended: ${e.message}" }
             } finally {
                 runCatching { stream.close() }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
@@ -68,6 +68,5 @@ abstract class FeedViewModel(
 
     override fun onCleared() {
         Log.d("Init") { "OnCleared: ${this::class.simpleName}" }
-        super.onCleared()
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/LiveStreamTopZappersViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/LiveStreamTopZappersViewModel.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nipB1Bolt12Zaps.zap.Bolt12ZapEvent
+import com.vitorpamplona.quartz.utils.toLongValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
@@ -162,7 +163,7 @@ class LiveStreamTopZappersViewModel(
         when (val ev = note.event) {
             is LnZapEvent -> {
                 val request = ev.zapRequest ?: return null
-                val sats = ev.amount()?.toLong() ?: return null
+                val sats = ev.amount()?.toLongValue() ?: return null
                 ZapContribution(note.idHex, request.pubKey, request.isAnonTagged(), sats)
             }
             is Bolt12ZapEvent -> {
@@ -178,7 +179,7 @@ class LiveStreamTopZappersViewModel(
     ): ZapContribution? {
         val receiptEv = receiptNote?.event as? LnZapEvent ?: return null
         val request = zapRequestNote.event as? LnZapRequestEvent ?: return null
-        val sats = receiptEv.amount()?.toLong() ?: return null
+        val sats = receiptEv.amount()?.toLongValue() ?: return null
         return ZapContribution(receiptNote.idHex, request.pubKey, request.isAnonTagged(), sats)
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomZapsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomZapsState.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.commons.viewmodels
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nipB1Bolt12Zaps.zap.Bolt12ZapEvent
+import com.vitorpamplona.quartz.utils.toLongValue
 
 /**
  * One in-flight kind-9735 zap to render as a floating overlay on the
@@ -59,7 +60,7 @@ data class RoomZap(
                 eventId = event.id,
                 sourcePubkey = event.zapRequest?.pubKey ?: event.pubKey,
                 targetPubkey = event.zappedAuthor().firstOrNull(),
-                amountSats = event.amount?.toLong(),
+                amountSats = event.amount?.toLongValue(),
                 createdAtSec = event.createdAt,
             )
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/search/PartialTokensTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/search/PartialTokensTest.kt
@@ -38,7 +38,7 @@ class PartialTokensTest {
     fun aHalfWrittenFromOpensThePeoplePicker() {
         val picker = pickerAtEnd("zaps from:ali")
         assertTrue(picker is ActivePicker.People)
-        assertEquals(KeyField.FROM, (picker as ActivePicker.People).keyField)
+        assertEquals(KeyField.FROM, picker.keyField)
         assertEquals("ali", picker.token.partial)
         assertEquals(5, picker.token.start)
     }
@@ -65,7 +65,7 @@ class PartialTokensTest {
     fun aHalfWrittenDateOpensTheCalendar() {
         val picker = pickerAtEnd("since:2026-0")
         assertTrue(picker is ActivePicker.Calendar)
-        assertEquals(DateField.SINCE, (picker as ActivePicker.Calendar).dateField)
+        assertEquals(DateField.SINCE, picker.dateField)
     }
 
     @Test

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -838,7 +838,6 @@ class NestViewModel(
         closed = true
         teardownBroadcast(BroadcastUiState.Idle, finalCleanup = true)
         teardown(targetState = ConnectionUiState.Closed, finalCleanup = true)
-        super.onCleared()
     }
 
     private fun observeSpeakerState(s: NestsSpeaker) {

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotPublishBeforeApplyTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotPublishBeforeApplyTest.kt
@@ -461,9 +461,9 @@ class MarmotPublishBeforeApplyTest {
 
         override suspend fun saveRetainedEpochs(
             nostrGroupId: String,
-            epochs: List<ByteArray>,
+            retainedSecrets: List<ByteArray>,
         ) {
-            retained[nostrGroupId] = epochs
+            retained[nostrGroupId] = retainedSecrets
         }
 
         override suspend fun loadRetainedEpochs(nostrGroupId: String): List<ByteArray> = retained[nostrGroupId] ?: emptyList()

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotPublishDurabilityTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotPublishDurabilityTest.kt
@@ -105,9 +105,9 @@ class MarmotPublishDurabilityTest {
 
         override suspend fun saveRetainedEpochs(
             nostrGroupId: String,
-            epochs: List<ByteArray>,
+            retainedSecrets: List<ByteArray>,
         ) {
-            retained[nostrGroupId] = epochs
+            retained[nostrGroupId] = retainedSecrets
         }
 
         override suspend fun loadRetainedEpochs(nostrGroupId: String): List<ByteArray> = retained[nostrGroupId].orEmpty()

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -254,7 +254,7 @@ compose.desktop {
 // The arch is selected at task-execution time from the host JVM's os.arch, so
 // the same task builds the correct AppImage on both x86_64 and aarch64 hosts.
 // BUILDING.md documents local-dev fetch.
-val createReleaseAppImage by tasks.registering(Exec::class) {
+val createReleaseAppImage = tasks.register<Exec>("createReleaseAppImage") {
     group = "compose desktop"
     description = "Package createReleaseDistributable output into a Linux AppImage via appimagetool."
     dependsOn("createReleaseDistributable")
@@ -330,7 +330,7 @@ val createReleaseAppImage by tasks.registering(Exec::class) {
 // proguarded jkeychain-1.1.0-*.jar with all 117 KB intact), so this task is
 // a regression guard, not a workaround. It's wired onto every release task so
 // it fails the build immediately if the .so disappears.
-val verifyJkeychainNativeSurvivesProguard by tasks.registering {
+val verifyJkeychainNativeSurvivesProguard = tasks.register("verifyJkeychainNativeSurvivesProguard") {
     description = "Fail the release build if osxkeychain.so is stripped from proguarded output (would break macOS Keychain at runtime)"
     group = "verification"
     dependsOn("proguardReleaseJars")
@@ -395,7 +395,7 @@ listOf(
 // into the .app) so the subsequent bundle signing seals already-signed code.
 // Runs only on macOS with the Developer ID identity exported — a no-op on every
 // other leg and on unsigned local/PR builds.
-val signMacJarNatives by tasks.registering {
+val signMacJarNatives = tasks.register("signMacJarNatives") {
     description = "Codesign macOS Mach-O natives embedded in bundled jars before the .app is sealed + notarized"
     group = "build"
     dependsOn("proguardReleaseJars")

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/live/LivesSection.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/live/LivesSection.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.FlowRowOverflow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -146,7 +145,6 @@ fun LivesSection(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 maxLines = 2,
-                overflow = FlowRowOverflow.Clip,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 ranked.forEach { channel ->

--- a/geode/build.gradle.kts
+++ b/geode/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
 // Generate a BuildConfig.kt carrying the app version from the catalog so
 // RelayInfo.VERSION (reported over NIP-11) tracks releases automatically
 // instead of being a hand-bumped literal.
-val generateVersionFile by tasks.registering {
+val generateVersionFile = tasks.register("generateVersionFile") {
     val versionValue = libs.versions.app.get()
     val outDir = layout.buildDirectory.dir("generated/version/kotlin")
     inputs.property("version", versionValue)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ uiautomator = "2.4.0"
 biometricKtx = "1.4.0-alpha02"
 coil = "3.6.2"
 composeBom = "2026.09.00"
+tracingPerfetto = "1.0.1"
 composeRuntimeAnnotation = "1.12.1"
 coreKtx = "1.19.0"
 datastore = "1.2.1"
@@ -136,6 +137,9 @@ androidx-camera-extensions = { module = "androidx.camera:camera-extensions", ver
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "androidxCamera" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "androidxCamera" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-runtime-tracing = { group = "androidx.compose.runtime", name = "runtime-tracing" }
+androidx-tracing-perfetto = { group = "androidx.tracing", name = "tracing-perfetto", version.ref = "tracingPerfetto" }
+androidx-tracing-perfetto-binary = { group = "androidx.tracing", name = "tracing-perfetto-binary", version.ref = "tracingPerfetto" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-runtime-annotation = { group = "androidx.compose.runtime", name = "runtime-annotation", version.ref = "composeRuntimeAnnotation" }
 androidx-collection = { group = "androidx.collection", name = "collection", version.ref = "androidxCollection" }

--- a/marmotBench/src/main/kotlin/com/vitorpamplona/marmotbench/MarmotBenchmarks.kt
+++ b/marmotBench/src/main/kotlin/com/vitorpamplona/marmotbench/MarmotBenchmarks.kt
@@ -24,12 +24,10 @@ import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.marmot.ingest
 import com.vitorpamplona.quartz.marmot.appComponents.GroupProfileV1
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageEvent
-import com.vitorpamplona.quartz.marmot.mip03GroupMessages.GroupEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
-import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.RandomInstance
 import kotlinx.coroutines.runBlocking
 
@@ -170,7 +168,7 @@ fun benchJoinWelcome(): BenchResult =
             }
         },
     ) { (bob, wrap) ->
-        runBlocking { bob.manager.ingest(wrap as GiftWrapEvent) }
+        runBlocking { bob.manager.ingest(wrap) }
     }
 
 /**
@@ -223,7 +221,7 @@ fun benchIngestAppMessage(members: Int): BenchResult =
             }
         },
     ) { (bob, event) ->
-        runBlocking { bob.manager.ingest(event as GroupEvent) }
+        runBlocking { bob.manager.ingest(event) }
     }
 
 private const val BENCH_RELAY = "wss://bench.invalid"

--- a/nestsClient/build.gradle.kts
+++ b/nestsClient/build.gradle.kts
@@ -154,7 +154,7 @@ val hangInteropCacheDir =
 val moqRelayVersion = "0.10.25"
 val moqTokenCliVersion = "0.5.23"
 
-val interopInstallMoqRelay by tasks.registering(Exec::class) {
+val interopInstallMoqRelay = tasks.register<Exec>("interopInstallMoqRelay") {
     description = "cargo install moq-relay $moqRelayVersion (interop)"
     group = "interop"
     commandLine(
@@ -178,7 +178,7 @@ val interopInstallMoqRelay by tasks.registering(Exec::class) {
     doFirst { hangInteropCacheDir.asFile.mkdirs() }
 }
 
-val interopInstallMoqTokenCli by tasks.registering(Exec::class) {
+val interopInstallMoqTokenCli = tasks.register<Exec>("interopInstallMoqTokenCli") {
     description = "cargo install moq-token-cli $moqTokenCliVersion (interop)"
     group = "interop"
     commandLine(
@@ -201,7 +201,7 @@ val interopInstallMoqTokenCli by tasks.registering(Exec::class) {
     doFirst { hangInteropCacheDir.asFile.mkdirs() }
 }
 
-val interopBuildSidecars by tasks.registering(Exec::class) {
+val interopBuildSidecars = tasks.register<Exec>("interopBuildSidecars") {
     description = "cargo build --release for nestsClient/tests/hang-interop sidecars"
     group = "interop"
     workingDir = hangInteropDir.asFile
@@ -226,7 +226,7 @@ val interopBuildSidecars by tasks.registering(Exec::class) {
     outputs.dir(hangInteropDir.dir("target/release"))
 }
 
-val interopBuildHangSidecars by tasks.registering {
+val interopBuildHangSidecars = tasks.register("interopBuildHangSidecars") {
     description = "Build all hang-interop binaries (sidecars + moq-relay + moq-token)."
     group = "interop"
     dependsOn(interopBuildSidecars, interopInstallMoqRelay, interopInstallMoqTokenCli)
@@ -305,7 +305,7 @@ fun resolveBunBinary(): String {
 fun resolveNpxBinary(): String =
     System.getenv("NPX_BIN") ?: System.getProperty("npxBin") ?: "npx"
 
-val interopBuildBrowserHarness by tasks.registering(Exec::class) {
+val interopBuildBrowserHarness = tasks.register<Exec>("interopBuildBrowserHarness") {
     description = "bun install && bun build for the browser interop harness"
     group = "interop"
     workingDir = browserInteropDir.asFile
@@ -325,7 +325,7 @@ val interopBuildBrowserHarness by tasks.registering(Exec::class) {
     outputs.dir(browserInteropDir.dir("dist"))
 }
 
-val interopInstallPlaywrightChromium by tasks.registering(Exec::class) {
+val interopInstallPlaywrightChromium = tasks.register<Exec>("interopInstallPlaywrightChromium") {
     description = "Install Playwright Chromium + dependencies for the browser interop harness"
     group = "interop"
     workingDir = browserInteropDir.asFile

--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -304,11 +304,11 @@ kotlin {
             dependsOn(appleMain)
         }
 
-        val iosArm64Main by getting {
+        getByName("iosArm64Main") {
             dependsOn(iosMain.get())
         }
 
-        val iosSimulatorArm64Main by getting {
+        getByName("iosSimulatorArm64Main") {
             dependsOn(iosMain.get())
         }
 
@@ -316,11 +316,11 @@ kotlin {
             dependsOn(appleTest)
         }
 
-        val iosArm64Test by getting {
+        getByName("iosArm64Test") {
             dependsOn(iosTest.get())
         }
 
-        val iosSimulatorArm64Test by getting {
+        getByName("iosSimulatorArm64Test") {
             dependsOn(iosTest.get())
         }
 
@@ -334,11 +334,11 @@ kotlin {
                 dependsOn(appleTest)
             }
 
-        val macosArm64Main by getting {
+        getByName("macosArm64Main") {
             dependsOn(macosMain)
         }
 
-        val macosArm64Test by getting {
+        getByName("macosArm64Test") {
             dependsOn(macosTest)
         }
 
@@ -355,11 +355,11 @@ kotlin {
                 dependsOn(nativeTest)
             }
 
-        val linuxX64Main by getting {
+        getByName("linuxX64Main") {
             dependsOn(linuxMain)
         }
 
-        val linuxX64Test by getting {
+        getByName("linuxX64Test") {
             dependsOn(linuxTest)
         }
     }
@@ -383,7 +383,7 @@ dependencies {
 // Scope: source sets whose code is compiled for at least one non-JVM
 // target. Excludes jvmAndroid, jvmMain, androidMain (and their tests),
 // where Jackson and OkHttp are legitimately used.
-val verifyKmpPurity by tasks.registering {
+val verifyKmpPurity = tasks.register("verifyKmpPurity") {
     group = "verification"
     description = "Fails if iOS-targeted source sets import JVM-only deps."
     val checkedDirs =

--- a/quartz/src/androidDeviceTest/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/Nip46Test.kt
+++ b/quartz/src/androidDeviceTest/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/Nip46Test.kt
@@ -56,6 +56,10 @@ internal class Nip46Test {
             sig = "ec39e60722a083cccbd2d82d2827e13f5499fa7cbcedac5b76011a844c077473adb629d50d01fab147835ac6c8a3d5ba9aaddd87d6723f0c3c864b9119fc4356",
         )
 
+    // The round trip is only type-safe by construction: the caller hands in a T,
+    // the message is encoded and decoded, and the decoder returns the same
+    // BunkerMessage subtype. The runtime has no way to check that.
+    @Suppress("UNCHECKED_CAST")
     suspend fun <T : BunkerMessage> encodeDecodeEvent(req: T): T {
         val eventStr = NostrConnectEvent.create(req, remoteKey.pubKey, signer).toJson()
 

--- a/quartz/src/appleMain/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.apple.kt
+++ b/quartz/src/appleMain/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.apple.kt
@@ -20,18 +20,4 @@
  */
 package com.vitorpamplona.quartz.utils
 
-operator fun BigDecimal.plus(other: BigDecimal): BigDecimal = add(other)
-
-operator fun BigDecimal.minus(other: BigDecimal): BigDecimal = subtract(other)
-
-/**
- * Truncate to a Long, the way Number.toLong() does on every platform.
- *
- * It has to be an expect *function* rather than a member of `expect class
- * BigDecimal`: every actual is already a Number and so already has toLong(),
- * but java.math.BigDecimal leaves toByte()/toShort() abstract, which makes
- * `expect class BigDecimal : Number` impossible to actualize with the JVM
- * typealias. Without this, `amount.toLong()` in shared code resolves only in
- * the platform compilations and breaks `compileCommonMainKotlinMetadata`.
- */
-expect fun BigDecimal.toLongValue(): Long
+actual fun BigDecimal.toLongValue(): Long = toLong()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/MarmotInboundProcessor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/MarmotInboundProcessor.kt
@@ -760,7 +760,7 @@ class MarmotInboundProcessor(
         val author = payloadAuthor(candidate.content.decodeToString())
         val sender = candidate.senderAccount
         val valid = author != null && sender != null && author == sender
-        if (valid && sender != null) {
+        if (valid) {
             convergence.recordWitness(groupId, candidate.stateId, sender)
         }
         return GroupEventResult.AppMessageOnCandidateBranch(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/protocolCore/MarmotConvergenceEngine.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/protocolCore/MarmotConvergenceEngine.kt
@@ -561,7 +561,7 @@ class MarmotConvergenceEngine(
 
         return mutex.withLock {
             val ctx = contexts[groupId] ?: return@withLock null
-            if (rewound && selectedTipId != null) {
+            if (rewound) {
                 adoptBranch(ctx, graph, selectedTipId, inputs.baseId)
             }
             // Keep the states of branches that LOST but stay eligible: losing
@@ -576,7 +576,7 @@ class MarmotConvergenceEngine(
                 .forEach { tipId ->
                     var cursor: String? = tipId
                     while (cursor != null && cursor !in canonical) {
-                        graph.statesById[cursor]?.let { ctx.candidateStates[cursor!!] = it }
+                        graph.statesById[cursor]?.let { ctx.candidateStates[cursor] = it }
                         cursor = graph.parentOf[cursor]
                     }
                 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/AuthOutcomeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/AuthOutcomeTest.kt
@@ -61,7 +61,7 @@ class AuthOutcomeTest {
             phase: RelayAuthSnapshot.Phase,
             successCount: Int = 0,
         ) {
-            state.value = state.value.put(relay, RelayAuthSnapshot(phase, null, successCount))
+            state.value = state.value.putting(relay, RelayAuthSnapshot(phase, null, successCount))
         }
     }
 

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.jvmAndroid.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.jvmAndroid.kt
@@ -20,18 +20,4 @@
  */
 package com.vitorpamplona.quartz.utils
 
-operator fun BigDecimal.plus(other: BigDecimal): BigDecimal = add(other)
-
-operator fun BigDecimal.minus(other: BigDecimal): BigDecimal = subtract(other)
-
-/**
- * Truncate to a Long, the way Number.toLong() does on every platform.
- *
- * It has to be an expect *function* rather than a member of `expect class
- * BigDecimal`: every actual is already a Number and so already has toLong(),
- * but java.math.BigDecimal leaves toByte()/toShort() abstract, which makes
- * `expect class BigDecimal : Number` impossible to actualize with the JVM
- * typealias. Without this, `amount.toLong()` in shared code resolves only in
- * the platform compilations and breaks `compileCommonMainKotlinMetadata`.
- */
-expect fun BigDecimal.toLongValue(): Long
+actual fun BigDecimal.toLongValue(): Long = toLong()

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/LastResortKeyPackageReuseTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/LastResortKeyPackageReuseTest.kt
@@ -245,8 +245,8 @@ class LastResortKeyPackageReuseTest {
 
         override suspend fun load(): ByteArray? = bytes
 
-        override suspend fun save(data: ByteArray) {
-            bytes = data
+        override suspend fun save(snapshot: ByteArray) {
+            bytes = snapshot
         }
 
         override suspend fun delete() {

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/prodbench/InternTradeoffBenchmark.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/prodbench/InternTradeoffBenchmark.kt
@@ -110,10 +110,16 @@ class InternTradeoffBenchmark {
             }
         }
 
+    /**
+     * Holds the last measured corpus so the JIT cannot drop the allocations we
+     * just paid for. A field rather than a local: a local's assignments are
+     * visible to the compiler's data flow, which then folds the `check` below
+     * into a constant.
+     */
+    private var sink: Any? = null
+
     @Test
     fun internCostAndBenefit() {
-        var sink: Any? = null
-
         println("\n=== corpus: $EVENTS events, $AUTHORS authors, $RELAYS relays ===")
 
         // ---- memory ----

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableContentGoldenTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableContentGoldenTest.kt
@@ -131,7 +131,7 @@ class IndexableContentGoldenTest {
                         }
                     }
                 val rejoined = visited.joinToString(event.indexableSeparator())
-                if (rejoined == event.indexableContent()) null else "kind $kind: visitor=${rejoined.take(120)!!} content=${event.indexableContent().take(120)}"
+                if (rejoined == event.indexableContent()) null else "kind $kind: visitor=${rejoined.take(120)} content=${event.indexableContent().take(120)}"
             }
         assertEquals("visitor and indexed content disagree", emptyList<String>(), disagreements)
     }

--- a/quartz/src/linuxMain/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.linux.kt
+++ b/quartz/src/linuxMain/kotlin/com/vitorpamplona/quartz/utils/BigDecimalOps.linux.kt
@@ -20,18 +20,4 @@
  */
 package com.vitorpamplona.quartz.utils
 
-operator fun BigDecimal.plus(other: BigDecimal): BigDecimal = add(other)
-
-operator fun BigDecimal.minus(other: BigDecimal): BigDecimal = subtract(other)
-
-/**
- * Truncate to a Long, the way Number.toLong() does on every platform.
- *
- * It has to be an expect *function* rather than a member of `expect class
- * BigDecimal`: every actual is already a Number and so already has toLong(),
- * but java.math.BigDecimal leaves toByte()/toShort() abstract, which makes
- * `expect class BigDecimal : Number` impossible to actualize with the JVM
- * typealias. Without this, `amount.toLong()` in shared code resolves only in
- * the platform compilations and breaks `compileCommonMainKotlinMetadata`.
- */
-expect fun BigDecimal.toLongValue(): Long
+actual fun BigDecimal.toLongValue(): Long = toLong()

--- a/quic/interop/src/main/kotlin/com/vitorpamplona/quic/interop/runner/Http3GetClient.kt
+++ b/quic/interop/src/main/kotlin/com/vitorpamplona/quic/interop/runner/Http3GetClient.kt
@@ -203,9 +203,7 @@ class Http3GetClient(
                         body += frame.body
                     }
 
-                    else -> {
-                        Unit
-                    }
+                    else -> {}
                 }
             }
         }


### PR DESCRIPTION
Started as "review all warnings in all modules, flavors and compilation targets and fix them", then extended to a bug/performance audit of what the sweep walked past.

## Compiler warnings — 26 → 0

Across every module and both flavors, on every target compilable on Linux: jvm, android (play/fdroid × debug/release/benchmark), linuxX64, and the common/jvmAndroid/native/apple/ios metadata compilations.

- **Redundant conditions and casts.** K2 propagates smart casts through boolean `val`s, so `if (valid && sender != null)` and `if (rewound && selectedTipId != null)` had dead conjuncts, and `cursor!!` inside a `let` was already non-null. `kotlin.test.assertTrue` carries a `returns() implies` contract, so the `is` checks in `PartialTokensTest` already smart-cast.
- **Deprecations.** `PersistentMap.put` → `putting()` (what the rest of the codebase uses); `FlowRowOverflow`/`FlowRow(overflow =)` dropped, since the non-deprecated overload already clips beyond `maxLines`; the four instrumented Compose tests moved to `androidx.compose.ui.test.junit4.v2.createComposeRule`, which returns the same `ComposeContentTestRule`.
- **`GitReplyEvent` (NIP-34 kind 1622).** Deprecated in favour of NIP-22, but events already on relays still arrive and still have to be routed, rendered and surfaced — `@Suppress("DEPRECATION")` with that reason at the five production sites and the coverage test that pins them.
- **Override parameter names** aligned with their supertypes (`retainedSecrets`, `snapshot`), so named-argument calls through the interfaces stay correct.
- **Missing opt-ins** (`ExperimentalCoroutinesApi`), an unchecked cast that cannot be checked at runtime, an unnecessary `!!`, a stale nullable alias in `MarmotFileUploader`, a hoisted `Json` format, and a benchmark liveness anchor moved from a local to a field — as a local, its assignments were visible to data flow, which folded the trailing `check(sink != null)` into a constant.

## `:commons:compileCommonMainKotlinMetadata` did not compile at all

Not a warning — a pre-existing error. Shared code called `BigDecimal.toLong()`, which resolves in every platform compilation (every actual is a `Number`) but not in the common metadata one, where only the expect class's own members are visible.

`expect class BigDecimal : Number` cannot work: `java.math.BigDecimal` overrides only `intValue`/`longValue`/`floatValue`/`doubleValue` and leaves `toByte()`/`toShort()` abstract, so the JVM typealias fails the expect/actual modality check. The conversion is a top-level `expect fun BigDecimal.toLongValue()` instead, with actuals beside each `BigDecimal` actual (`jvmAndroid`, `appleMain`, `linuxMain`).

## Gradle 10 deprecations — 5 kinds, 19 sites → 0

Every build printed *"Deprecated Gradle features were used… incompatible with Gradle 10"*. All five were Kotlin DSL delegated properties in our own scripts:

| Was | Now | Sites |
|---|---|---|
| `val x by extra(…)` / `val x: T by extra` | `extra.set(…)` / `extra["x"] as T` | root script's Sonar gate |
| `val x by getting { }` | `getByName("x") { }` (what `commons` already did) | 8 quartz source sets |
| `val x by tasks.registering { }` (and the typed form) | `tasks.register("x") { }` / `register<T>("x") { }` | 13 tasks across 6 modules |

`register` returns the same `TaskProvider`, so the `dependsOn`/`finalizedBy` references are unchanged. `./gradlew --warning-mode all help` is now silent.

## Android Lint — 874 → 838 warnings, 0 errors

Took the mechanical, behaviour-preserving ones: 26 redundant `super.onCleared()` calls (`ViewModel.onCleared` is documented empty), two `UseKtx` swaps, six Android Studio wizard leftover colors, and the debug-only tracing dependencies moved into the version catalog.

`ConstantLocale` in `CalendarEventListCard` is worth calling out: the `"MMM"` formatter lived in a file-level `val`, so month abbreviations froze in whatever language was active at class-init. It is now cached per locale — keeping the property the original comment protected, that a formatter per recompose was 500 allocations while scrolling — and the locale comes from `LocalLocale.current.platformLocale`. Reading `Locale.getDefault()` inside a composable is *not* observable, and Compose's own `NonObservableLocale` check rates that an error.

**Not touched, because each is a decision rather than a cleanup:** the 512 findings in Crowdin-managed `values-*/strings.xml` (mostly `MissingQuantity` — a translator's plural missing a `quantity`, fixable only upstream); the 126 unused source strings and 10 `PluralsCandidate`, which churn the translation surface for every locale; `AppLinkWarning` (`autoVerify` only works if the domains serve a matching `assetlinks.json` — setting it blind makes verification *fail*); `GradleDependency`/`NewerVersionAvailable` (dependency bumps need the licence check); the vector/icon advisories (redrawing assets); `BatteryLife` (the battery-optimization helper working as designed); and `InlinedApi`/`ClickableViewAccessibility`/`DiscouragedApi`/`InsecureBaseConfiguration`, each of which needs its surrounding intent read first.

## Audit: one performance fix and six swallowed cancellations

**`debugState()` walked the whole cache to build output that was thrown away.** `MainActivity.onPause()` calls it unconditionally, and it uses the *eager* `Log.d` overload, so the arguments are evaluated before the level check — nine materialising `LargeCache.filter` scans over notes/addressables/users and the three channel maps, nested sums over every channel and chatroom, two sorted passes, and three passes calling `Event.countMemory()`, which itself walks every tag of every cached event. Release sits at `WARN`, so all of it ran on every backgrounding and was discarded.

Gated on `Log.minLevel > LogLevel.DEBUG` rather than `isDebug`, because that is exactly the condition under which the lines are dropped: benchmark builds *are* `isDebug` but sit at INFO, so an `isDebug` gate would have left the one variant whose numbers are meant to be trustworthy still paying it. The function only reads and logs, so the early return cannot skip a side effect. The same shape is already gated elsewhere — `AppModules` builds `relayReqStats` and `bootDiagnostics` as `if (isDebug) … else null`.

**Six catch blocks swallowed `CancellationException`,** against the `if (e is CancellationException) throw e` convention this codebase follows in 192 files. What cancellation used to mean:

| Site | Was |
|---|---|
| `VanishRequestsState` | published `ComplianceStatus.ERROR` — a relay shown as answering badly when it was never asked |
| `NappletResourceFetcher` | reported `ERROR_NETWORK`, indistinguishable from a real upstream failure |
| `MarmotAgentStreamWatcher` (×2) | the per-candidate handler does `continue`, so a cancelled watcher kept dialling the remaining brokers |
| `CallSession` | logged as a PeerConnection creation failure |
| `NamecoinSharedPreferences` | returned `emptyList()`, i.e. "no pinned certs" |

## Verification

Compiled warning- and error-free across every module, both flavors, and all the targets listed above; `:quartz:jvmTest`, `:commons:jvmTest`, `:nestsClient:jvmTest`, `:quic:jvmTest`, `:cli:test` and `:amethyst:testPlayDebugUnitTest` green. The Apple actuals are checked by `compileAppleMainKotlinMetadata`, which runs the frontend against the Apple klibs without needing a macOS host.

## Known gaps

- **Not fixed, deliberately:** `MarkdownMediaRenderer.renderNostrUri` blocks the calling thread with `runBlocking` on a `bechLinkCache` miss during composition — and `compute()` is `withContext(Dispatchers.IO)` plus `LocalCache` work, so the comment claiming "this should be fast" does not hold. The fix is the async `produceCachedState` pattern the two sibling call sites (`RichTextViewer`, `PreviewUrl`) already use; that is a refactor, not a guard.
- **The cancellation sweep under-reports.** `MarmotAgentStreamWatcher` had two swallowing sites, not the one the scan found — the second came from reading the surrounding code. The scanner required a `try {` at matching indentation within 120 lines, so longer or differently-indented bodies were skipped. Treat these six as a floor.
- One unrelated environment note for anyone reusing a build dir: `:amethyst:testPlayDebugUnitTest` fails in *report generation* (not in any test) when `LANG` is unset, because `sun.jnu.encoding` falls back to ASCII and `TorCircuitHealthTrackerTest` has an em dash in a test name. `LC_ALL=C.utf8` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123kXtseu4X18hL3GMDcdER
